### PR TITLE
Add draggable layer numbering

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,10 +67,12 @@
     .tool-btn.active { background: #ddd; }
     .pinezka.active { color: #007bff; font-weight: bold; }
     .pinezka:hover { text-decoration: underline; }
-    .warstwa { margin-bottom: 10px; cursor: move; }
+    .warstwa { margin-bottom: 10px; }
     .dragging { opacity: 0.5; }
     .warstwa h3 { margin: 5px 0; font-size: 16px; display: flex; align-items: center; cursor: pointer; }
     .warstwa input[type="checkbox"] { margin-right: 5px; }
+    .layer-number { margin-right: 5px; color: #bbb; cursor: move; user-select: none; }
+    .layer-number.dragging { opacity: 0.5; }
     .pinezki-lista { margin-left: 10px; display: block; }
     .ukryta { display: none; }
     #ekran-logowania {
@@ -1127,6 +1129,13 @@ const data = {
       if (JSON.stringify(prev) !== JSON.stringify(order)) updateSaveButton();
     }
 
+    function updateLayerNumbers() {
+      document.querySelectorAll('#lista-warstw .warstwa').forEach((div, idx) => {
+        const num = div.querySelector('.layer-number');
+        if (num) num.textContent = idx + 1;
+      });
+    }
+
     function loadNewPinsFromLocal() {
       try {
         nowePinezki = JSON.parse(localStorage.getItem('nowePinezki')) || [];
@@ -1159,14 +1168,14 @@ const data = {
       updateCategoryFilter();
     }
 
-    function setupDrag(div) {
-      div.draggable = true;
-      div.addEventListener('dragstart', () => {
+    function setupDrag(div, handle) {
+      handle.draggable = true;
+      handle.addEventListener('dragstart', () => {
         draggedLayer = div;
-        div.classList.add('dragging');
+        handle.classList.add('dragging');
       });
-      div.addEventListener('dragend', () => {
-        div.classList.remove('dragging');
+      handle.addEventListener('dragend', () => {
+        handle.classList.remove('dragging');
         draggedLayer = null;
       });
       div.addEventListener('dragover', e => e.preventDefault());
@@ -1176,6 +1185,7 @@ const data = {
           const lista = document.getElementById('lista-warstw');
           lista.insertBefore(draggedLayer, div);
           saveLayerOrder();
+          updateLayerNumbers();
         }
       });
     }
@@ -1381,11 +1391,14 @@ const data = {
       lista.innerHTML = "";
       const saved = loadLayerOrder();
       const nazwy = [...saved.filter(n => warstwy[n]), ...Object.keys(warstwy).filter(n => !saved.includes(n))];
-      nazwy.forEach(nazwa => {
+      nazwy.forEach((nazwa, idx) => {
         const div = document.createElement("div");
         div.className = "warstwa";
         div.dataset.nazwa = nazwa;
-        setupDrag(div);
+        const numberSpan = document.createElement("span");
+        numberSpan.className = "layer-number";
+        numberSpan.textContent = idx + 1;
+        setupDrag(div, numberSpan);
         const h3 = document.createElement("h3");
         const checkbox = document.createElement("input");
         checkbox.type = "checkbox";
@@ -1401,6 +1414,7 @@ const data = {
         label.textContent = `${nazwa} (${warstwy[nazwa].lista.length})`;
         const left = document.createElement("span");
         left.appendChild(checkbox);
+        left.appendChild(numberSpan);
         left.appendChild(label);
         const toggleBtn = document.createElement("span");
         toggleBtn.textContent = "🔽";
@@ -1477,6 +1491,7 @@ editBtn.style.verticalAlign = "top";
         lista.appendChild(div);
       });
       saveLayerOrder();
+      updateLayerNumbers();
 
       document.getElementById("wyszukiwarka").addEventListener("input", e => {
         const q = e.target.value.toLowerCase();


### PR DESCRIPTION
## Summary
- show numbered handles before each layer
- enable dragging layers via the number handle
- update displayed order after drag or list regeneration

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68873b512f308330a62b6bdef4c90427