### PR TITLE
Improve mobile map interaction and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -503,7 +503,7 @@ body, #sidebar, #basemap-switcher {
   #sidebar { position: fixed; transform: translateX(-100%); transition: transform 0.3s ease; width: 260px; z-index: 1500; }
   #sidebar.show { transform: translateX(0); }
   #basemap-switcher { display: none; }
-  #narzedzia { left: 10px; top: 50px; }
+  #narzedzia { left: 10px; top: 140px; }
   #geosearch { left: 10px; right: 10px; top: 90px; }
   #gpsFollowBtn {
     position: fixed;
@@ -531,14 +531,6 @@ body, #sidebar, #basemap-switcher {
     <div id="sidebar-inner">
       <h2 id="logoNaglowek">ExploMapy</h2>
       <input type="text" id="wyszukiwarka" placeholder="Szukaj pinezki...">
-   <div id="narzedzia">
-  <button id="handTool" class="tool-btn">
-    <img src="https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f44b.svg" width="24" height="24" alt="hand">
-  </button>
-  <button id="pinTool" class="tool-btn">
-    <img src="https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f4cd.svg" width="24" height="24" alt="pin">
-  </button>
-</div>
       <select id="sortowanie">
         <option value="dateDesc">Sortuj wg daty – od najnowszych</option>
         <option value="dateAsc">Sortuj wg daty – od najstarszych</option>
@@ -552,19 +544,27 @@ body, #sidebar, #basemap-switcher {
       <button id="addLayerBtn">+ Nowa warstwa</button>
       <input type="text" id="newLayerInput" style="display:none;width:90%;margin-top:5px;" placeholder="Nazwa warstwy">
         <button id="collapseAllLayers">Rozwiń wszystkie warstwy</button>
-        <button id="toggleVisibility">Ukryj wszystkie warstwy</button>
+      <button id="toggleVisibility">Ukryj wszystkie warstwy</button>
       <div id="lista-warstw"></div>
     </div>
   </div>
   <input type="text" id="geosearch" placeholder="Szukaj adresu lub współrzędnych...">
+  <div id="narzedzia">
+    <button id="handTool" class="tool-btn">
+      <img src="https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f44b.svg" width="24" height="24" alt="hand">
+    </button>
+    <button id="pinTool" class="tool-btn">
+      <img src="https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f4cd.svg" width="24" height="24" alt="pin">
+    </button>
+  </div>
   <div id="map"></div>
   <button id="toggleLayers">☰ Warstwy</button>
   <div id="basemap-switcher">
     <h3>Rodzaj mapy</h3>
+    <label><input type="radio" name="basemap" value="osm"> Mapa podstawowa</label><br>
     <label><input type="radio" name="basemap" value="sat" checked> Satelitarna + miasta + drogi</label><br>
     <label><input type="radio" name="basemap" value="hill"> Cieniowanie + miasta + drogi</label><br>
-    <label><input type="radio" name="basemap" value="hist"> Mapa historyczna (Geoportal)</label><br>
-    <label><input type="radio" name="basemap" value="osm"> Mapa podstawowa</label>
+    <label><input type="radio" name="basemap" value="hist"> Mapa historyczna (Geoportal)</label>
 
     <h3>Widok ulic</h3>
     <label><input type="radio" name="streets" value="full" checked> Wszystkie ulice</label><br>

--- a/style.css
+++ b/style.css
@@ -5,6 +5,10 @@
   z-index: 1000;
 }
 
+#map {
+  touch-action: none;
+}
+
 .emoji-dropdown {
   position: absolute;
   background: #2b2b2b;
@@ -176,7 +180,14 @@
     border-radius: 4px;
     display: none;
   }
-  #narzedzia { top: 50px; left: 10px; }
+  #narzedzia { top: 140px; left: 10px; }
+  #saveChanges {
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: auto;
+    right: auto;
+  }
   #exportKML { display: none; }
 }
 .trudnosc-wrapper {


### PR DESCRIPTION
## Summary
- Show default map view option at top of basemap list
- Fix mobile map panning by disabling native touch scrolling
- Keep tool icons and save button visible in mobile view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1682435fc833091cca3c1a2d1a962