### PR TITLE
Adjust pin cursor hotspot for desktop pintool

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@ width: 15px;
       z-index: 1000;
     }
     #map.pin-cursor {
-      cursor: url('https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2_hdpi.png') 12 36, auto !important;
+      cursor: url('https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2_hdpi.png') 12 39, auto !important;
     }
       .leaflet-grab {
     cursor: default !important;


### PR DESCRIPTION
## Summary
- align desktop pin tool cursor hotspot to bottom center for more accurate pin placement

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1914814b083308fcdfbc464dbee16