### PR TITLE
Add temporary layer for searched locations with green pin

### DIFF
--- a/index.html
+++ b/index.html
@@ -687,6 +687,16 @@ function slugify(str) {
     const handBtn = document.getElementById("handTool");
     const pinBtn = document.getElementById("pinTool");
     const mapEl = document.getElementById("map");
+    let searchLayer = null;
+    let searchMarker = null;
+    const greenIcon = L.icon({
+      iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-green.png',
+      shadowUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-shadow.png',
+      iconSize: [25, 41],
+      iconAnchor: [12, 41],
+      popupAnchor: [1, -34],
+      shadowSize: [41, 41]
+    });
     const sortSelect = document.getElementById('sortowanie');
     sortSelect.addEventListener('change', () => {
       sortMode = sortSelect.value;
@@ -1671,7 +1681,8 @@ attachPopupHandlers(p.marker, p);
 
     function saveLayerOrder() {
       const order = Array.from(document.querySelectorAll('#lista-warstw .warstwa'))
-        .map(el => el.dataset.nazwa);
+        .map(el => el.dataset.nazwa)
+        .filter(n => !warstwy[n] || !warstwy[n].temporary);
       const prev = loadLayerOrder();
       localStorage.setItem('warstwaOrder', JSON.stringify(order));
       if (JSON.stringify(prev) !== JSON.stringify(order)) {
@@ -2078,6 +2089,35 @@ function showRoutePopup(pinId, tr, latlng) {
       closeRouteEditor();
     });
 
+    function showSearchMarker(lat, lng, label) {
+      if (searchLayer) {
+        map.removeLayer(searchLayer.layer);
+        delete warstwy['wyszukane'];
+        searchLayer = null;
+        searchMarker = null;
+      }
+      searchLayer = { lista: [], layer: L.layerGroup().addTo(map), collapsed: true, emoji: '', temporary: true };
+      warstwy['wyszukane'] = searchLayer;
+      const latlng = L.latLng(lat, lng);
+      searchMarker = L.marker(latlng, {icon: greenIcon}).addTo(searchLayer.layer);
+      const coordsDisplay = formatCoords(lat, lng);
+      const container = document.createElement('div');
+      container.innerHTML = `${label}<br>${coordsDisplay}<br><button id="addSearchPin">dodaj pinezkę</button>`;
+      searchMarker.bindPopup(container).openPopup();
+      container.querySelector('#addSearchPin').addEventListener('click', () => {
+        if (searchLayer) {
+          map.removeLayer(searchLayer.layer);
+          delete warstwy['wyszukane'];
+          searchLayer = null;
+          searchMarker = null;
+          generujListeWarstw();
+        }
+        openNewPinPopup(latlng);
+      });
+      searchLayer.lista.push({ id: 'search', nazwa: label, marker: searchMarker, lat, lng });
+      generujListeWarstw();
+    }
+
     function initGeoSearch() {
       const input = document.getElementById('geosearch');
       if (!input) return;
@@ -2090,7 +2130,7 @@ function showRoutePopup(pinId, tr, latlng) {
           const lat = parseFloat(m[1]);
           const lng = parseFloat(m[2]);
           map.setView([lat, lng], 16);
-          openNewPinPopup(L.latLng(lat, lng));
+          showSearchMarker(lat, lng, q);
           return;
         }
         fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(q)}`)
@@ -2100,7 +2140,7 @@ function showRoutePopup(pinId, tr, latlng) {
               const lat = parseFloat(data[0].lat);
               const lng = parseFloat(data[0].lon);
               map.setView([lat, lng], 16);
-              openNewPinPopup(L.latLng(lat, lng));
+              showSearchMarker(lat, lng, data[0].display_name);
             } else {
               alert('Nie znaleziono adresu');
             }
@@ -2239,14 +2279,19 @@ function showRoutePopup(pinId, tr, latlng) {
       lista.innerHTML = "";
       const saved = loadLayerOrder();
       const nazwy = [...saved.filter(n => warstwy[n]), ...Object.keys(warstwy).filter(n => !saved.includes(n))];
-      nazwy.forEach((nazwa, idx) => {
+      const tempLayers = nazwy.filter(n => warstwy[n].temporary);
+      const regularLayers = nazwy.filter(n => !warstwy[n].temporary);
+      const finalNazwy = [...tempLayers, ...regularLayers];
+      finalNazwy.forEach((nazwa, idx) => {
         const div = document.createElement("div");
         div.className = "warstwa";
         div.dataset.nazwa = nazwa;
         const numberSpan = document.createElement("span");
         numberSpan.className = "layer-number";
         numberSpan.textContent = idx + 1;
-        setupDrag(div, numberSpan);
+        if (!warstwy[nazwa].temporary) {
+          setupDrag(div, numberSpan);
+        }
         const h3 = document.createElement("h3");
         const checkbox = document.createElement("input");
         checkbox.type = "checkbox";
@@ -2277,15 +2322,17 @@ function showRoutePopup(pinId, tr, latlng) {
        toggleBtn.style.cursor = "pointer";
 toggleBtn.style.display = "inline-block";
 toggleBtn.style.verticalAlign = "top";
-        const editBtn = document.createElement("span");
-        editBtn.textContent = "✏️";
-        editBtn.style.cursor = "pointer";
-        editBtn.style.marginRight = "5px";
-        editBtn.style.display = "inline-block";
-        editBtn.style.verticalAlign = "top";
-        editBtn.onclick = () => showLayerEditor(nazwa);
         const controls = document.createElement("span");
-        controls.appendChild(editBtn);
+        if (!warstwy[nazwa].temporary) {
+          const editBtn = document.createElement("span");
+          editBtn.textContent = "✏️";
+          editBtn.style.cursor = "pointer";
+          editBtn.style.marginRight = "5px";
+          editBtn.style.display = "inline-block";
+          editBtn.style.verticalAlign = "top";
+          editBtn.onclick = () => showLayerEditor(nazwa);
+          controls.appendChild(editBtn);
+        }
         controls.appendChild(toggleBtn);
         controls.style.display = "flex";
         controls.style.alignItems = "center";


### PR DESCRIPTION
## Summary
- show green pin for searched address in new "wyszukane" layer at top
- display compact popup with address, coordinates and "dodaj pinezkę" button
- clicking button opens standard pin form and removes temporary layer

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b144a71c5083309e3189e69bee9730