### PR TITLE
Hide emoji picker grid until preview clicked

### DIFF
--- a/style.css
+++ b/style.css
@@ -52,7 +52,6 @@
   padding: 4px;
   display: none;
   z-index: 2000;
-  display: grid;
   grid-template-columns: repeat(8, 24px);
   gap: 4px;
   width: calc(8 * 24px + 7 * 4px);


### PR DESCRIPTION
## Summary
- Prevent emoji picker grid from displaying by default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b54fbf64f48330ae5f553634812174