### PR TITLE
Replace floating emoji tool button and add picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -3193,9 +3193,8 @@ function confirmLayerDelete() {
 
   // === CSS + UI (jak wcześniej) ===
   const css = `
-  .expe-fab{position:fixed;right:18px;bottom:18px;z-index:2147483000;background:#7aa2f7;color:#0c1020;border:none;padding:12px 14px;border-radius:999px;font-weight:700;cursor:pointer;box-shadow:0 10px 24px rgba(0,0,0,.3)}
   .expe-modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);backdrop-filter:saturate(0.9) blur(2px);z-index:2147483000;display:none}
-  .expe-modal{position:fixed;right:24px;bottom:24px;width:680px;max-width:calc(100vw - 32px);max-height:80vh;overflow:hidden;border-radius:16px;background:#151821;border:1px solid #202635;box-shadow:0 24px 60px rgba(0,0,0,.45)}
+  .expe-modal{position:fixed;left:300px;top:24px;width:680px;max-width:calc(100vw - 340px);max-height:80vh;overflow:hidden;border-radius:16px;background:#151821;border:1px solid #202635;box-shadow:0 24px 60px rgba(0,0,0,.45)}
   .expe-hdr{display:flex;align-items:center;justify-content:space-between;padding:12px 14px;border-bottom:1px solid #1e2430}
   .expe-hdr h3{margin:0;font:600 15px/1.2 system-ui,-apple-system,Segoe UI,Roboto}
   .expe-hdr .expe-close{background:transparent;color:#9aa3b2;border:none;font-size:20px;cursor:pointer}
@@ -3216,9 +3215,10 @@ function confirmLayerDelete() {
   `;
   const style = document.createElement('style'); style.textContent = css; document.head.appendChild(style);
 
-  const fab = document.createElement('button');
-  fab.className = 'expe-fab'; fab.textContent = '🎛️ Emoji tool'; document.body.appendChild(fab);
-
+  const emojiBtn = document.getElementById('emojiToolBtn');
+  const isMobile = window.matchMedia('(max-width: 768px)').matches;
+  if (isMobile && emojiBtn) { emojiBtn.style.display = 'none'; }
+  if (!isMobile && emojiBtn) {
   const backdrop = document.createElement('div');
   backdrop.className = 'expe-modal-backdrop';
   backdrop.innerHTML = `
@@ -3237,6 +3237,7 @@ function confirmLayerDelete() {
           <input id="expe-kw" class="expe-inp" placeholder="np. fabryka, cementownia, kopalnia, pałac">
           <label class="expe-lbl" style="margin-top:10px">Wartość do wpisania w polu <code>emoji</code></label>
           <input id="expe-emoji" class="expe-inp" placeholder="np. 📌 lub URL SVG" />
+          <div id="expe-emoji-picker" style="position:relative;margin-top:4px;"></div>
           <div style="height:1px;background:#1e2430;margin:10px 0"></div>
           <label class="expe-row"><input type="checkbox" id="expe-preview" checked> <span class="expe-lbl" style="margin:0">Podgląd (bez zmian)</span></label>
           <label class="expe-row" style="margin-top:6px"><input type="checkbox" id="expe-whole"> <span class="expe-lbl" style="margin:0">Dopasowanie całych słów</span></label>
@@ -3272,10 +3273,64 @@ function confirmLayerDelete() {
     close: $('.expe-close'), modal: $('.expe-modal'),
     user: $('#expe-user'), login: $('#expe-login')
   };
-  const logEl = $('#expe-log'); let abortFlag = false;
+  const logEl = $('#expe-log'); let abortFlag = false; let emojiToolChanged = false;
+  setupEmojiToolPicker(document.getElementById('expe-emoji-picker'), els.emoji);
   function log(msg){ const t=new Date().toLocaleTimeString(); logEl.textContent+=`[${t}] ${msg}\n`; logEl.scrollTop=logEl.scrollHeight; }
   function setCounters({found, ok, bad, skip}){ if(found!=null)els.found.textContent=found; if(ok!=null)els.ok.textContent=ok; if(bad!=null)els.bad.textContent=bad; if(skip!=null)els.skip.textContent=skip; }
   function buildMatcher(keywords,{caseSensitive,wholeWord}){ const parts=keywords.map(k=>k.trim()).filter(Boolean).map(k=>k.replace(/[.*+?^${}()|[\\]\\]/g,'\\$&')); if(!parts.length)return null; const b=wholeWord?'\\b':''; try{return new RegExp(`${b}(${parts.join('|')})${b}`,caseSensitive?'':'i');}catch(e){log(`❌ Błąd regex: ${e.message}`);return null;} }
+
+  function setupEmojiToolPicker(container, input) {
+    if (!container || !input) return;
+    container.style.position = 'relative';
+    const preview = document.createElement('img');
+    preview.className = 'emoji-picker-preview';
+    preview.width = 28; preview.height = 28;
+    function current() {
+      const val = input.value.trim();
+      const resolved = resolveEmoji(val);
+      return resolved && resolved.startsWith('http') ? resolved : 'https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2_hdpi.png';
+    }
+    preview.src = current();
+    container.appendChild(preview);
+    const grid = document.createElement('div');
+    grid.className = 'emoji-picker-grid';
+    emojiList.forEach(({id, url}) => {
+      const img = document.createElement('img');
+      img.src = url;
+      img.addEventListener('click', e => {
+        e.stopPropagation();
+        input.value = id;
+        preview.src = url;
+        grid.style.display = 'none';
+      });
+      grid.appendChild(img);
+    });
+    container.appendChild(grid);
+    preview.addEventListener('click', e => {
+      e.stopPropagation();
+      grid.style.display = grid.style.display === 'grid' ? 'none' : 'grid';
+    });
+    document.addEventListener('click', e => {
+      if (!container.contains(e.target)) grid.style.display = 'none';
+    });
+  }
+
+  async function addEmojiToList(url) {
+    const nextNum = emojiList.reduce((m,e)=>{
+      const n = parseInt(String(e.id).replace('emoji','')) || 0;
+      return Math.max(m,n);
+    },0) + 1;
+    const newId = `emoji${nextNum}`;
+    emojiList.push({ id: newId, url });
+    if (window.emojiMap) window.emojiMap[newId] = url;
+    try {
+      const content = 'const emojiList = window.emojiList = ' + JSON.stringify(emojiList, null, 2) + ';';
+      await fetch('emoji-list.js', { method:'POST', headers:{'Content-Type':'text/javascript'}, body: content });
+      log(`💾 Dodano ${newId} do emoji-list.js`);
+    } catch(e) {
+      log(`❌ Błąd zapisu emoji-list.js: ${e.message}`);
+    }
+  }
 
   // Auth UI
   onAuthStateChanged(auth, user => {
@@ -3327,16 +3382,24 @@ function confirmLayerDelete() {
         catch(e){ bad+=writes; setCounters({bad}); log(`❌ Błąd commit: ${e.message}`); }
       }
       log(`— KONIEC — Zmieniono: ${ok} | Pominięto: ${skip} | Błędy: ${bad}`);
+      if (!preview && ok > 0) {
+        emojiToolChanged = true;
+        if (emojiVal.startsWith('http')) {
+          const exists = emojiList.some(e => e.id === emojiVal || e.url === emojiVal);
+          if (!exists) await addEmojiToList(emojiVal);
+        }
+      }
     }catch(e){ log('❌ Błąd: ' + e.message); }
     finally{ reset(); }
   }
 
   function reset(){ els.start.disabled=false; els.stop.disabled=true; abortFlag=false; }
-  fab.addEventListener('click', ()=>{ backdrop.style.display='block'; });
-  els.close.addEventListener('click', ()=>{ backdrop.style.display='none'; });
-  backdrop.addEventListener('click', (e)=>{ if(e.target===backdrop) backdrop.style.display='none'; });
+  emojiBtn.addEventListener('click', ()=>{ backdrop.style.display='block'; });
+  els.close.addEventListener('click', ()=>{ backdrop.style.display='none'; if(emojiToolChanged) location.reload(); });
+  backdrop.addEventListener('click', (e)=>{ if(e.target===backdrop){ backdrop.style.display='none'; if(emojiToolChanged) location.reload(); } });
   els.start.addEventListener('click', runUpdate);
   els.stop.addEventListener('click', ()=>{ abortFlag=true; els.stop.disabled=true; log('🛑 Przerwano…'); });
+  }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove floating action button and open emoji tool via existing sidebar button on desktop only
- Add visual emoji picker below emoji ID input and position tool beside layer list
- Persist custom emoji URLs to emoji-list and reload map if emojis changed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b79efa58833092ebc32f7075d78d