### PR TITLE
Show status icons on sztosy layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -468,6 +468,12 @@ body, #sidebar, #basemap-switcher {
   right: -6px;
   z-index: 10;
 }
+
+.status-icon.sztosy {
+  top: -8px;
+  bottom: auto;
+  z-index: 20;
+}
 .checkmark-obrys {
   filter: drop-shadow(0 0 0.5px black) drop-shadow(1px 1px 0 black) drop-shadow(-1px -1px 0 black);
   border-radius: 2px;
@@ -1063,17 +1069,17 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
       }
 
       const isUrl = emojiOrUrl && emojiOrUrl.startsWith("http");
-      const overlay = isSztosy
-        ? `<span class="sztosy-gwiazda">⭐</span>`
-        : (status.nieaktywne || status.niedostepne)
-          ? `<span class="status-icon">⛔</span>`
-          : status.zamkniete
-            ? `<span class="status-icon">🔐</span>`
-            : status.doSprawdzenia
-              ? `<span class="status-icon">❔</span>`
-              : (status.zwiedzone || isVisitedLayer)
-                ? `<img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Green_check.svg" width="20" height="20" class="status-icon checkmark-obrys">`
-                : '';
+      const statusClass = isSztosy ? 'status-icon sztosy' : 'status-icon';
+      const statusIcon = (status.nieaktywne || status.niedostepne)
+        ? `<span class="${statusClass}">⛔</span>`
+        : status.zamkniete
+          ? `<span class="${statusClass}">🔐</span>`
+          : status.doSprawdzenia
+            ? `<span class="${statusClass}">❔</span>`
+            : (status.zwiedzone || isVisitedLayer)
+              ? `<img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Green_check.svg" width="20" height="20" class="${statusClass} checkmark-obrys">`
+              : '';
+      const overlay = `${isSztosy ? '<span class="sztosy-gwiazda">⭐</span>' : ''}${statusIcon}`;
 
       if (isUrl) {
         const cls = isSztosy ? "emoji-obrys-sztosy" : "emoji-obrys";


### PR DESCRIPTION
## Summary
- Ensure pin status icons render alongside the star for the "sztosy" layer.
- Add CSS to position status icons over the star when present.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b58589f3ac8330abe0084a4540520e