### PR TITLE
Add pin cursor toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,9 @@
       z-index: 1000;
       display: none;
     }
+    #map.pin-cursor {
+      cursor: url('https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2.png') 12 32, auto !important;
+    }
       .leaflet-grab {
     cursor: default !important;
   }
@@ -171,10 +174,18 @@
     let currentTool = "hand";
     const handBtn = document.getElementById("handTool");
     const pinBtn = document.getElementById("pinTool");
+    const mapEl = document.getElementById("map");
     function selectTool(t) {
       currentTool = t;
       handBtn.classList.toggle("active", t === "hand");
       pinBtn.classList.toggle("active", t === "pin");
+      if (mapEl) {
+        if (t === "pin") {
+          mapEl.classList.add("pin-cursor");
+        } else {
+          mapEl.classList.remove("pin-cursor");
+        }
+      }
     }
     handBtn.addEventListener("click", () => selectTool("hand"));
     pinBtn.addEventListener("click", () => selectTool("pin"));


### PR DESCRIPTION
## Summary
- add custom cursor when pin tool is active
- revert cursor when switching back to hand tool

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877f46ac37483309e2a058009525488