### PR TITLE
Remove duplicate marker click handlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,7 @@
           warstwy[p.warstwa].lista.push(p);
           if (p.marker) p.marker.remove();
           p.marker = L.marker([p.lat, p.lng], {icon: createEmojiIcon(p.emoji)}).addTo(warstwy[p.warstwa].layer);
+          p.marker.off('click');
           p.marker.on('click', () => highlightListItem(p.el));
         } else {
           p.marker.setIcon(createEmojiIcon(p.emoji));
@@ -549,6 +550,7 @@
             highlightListItem(el);
           };
           if (p.marker) {
+            p.marker.off('click');
             p.marker.on('click', () => highlightListItem(el));
           }
           p.el = el;


### PR DESCRIPTION
## Summary
- avoid attaching duplicate click handlers when regenerating layer list
- remove previous click handlers when creating markers after editing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68738b4555c08330a190f3ee3681c80e