### PR TITLE
Dodanie checkmarka do zwiedzonych pinezek

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,6 +357,12 @@ body, #sidebar, #basemap-switcher {
           drop-shadow(0 0 1px red)
           drop-shadow(0 0 1px red);
 }
+.zwiedzone-check {
+  position: absolute;
+  top: -8px;
+  right: -6px;
+  z-index: 10;
+}
 .checkmark-obrys {
   filter: drop-shadow(0 0 0.5px black) drop-shadow(1px 1px 0 black) drop-shadow(-1px -1px 0 black);
   border-radius: 2px;
@@ -524,14 +530,8 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
     }
 
     function createEmojiIcon(emojiOrUrl, warstwa) {
-      if (warstwa && warstwa.toLowerCase() === 'zwiedzone i niedostępne') {
-        return L.divIcon({
-          className: 'emoji-marker',
-          html: `<img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Green_check.svg" width="28" height="28" class="checkmark-obrys">`,
-          iconSize: [32, 32],
-          iconAnchor: [16, 32]
-        });
-      }
+      const isVisited = warstwa && warstwa.toLowerCase() === 'zwiedzone i niedostępne';
+      const isSztosy = warstwa === "Sztosy";
 
       if (!emojiOrUrl || String(emojiOrUrl).trim() === "" || emojiOrUrl === "undefined") {
         return L.icon({
@@ -542,14 +542,14 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
       }
 
       const isUrl = emojiOrUrl && emojiOrUrl.startsWith("http");
-
-      if (isUrl) {
-        const isSztosy = warstwa === "Sztosy";
-        const cls = isSztosy ? "emoji-obrys-sztosy" : "emoji-obrys";
-        const overlay = isSztosy
-          ? `<span class="sztosy-gwiazda">⭐</span>`
+      const overlay = isSztosy
+        ? `<span class="sztosy-gwiazda">⭐</span>`
+        : isVisited
+          ? `<img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Green_check.svg" width="14" height="14" class="zwiedzone-check checkmark-obrys">`
           : '';
 
+      if (isUrl) {
+        const cls = isSztosy ? "emoji-obrys-sztosy" : "emoji-obrys";
         return L.divIcon({
           className: 'emoji-marker',
           html: `
@@ -562,11 +562,15 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
         });
       }
 
-      const cls = warstwa === "Sztosy" ? "emoji-sztosy" : "";
+      const cls = isSztosy ? "emoji-sztosy" : "";
 
       return L.divIcon({
         className: 'emoji-marker',
-        html: `<span class="${cls}">${emojiOrUrl}</span>`,
+        html: `
+          <div style="position: relative; display: inline-block;">
+            <span class="${cls}">${emojiOrUrl}</span>
+            ${overlay}
+          </div>`,
         iconSize: [32, 32],
         iconAnchor: [16, 32]
       });


### PR DESCRIPTION
## Podsumowanie
- dodano klasę `.zwiedzone-check` i obsługę overlay
- funkcja `createEmojiIcon` nakłada teraz ikonę checkmark na emoji w warstwie "Zwiedzone i niedostępne"

## Testy
- brak zautomatyzowanych testów w repo

------
https://chatgpt.com/codex/tasks/task_e_6885eaa3e4f0833085e29a6c28cd0bf2