### PR TITLE
Fix save button on new pin popup for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1664,6 +1664,9 @@ attachPopupHandlers(p.marker, p);
       if (saveBtnTmp) saveBtnTmp.style.display = 'block';
       const marker = L.marker(latlng, {icon: createEmojiIcon("📍", null, 24)}).addTo(map);
       const container = document.createElement("div");
+      // Zapobiega zamykaniu popupu przy dotyku na urządzeniach mobilnych
+      // i umożliwia poprawne działanie przycisków wewnątrz popupu.
+      L.DomEvent.disableClickPropagation(container);
       const coordsDisplay = formatCoords(latlng.lat, latlng.lng);
       container.innerHTML = `
         <div>${coordsDisplay}<br>


### PR DESCRIPTION
## Summary
- prevent map events from closing new pin popup so the save button works on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b179910a788330bf5e95687adda8df