### PR TITLE
Fix duplicate pin creation when saving new pins

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,7 +440,8 @@ setTimeout(() => {
       };
       marker.on('popupclose', removeOnClose);
 
-      container.querySelector("#saveNew").addEventListener("click", () => {
+      container.querySelector("#saveNew").addEventListener("click", (e) => {
+        e.stopPropagation();
         const data = {
           nazwa: container.querySelector("#nazwaNew").value,
           opis: container.querySelector("#opisNew").value,
@@ -477,7 +478,8 @@ setTimeout(() => {
         map.closePopup();
       });
 
-      container.querySelector("#cancelNew").addEventListener("click", () => {
+      container.querySelector("#cancelNew").addEventListener("click", (e) => {
+        e.stopPropagation();
         map.closePopup();
       });
     }


### PR DESCRIPTION
## Summary
- stop event propagation on Save and Cancel button handlers in `openNewPinPopup` so map does not receive the click

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687adb98f9c88330a090ef39fe498158