### PR TITLE
Update pin appearance

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
       display: none;
     }
     #map.pin-cursor {
-      cursor: url('https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2.png') 12 32, auto !important;
+      cursor: url('https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2_hdpi.png') 12 32, auto !important;
     }
       .leaflet-grab {
     cursor: default !important;
@@ -294,10 +294,16 @@ body, #sidebar, #basemap-switcher {
     }
 
     function createEmojiIcon(e) {
-      const emoji = e || '📍';
+      if (!e || e === '📍') {
+        return L.icon({
+          iconUrl: 'https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2_hdpi.png',
+          iconSize: [25, 41],
+          iconAnchor: [12, 41]
+        });
+      }
       return L.divIcon({
         className: 'emoji-marker',
-        html: `<span>${emoji}</span>`,
+        html: `<span>${e}</span>`,
         iconSize: [32, 32],
         iconAnchor: [16, 32]
       });


### PR DESCRIPTION
## Summary
- update the pin cursor image to `spotlight-poi2_hdpi.png`
- use Google Maps pin image as default marker icon when no emoji is provided

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e05f564ec8330a06a22fbb2edcddd