### PR TITLE
Show confirmation when saving pin on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3127,6 +3127,15 @@ function confirmLayerDelete() {
     updateSaveButton();
   }
 
+  function showPinSavedMessage() {
+    const el = document.getElementById('pinSavedMessage');
+    if (!el) return;
+    el.style.display = 'block';
+    setTimeout(() => {
+      el.style.display = 'none';
+    }, 3000);
+  }
+
   function setupMobile() {
     if (setupMobile.initialized) return;
     setupMobile.initialized = true;
@@ -3194,7 +3203,7 @@ function confirmLayerDelete() {
     });
 
     cancel.addEventListener('click', () => { modal.style.display = 'none'; });
-    ok.addEventListener('click', () => {
+    ok.addEventListener('click', async () => {
       const name = nameInput.value.trim();
       if (!name) { modal.style.display = 'none'; return; }
       if (currentTool === 'pin') {
@@ -3207,9 +3216,10 @@ function confirmLayerDelete() {
           nieaktywne: inactiveInput.checked
         });
       } else {
-        saveMovingPin(name);
+        await saveMovingPin(name);
       }
       modal.style.display = 'none';
+      showPinSavedMessage();
     });
 
     if (gpsBtn) {
@@ -3245,6 +3255,7 @@ function confirmLayerDelete() {
   </div>
   <img id="centerMarker" src="https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2_hdpi.png" alt="center marker">
   <button id="savePinBtn">ZAPISZ PIN</button>
+  <div id="pinSavedMessage">Zapisano pinezkę</div>
   <div id="mobilePinModal" class="mobile-modal">
     <div class="mobile-modal-content">
       <input type="text" id="mobilePinName" placeholder="Nazwa pinezki">

--- a/style.css
+++ b/style.css
@@ -120,6 +120,21 @@
   display: none;
 }
 
+#pinSavedMessage {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0,0,0,0.8);
+  color: #fff;
+  padding: 10px 20px;
+  border-radius: 8px;
+  z-index: 2000;
+  display: none;
+  font-size: 24px;
+  text-align: center;
+}
+
 #loadPinsBtn {
   background: #007bff;
   color: white;


### PR DESCRIPTION
## Summary
- Display toast message when a pin is saved on mobile
- Style mobile save confirmation overlay

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e00a9ec8833090aa3caf3095b082