### PR TITLE
Add mobile layout toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -368,6 +368,19 @@ body, #sidebar, #basemap-switcher {
   border-radius: 2px;
 }
 
+#toggleLayers { display: none; }
+
+@media (max-width: 700px) {
+  #map { left: 0 !important; right: 0 !important; }
+  #sidebar { position: fixed; transform: translateX(-100%); transition: transform 0.3s ease; width: 260px; z-index: 1500; }
+  #sidebar.show { transform: translateX(0); }
+  #basemap-switcher { display: none; }
+  #narzedzia { left: 10px; top: 60px; }
+  #geosearch { left: 10px; right: 10px; top: 100px; }
+  .leaflet-control-zoom { left: 10px; }
+  #toggleLayers { position: fixed; top: 10px; left: 10px; z-index: 1600; background: #2b2b2b; color: #f0f0f0; border: 1px solid #444; padding: 5px 10px; display: block; }
+}
+
   </style>
 </head>
 <body>
@@ -394,6 +407,7 @@ body, #sidebar, #basemap-switcher {
   </div>
   <input type="text" id="geosearch" placeholder="Szukaj adresu lub współrzędnych...">
   <div id="map"></div>
+  <button id="toggleLayers">☰ Warstwy</button>
   <div id="basemap-switcher">
     <h3>Rodzaj mapy</h3>
     <label><input type="radio" name="basemap" value="sat" checked> Satelitarna + miasta + drogi</label><br>
@@ -477,6 +491,13 @@ body, #sidebar, #basemap-switcher {
       generujListeWarstw();
     });
 
+    const toggleLayersBtn = document.getElementById("toggleLayers");
+    const sidebarEl = document.getElementById("sidebar");
+    if (toggleLayersBtn && sidebarEl) {
+      toggleLayersBtn.addEventListener("click", () => {
+        sidebarEl.classList.toggle("show");
+      });
+    }
     const addLayerBtn = document.getElementById('addLayerBtn');
     const newLayerInput = document.getElementById('newLayerInput');
     if (addLayerBtn && newLayerInput) {


### PR DESCRIPTION
## Summary
- add media queries for phone layout and layers menu button
- provide `☰ Warstwy` button to show/hide layer list on phones

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887347d749483309234a3a63083b495