### PR TITLE
Handle category filtering for map pins

### DIFF
--- a/index.html
+++ b/index.html
@@ -1530,7 +1530,26 @@ const data = {
       });
     }
 
+    function updateMarkerVisibility() {
+      Object.values(warstwy).forEach(w => {
+        w.lista.forEach(p => {
+          if (!p.marker) return;
+          const visible = selectedCategories.size === 0 || selectedCategories.has(p.kategoria || '');
+          if (visible) {
+            if (!w.layer.hasLayer(p.marker)) {
+              w.layer.addLayer(p.marker);
+            }
+          } else {
+            if (w.layer.hasLayer(p.marker)) {
+              w.layer.removeLayer(p.marker);
+            }
+          }
+        });
+      });
+    }
+
     function generujListeWarstw() {
+      updateMarkerVisibility();
       const lista = document.getElementById("lista-warstw");
       lista.innerHTML = "";
       const saved = loadLayerOrder();


### PR DESCRIPTION
## Summary
- hide or show map markers when categories are toggled

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6887d4adbb98833086874cada12f1032