### PR TITLE
Implement local save for layer rename

### DIFF
--- a/index.html
+++ b/index.html
@@ -668,16 +668,19 @@ setTimeout(() => {
           input.replaceWith(labelEl);
           return;
         }
-        Promise.all(layer.lista.map(p => {
+        layer.lista.forEach(p => {
+          const cur = zmianyDoZapisania[p.id] || {};
+          cur.warstwa = newName;
+          zmianyDoZapisania[p.id] = cur;
           p.warstwa = newName;
-          return db.collection('pinezki').doc(p.id).update({warstwa: newName});
-        })).then(() => {
-          warstwy[newName] = layer;
-          delete warstwy[oldName];
-          const order = loadLayerOrder().map(n => n === oldName ? newName : n);
-          localStorage.setItem('warstwaOrder', JSON.stringify(order));
-          location.reload();
+          p.unsaved = true;
         });
+        warstwy[newName] = layer;
+        delete warstwy[oldName];
+        const order = loadLayerOrder().map(n => n === oldName ? newName : n);
+        localStorage.setItem('warstwaOrder', JSON.stringify(order));
+        generujListeWarstw();
+        updateSaveButton();
       }
 
       input.onblur = finish;


### PR DESCRIPTION
## Summary
- keep renamed layers only locally until saving
- reload sidebar and show save button on rename

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687af2148400833088f8a766f64e847f