### PR TITLE
Fix save button visibility for new pins

### DIFF
--- a/index.html
+++ b/index.html
@@ -415,6 +415,8 @@ setTimeout(() => {
 
 
     function openNewPinPopup(latlng) {
+      const saveBtnTmp = document.getElementById('saveChanges');
+      if (saveBtnTmp) saveBtnTmp.style.display = 'block';
       const warstwaOptions = Object.keys(warstwy)
           .map(n => `<option value="${n}">${n}</option>`).join("");
       const marker = L.marker(latlng, {icon: createEmojiIcon("📍")}).addTo(map);
@@ -437,6 +439,7 @@ setTimeout(() => {
           map.removeLayer(marker);
         }
         marker.off('popupclose', removeOnClose);
+        if (!saved) updateSaveButton();
       };
       marker.on('popupclose', removeOnClose);
 


### PR DESCRIPTION
## Summary
- reveal the `Zapisz edycję mapy` button as soon as a new pin is placed
- hide it again if the pin popup is closed without saving

## Testing
- `python3 -m http.server 8001` *(served the app without errors)*

------
https://chatgpt.com/codex/tasks/task_e_687adfa0ed608330af2fa749fe901a8f