### PR TITLE
Add color blocks to difficulty slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -935,6 +935,7 @@ function emojiHtml(str) {
       const slug = p.slug || slugify(p.nazwa || '');
       const trudHtml = p.trudnosc !== undefined ?
         `<div class="trudnosc-wrapper">
+          <div class="trudnosc-title">Poziom trudności</div>
           <input type="range" id="trudnoscRange-${p.id}" class="trudnosc-range" min="0" max="4" step="1" value="${p.trudnosc}" disabled>
           <div class="trudnosc-value" id="trudnoscLabel-${p.id}">${trudnoscText(p.trudnosc)}</div>
         </div>` : '';
@@ -1293,6 +1294,7 @@ function zaladujPinezkiZFirestore() {
         <input id="ekategoria" value="${p.kategoria || ''}" placeholder="Kategoria" style="width: 100%"><br>
         <input id="eemoji" value="${p.emoji || ''}" placeholder="Emoji" style="width: 10%"><br>
         <div class="trudnosc-wrapper">
+          <div class="trudnosc-title">Poziom trudności</div>
           <input type="range" id="etrudnosc" class="trudnosc-range" min="0" max="4" step="1" value="${p.trudnosc ?? 2}">
           <div class="trudnosc-value" id="etrudnoscLabel">${trudnoscText(p.trudnosc ?? 2)}</div>
         </div>

--- a/style.css
+++ b/style.css
@@ -146,12 +146,29 @@
 .trudnosc-wrapper {
   margin: 6px 0;
 }
+.trudnosc-title {
+  text-align: center;
+  font-size: 12px;
+  margin-bottom: 2px;
+}
 .trudnosc-range {
   -webkit-appearance: none;
   width: 100%;
   height: 10px;
   border-radius: 5px;
-  background: linear-gradient(to right, green, red);
+  background: repeating-linear-gradient(
+    to right,
+    green 0%,
+    green 20%,
+    limegreen 20%,
+    limegreen 40%,
+    yellow 40%,
+    yellow 60%,
+    orange 60%,
+    orange 80%,
+    red 80%,
+    red 100%
+  );
   outline: none;
 }
 .trudnosc-range::-webkit-slider-thumb {


### PR DESCRIPTION
## Summary
- style difficulty slider using repeating-linear-gradient
- add label "Poziom trudności" above each difficulty slider

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6889fe15e2e88330ba4321d4518a13c6