### PR TITLE
Position emoji picker preview beside delete button

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,16 +30,17 @@
 }
 
   .emoji-picker-preview {
-    display: block;
+    display: inline-block;
     width: 28px;
     height: 28px;
     cursor: pointer;
+    vertical-align: middle;
+    margin-left: 4px;
   }
 
 .emoji-picker {
-  position: absolute;
-  bottom: 0;
-  right: 0;
+  position: relative;
+  display: inline-block;
 }
 
   .emoji-picker-grid {


### PR DESCRIPTION
## Summary
- Align the emoji picker preview next to the delete button by making it inline and repositioning its container.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b54de157a08330824704d74fd6d84d