### PR TITLE
Add pin timestamps and sorting

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,6 +214,10 @@ body, #sidebar, #basemap-switcher {
       <h2 id="logoNaglowek">ExploMapy</h2>
       <input type="text" id="wyszukiwarka" placeholder="Szukaj pinezki...">
       <div id="narzedzia"><button id="handTool" class="tool-btn">✋</button> <button id="pinTool" class="tool-btn">📌</button></div>
+      <select id="sortowanie">
+        <option value="name">Sortuj wg nazwy</option>
+        <option value="date">Sortuj wg daty</option>
+      </select>
       <div id="lista-warstw"></div>
     </div>
   </div>
@@ -273,10 +277,16 @@ body, #sidebar, #basemap-switcher {
     let highlightedItem = null;
     let zmianyDoZapisania = {};
     let nowePinezki = [];
+    let sortMode = 'name';
     let currentTool = "hand";
     const handBtn = document.getElementById("handTool");
     const pinBtn = document.getElementById("pinTool");
     const mapEl = document.getElementById("map");
+    const sortSelect = document.getElementById('sortowanie');
+    sortSelect.addEventListener('change', () => {
+      sortMode = sortSelect.value;
+      generujListeWarstw();
+    });
 
     function updateSaveButton() {
       const btn = document.getElementById('saveChanges');
@@ -400,6 +410,11 @@ function zaladujPinezkiZFirestore() {
   db.collection("pinezki").get().then(snapshot => {
     snapshot.forEach(doc => {
       const p = doc.data();
+      if (p.dataDodania && p.dataDodania.seconds !== undefined) {
+        p.dataDodania = p.dataDodania.seconds * 1000;
+      } else if (typeof p.dataDodania === 'string' || p.dataDodania instanceof Date) {
+        p.dataDodania = new Date(p.dataDodania).getTime();
+      }
       const id = doc.id;
       const warstwaNazwa = p.warstwa || "Inne";
       if (!warstwy[warstwaNazwa]) {
@@ -578,6 +593,7 @@ setTimeout(() => {
           emoji: container.querySelector("#emojiNew").value,
           lat: latlng.lat,
           lng: latlng.lng,
+          dataDodania: Date.now(),
           unsaved: true
         };
         saved = true;
@@ -647,6 +663,7 @@ setTimeout(() => {
       }
       nowePinezki.forEach(p => {
         p.unsaved = true;
+        if (!p.dataDodania) p.dataDodania = Date.now();
         const warstwaN = p.warstwa || 'Inne';
         if (!warstwy[warstwaN]) {
           warstwy[warstwaN] = { lista: [], layer: L.layerGroup().addTo(map) };
@@ -846,7 +863,15 @@ editBtn.style.verticalAlign = "top";
         const listaP = document.createElement("div");
         listaP.className = "pinezki-lista";
 
-        warstwy[nazwa].lista.forEach(p => {
+        const sorted = warstwy[nazwa].lista.slice().sort((a, b) => {
+          if (sortMode === 'date') {
+            const ad = a.dataDodania ? new Date(a.dataDodania).getTime() : 0;
+            const bd = b.dataDodania ? new Date(b.dataDodania).getTime() : 0;
+            return bd - ad;
+          }
+          return (a.nazwa || '').localeCompare(b.nazwa || '');
+        });
+        sorted.forEach(p => {
           const el = document.createElement("div");
           el.className = "pinezka";
           el.textContent = (p.emoji ? p.emoji + ' ' : '') + p.nazwa;
@@ -893,7 +918,8 @@ editBtn.style.verticalAlign = "top";
           warstwa: p.warstwa,
           emoji: p.emoji,
           lat: p.lat,
-          lng: p.lng
+          lng: p.lng,
+          dataDodania: firebase.firestore.FieldValue.serverTimestamp()
         })
       );
       Promise.all([batch.commit(), ...addPromises]).then(() => {


### PR DESCRIPTION
## Summary
- add dropdown to choose sorting method
- store `dataDodania` when adding new pins
- load timestamp from local storage and Firestore
- sort pins by name or newest date (old pins without date last)

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e3ae8e4a483308a5c98141ad29287