### PR TITLE
Shorten link text to domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,7 +451,13 @@ body, #sidebar, #basemap-switcher {
       return text
         .replace(urlRegex, url => {
           const href = url.startsWith('http') ? url : `https://${url}`;
-          return `<a href="${href}" target="_blank">${url}</a>`;
+          let display;
+          try {
+            display = new URL(href).hostname.replace(/^www\./, '');
+          } catch (e) {
+            display = url;
+          }
+          return `<a href="${href}" target="_blank">${display}</a>`;
         })
         .replace(/\n/g, '<br>');
     }


### PR DESCRIPTION
## Summary
- shorten URLs in pin descriptions to display only the domain name

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6880d9200b348330b0ccd58025695b48