### PR TITLE
Implement marker cleanup on cancel

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,6 +421,16 @@ setTimeout(() => {
         <button id="saveNew">💾 Zapisz</button>
         <button id="cancelNew">Anuluj</button>`;
       const popup = marker.bindPopup(container).openPopup();
+
+      let saved = false;
+      const removeOnClose = () => {
+        if (!saved && map.hasLayer(marker)) {
+          map.removeLayer(marker);
+        }
+        marker.off('popupclose', removeOnClose);
+      };
+      marker.on('popupclose', removeOnClose);
+
       container.querySelector("#saveNew").addEventListener("click", () => {
         const data = {
           nazwa: container.querySelector("#nazwaNew").value,
@@ -430,12 +440,13 @@ setTimeout(() => {
           lat: latlng.lat,
           lng: latlng.lng
         };
+        saved = true;
         map.removeLayer(marker);
         db.collection("pinezki").add(data).then(() => location.reload());
       });
+
       container.querySelector("#cancelNew").addEventListener("click", () => {
-        map.closePopup(popup);
-        map.removeLayer(marker);
+        map.closePopup();
       });
     }
     function onMapClick(e) {


### PR DESCRIPTION
## Summary
- ensure new pin is removed when canceling or closing its popup

## Testing
- `npm test` *(fails: no such script)*

------
https://chatgpt.com/codex/tasks/task_e_6878932463788330a4cf259582cd46ce