### PR TITLE
Add clickable emoji dropdown for layer editing

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,6 +474,7 @@ body, #sidebar, #basemap-switcher {
     <h3>Edycja warstwy</h3>
     <input type="text" id="layerEditName" placeholder="Nazwa warstwy"><br>
     <input type="number" id="layerEditOrder" min="1" style="width:70px;"> <button id="layerEditSave" onclick="applyLayerEdits()">Zastosuj</button><br>
+    <input type="text" id="layerEditEmoji" placeholder="Emoji"><br>
     <button id="layerEditDelete">🗑️ Usuń warstwę</button>
     <button id="layerEditClose" onclick="closeLayerEditor()">Zamknij</button>
   </div>
@@ -553,6 +554,7 @@ body, #sidebar, #basemap-switcher {
     let pinsToDelete = [];
     let initialLayerOrder = [];
     let layerOrderChanged = false;
+    let layerEmojiChanged = false;
     let currentTool = "hand";
     let initialLayerVisibilitySet = false;
     const handBtn = document.getElementById("handTool");
@@ -603,7 +605,7 @@ body, #sidebar, #basemap-switcher {
     function updateSaveButton() {
       const btn = document.getElementById('saveChanges');
       if (!btn) return;
-      const layerChanges = layersToAdd.length > 0 || layersToDelete.length > 0 || layerOrderChanged;
+      const layerChanges = layersToAdd.length > 0 || layersToDelete.length > 0 || layerOrderChanged || layerEmojiChanged;
       btn.style.display = (Object.keys(zmianyDoZapisania).length > 0 || nowePinezki.length > 0 || layerChanges) ? 'block' : 'none';
     }
 
@@ -670,6 +672,13 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
     function createEmojiIcon(emojiOrUrl, warstwaId) {
       const isVisited = warstwaId && warstwaId === visitedId;
       const isSztosy = warstwaId && warstwaId === sztosyId;
+      if (warstwaId === 'Pwgv6ssxu9sTvrjTaB43') {
+        return L.icon({
+          iconUrl: 'https://maps.gstatic.com/mapfiles/ms2/micons/orange-dot.png',
+          iconSize: [32, 32],
+          iconAnchor: [16, 32]
+        });
+      }
       if (warstwaId && warstwaId === movingLayerId) {
         return L.icon({
           iconUrl: 'https://maps.gstatic.com/mapfiles/ms2/micons/blue-dot.png',
@@ -896,6 +905,7 @@ function emojiHtml(str) {
 
       input.addEventListener('focus', show);
       input.addEventListener('click', show);
+      input.addEventListener('pointerdown', show);
       input.addEventListener('blur', () => {
         setTimeout(() => { list.style.display = 'none'; }, 100);
       });
@@ -979,7 +989,9 @@ function emojiHtml(str) {
           if (data.name === 'Tryb w ruchu') movingLayerId = doc.id;
           order.push(data.name);
           if (!warstwy[data.name]) {
-            warstwy[data.name] = { lista: [], layer: L.layerGroup().addTo(map), collapsed: false };
+            warstwy[data.name] = { lista: [], layer: L.layerGroup().addTo(map), collapsed: false, emoji: data.emoji || '' };
+          } else {
+            warstwy[data.name].emoji = data.emoji || '';
           }
         });
         if (order.length > 0) {
@@ -1377,7 +1389,7 @@ const data = {
 
     function addLayer(name) {
       if (!name || warstwy[name]) return;
-      warstwy[name] = { lista: [], layer: L.layerGroup().addTo(map), collapsed: false };
+      warstwy[name] = { lista: [], layer: L.layerGroup().addTo(map), collapsed: false, emoji: '' };
       layersToAdd.push(name);
       const order = loadLayerOrder();
       order.unshift(name);
@@ -1417,6 +1429,12 @@ const data = {
       const order = loadLayerOrder();
       const idx = order.indexOf(name);
       document.getElementById('layerEditOrder').value = idx >= 0 ? idx + 1 : (order.length + 1);
+      const emojiInput = document.getElementById('layerEditEmoji');
+      emojiInput.value = warstwy[name].emoji || '';
+      if (!emojiInput.dataset.setup) {
+        setupEmojiInput(emojiInput);
+        emojiInput.dataset.setup = '1';
+      }
       panel.style.display = 'block';
     }
 
@@ -1428,9 +1446,23 @@ const data = {
     function applyLayerEdits() {
       const newName = document.getElementById('layerEditName').value.trim();
       const newOrder = parseInt(document.getElementById('layerEditOrder').value, 10);
+      const newEmoji = document.getElementById('layerEditEmoji').value.trim();
       if (newName && newName !== editedLayer) {
         applyRenameLayer(editedLayer, newName);
         editedLayer = newName;
+      }
+      if (warstwy[editedLayer] && warstwy[editedLayer].emoji !== newEmoji) {
+        layerEmojiChanged = true;
+        warstwy[editedLayer].emoji = newEmoji;
+        warstwy[editedLayer].lista.forEach(p => {
+          const cur = zmianyDoZapisania[p.id] || {};
+          cur.emoji = newEmoji;
+          zmianyDoZapisania[p.id] = cur;
+          p.emoji = newEmoji;
+          p.unsaved = true;
+          if (p.marker) p.marker.setIcon(createEmojiIcon(p.emoji, p.warstwaId));
+          if (p.el) p.el.innerHTML = (p.emoji ? emojiHtml(p.emoji) + ' ' : '') + p.nazwa;
+        });
       }
       reorderLayer(editedLayer, newOrder);
       generujListeWarstw();
@@ -1479,7 +1511,8 @@ const data = {
       const saveBtn = document.getElementById('layerEditSave');
       const delBtn = document.getElementById('layerEditDelete');
       const orderInput = document.getElementById('layerEditOrder');
-
+      const emojiInput = document.getElementById('layerEditEmoji');
+      
       closeBtn.addEventListener('click', e => {
         e.preventDefault();
         e.stopPropagation();
@@ -1643,7 +1676,7 @@ const data = {
           }
         };
         const label = document.createElement("span");
-        label.textContent = `${nazwa} (${warstwy[nazwa].lista.length})`;
+        label.innerHTML = (warstwy[nazwa].emoji ? emojiHtml(warstwy[nazwa].emoji) + ' ' : '') + `${nazwa} (${warstwy[nazwa].lista.length})`;
         const left = document.createElement("span");
         left.appendChild(checkbox);
         left.appendChild(numberSpan);
@@ -1770,10 +1803,11 @@ toggleBtn.style.verticalAlign = "top";
         const layerUpdates = Object.keys(warstwy).map(name => {
           const order = orderList.indexOf(name);
           const docId = layerDocs[name];
+          const data = {name, order, emoji: warstwy[name].emoji || ''};
           if (docId) {
-            return db.collection('layers').doc(docId).set({name, order});
+            return db.collection('layers').doc(docId).set(data);
           } else if (layersToAdd.includes(name)) {
-            return db.collection('layers').add({name, order});
+            return db.collection('layers').add(data);
           }
           return Promise.resolve();
         });
@@ -1790,6 +1824,7 @@ toggleBtn.style.verticalAlign = "top";
         layersToAdd = [];
         layersToDelete = [];
         pinsToDelete = [];
+        layerEmojiChanged = false;
         localStorage.removeItem('nowePinezki');
         location.reload();
       } catch (err) {


### PR DESCRIPTION
## Summary
- initialize emoji dropdown when layer editor opens
- show emoji dropdown on pointer events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888abb5db208330bb775a185e9ecfc7