### PR TITLE
Add custom icon for visited but closed layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,6 +490,14 @@ body, #sidebar, #basemap-switcher {
     }
 
 function createEmojiIcon(emojiOrUrl, warstwa = "") {
+  if (warstwa && warstwa.toLowerCase() === 'zwiedzone i niedostępne') {
+    return L.icon({
+      iconUrl: 'https://upload.wikimedia.org/wikipedia/commons/0/03/Green_check.svg',
+      iconSize: [32, 32],
+      iconAnchor: [16, 32]
+    });
+  }
+
   if (!emojiOrUrl || String(emojiOrUrl).trim() === "" || emojiOrUrl === "undefined") {
     return L.icon({
       iconUrl: 'https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2_hdpi.png',


### PR DESCRIPTION
## Summary
- add special case in `createEmojiIcon` so markers in the layer *zwiedzone i niedostępne* use a green check icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688158b2b550833087435f81fb2b9d6e