### PR TITLE
Change emoji picker layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1110,7 +1110,7 @@ function emojiHtml(str) {
 
       preview.addEventListener('click', e => {
         e.stopPropagation();
-        grid.style.display = grid.style.display === 'flex' ? 'none' : 'flex';
+        grid.style.display = grid.style.display === 'grid' ? 'none' : 'grid';
       });
       document.addEventListener('click', function hide(e) {
         if (!container.contains(e.target)) grid.style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -38,21 +38,22 @@
 
 .emoji-picker-grid {
   position: absolute;
-  bottom: 34px;
+  top: 34px;
   right: 0;
   background: #2b2b2b;
   border: 1px solid #444;
   padding: 4px;
-  flex-wrap: wrap;
   display: none;
-  max-width: 200px;
   z-index: 2000;
+  display: grid;
+  grid-template-columns: repeat(8, 24px);
+  gap: 4px;
+  width: calc(8 * 24px + 7 * 4px);
 }
 
 .emoji-picker-grid img {
   width: 24px;
   height: 24px;
-  margin: 2px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- adjust emoji picker grid to drop down under the button
- show emoji in 8 column grid

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d42abeee083309870f5d4379fdee3