### PR TITLE
Add inactive pin desaturation

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,6 +204,7 @@ width: 15px;
     .inactive {
       opacity: 0.5;
       color: #999;
+      filter: saturate(50%);
     }
     #saveChanges {
       background-color: red;
@@ -1620,6 +1621,8 @@ attachPopupHandlers(p.marker, p);
     function applyInactiveStyle(p) {
       if (p.marker) {
         p.marker.setOpacity(p.nieaktywne ? 0.5 : 1);
+        const el = p.marker.getElement();
+        if (el) el.style.filter = p.nieaktywne ? 'saturate(50%)' : '';
       }
       if (p.el) {
         if (p.nieaktywne) {


### PR DESCRIPTION
## Summary
- tone down inactive pins in map and sidebar
- set marker filter style when pin marked inactive

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6889f60427688330a7d712635fdaced1