### PR TITLE
Align new pin popup layout with edit popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1938,20 +1938,34 @@ attachPopupHandlers(p.marker, p);
       const saveBtnTmp = document.getElementById('saveChanges');
       if (saveBtnTmp) saveBtnTmp.style.display = 'block';
       const marker = L.marker(latlng, {icon: createEmojiIcon("📍", null, 24)}).addTo(map);
+      const newId = crypto.randomUUID();
+      const tempPin = {
+        id: newId,
+        slug: `tmp-${newId}`,
+        emoji: "📍",
+        trudnosc: 3
+      };
       const container = document.createElement("div");
+      container.className = "popup-container edit-popup";
       // Zapobiega zamykaniu popupu przy dotyku na urządzeniach mobilnych
       // i umożliwia poprawne działanie przycisków wewnątrz popupu.
       L.DomEvent.disableClickPropagation(container);
-      const coordsDisplay = formatCoords(latlng.lat, latlng.lng);
       container.innerHTML = `
-        <div>${coordsDisplay}<br>
-        <a href="https://maps.google.com/?q=${latlng.lat},${latlng.lng}" target="_blank">📍 Google Maps</a></div><br>
+        <div class="photo-gallery" data-slug="${tempPin.slug}"></div>
+        <button class="popup-add-photo" data-slug="${tempPin.slug}">📷</button>
         <input id="nazwaNew" placeholder="Nazwa" style="width: 100%"><br>
-        <textarea id="opisNew" placeholder="Opis" style="width: 100%"></textarea><br>
+        <textarea id="opisNew" placeholder="Opis" style="width: 100%; height: 100px"></textarea><br>
         <input id="odKogoNew" placeholder="Od kogo" style="width: 100%"><br>
         <input id="warstwaNew" placeholder="Warstwa" style="width: 100%"><br>
         <input id="kategoriaNew" placeholder="Kategoria" style="width: 100%"><br>
-        <input id="emojiNew" placeholder="Emoji" style="width: 100%"><br>
+        <div class="trudnosc-wrapper">
+          <div class="trudnosc-title">Poziom trudności</div>
+          <input type="range" id="trudnoscNew" class="trudnosc-range" min="1" max="5" step="1" value="3">
+          <div class="trudnosc-labels">
+            <span>B.łatwy</span><span>Łatwy</span><span>Średni</span><span>Trudny</span><span>B.trudny</span>
+          </div>
+          <div class="trudnosc-value" id="trudnoscNewLabel" style="color:${trudnoscColor(3)}">${trudnoscText(3)}</div>
+        </div>
         <div class="status-grid">
           <label><input type="checkbox" id="nieaktywneNew"> Niedostępne ⛔</label>
           <label><input type="checkbox" id="zamknieteNew"> Zamknięte 🔐</label>
@@ -1961,11 +1975,15 @@ attachPopupHandlers(p.marker, p);
           <label><input type="checkbox" id="wyroznioneNew"> Wyróżnione ⭐</label>
         </div>
         <button id="saveNew">💾 Zapisz</button>
-        <button id="cancelNew">Anuluj</button>`;
-      setupEmojiInput(container.querySelector('#emojiNew'));
+        <button id="cancelNew">Anuluj</button>
+        <div id="emojiPickerNew" class="emoji-picker"></div>`;
 
+      setupGallery(container.querySelector('.photo-gallery'));
+      setupAddPhotoButton(container.querySelector('.popup-add-photo'), tempPin.slug, container.querySelector('.photo-gallery'));
+      setupEmojiPicker(container.querySelector('#emojiPickerNew'), tempPin);
       setupDropdownInput(container.querySelector('#warstwaNew'), () => Object.keys(warstwy));
       setupDropdownInput(container.querySelector('#kategoriaNew'), () => Array.from(categories).filter(c => c));
+      setupTrudnoscInput(container.querySelector('#trudnoscNew'), container.querySelector('#trudnoscNewLabel'));
 
       const popup = marker.bindPopup(container).openPopup();
 
@@ -1984,9 +2002,10 @@ attachPopupHandlers(p.marker, p);
           zwiedzone: chkNewVisited && chkNewVisited.checked,
           wyroznione: chkNewHighlighted && chkNewHighlighted.checked
         };
-        const emojiVal = container.querySelector('#emojiNew').value || "📍";
+        const emojiVal = tempPin.noweEmoji !== undefined ? tempPin.noweEmoji : tempPin.emoji || "📍";
         marker.setIcon(createEmojiIcon(emojiVal, null, 24, status));
       };
+      container.querySelector('#emojiPickerNew').addEventListener('click', () => setTimeout(refreshIcon, 0));
       if (chkNewInactive) {
         chkNewInactive.addEventListener('change', () => {
           const tmp = { marker, el: null, nieaktywne: chkNewInactive.checked };
@@ -2016,15 +2035,14 @@ attachPopupHandlers(p.marker, p);
           if (layerVal && !warstwy[layerVal]) addLayer(layerVal);
           const catVal = container.querySelector("#kategoriaNew").value.trim();
           if (catVal && !categories.has(catVal)) { categories.add(catVal); updateCategoryFilter(); }
-          const newId = crypto.randomUUID();
           const data = {
-            id: newId,
-            IDpinezki: newId,
+            id: tempPin.id,
+            IDpinezki: tempPin.id,
             nazwa: container.querySelector("#nazwaNew").value,
             opis: container.querySelector("#opisNew").value.replace(/\n/g, '<br>'),
             warstwa: layerVal,
             kategoria: catVal,
-            emoji: container.querySelector("#emojiNew").value,
+            emoji: tempPin.noweEmoji !== undefined ? tempPin.noweEmoji : tempPin.emoji,
             nieaktywne: container.querySelector("#nieaktywneNew").checked,
             zamkniete: container.querySelector("#zamknieteNew").checked,
             tajne: container.querySelector("#tajneNew").checked,
@@ -2032,6 +2050,7 @@ attachPopupHandlers(p.marker, p);
             zwiedzone: container.querySelector("#zwiedzoneNew").checked,
             wyroznione: container.querySelector("#wyroznioneNew").checked,
             odKogo: container.querySelector("#odKogoNew").value,
+            trudnosc: parseInt(container.querySelector("#trudnoscNew").value, 10),
             lat: latlng.lat,
             lng: latlng.lng,
             dataDodania: Date.now(),
@@ -2049,8 +2068,13 @@ attachPopupHandlers(p.marker, p);
         const iconEmoji = warstwy[warstwaN].emoji || data.emoji;
         marker.setIcon(createEmojiIcon(iconEmoji, data.warstwaId, 32, data));
         applyInactiveStyle(data);
+        const oldSlug = tempPin.slug;
         data.slug = slugify(data.nazwa);
-        if (!photosMap[data.slug]) {
+        if (oldSlug !== data.slug) {
+          const photos = getStoredPhotos(oldSlug);
+          delete photosMap[oldSlug];
+          storePhotos(data.slug, photos);
+        } else if (!photosMap[data.slug]) {
           storePhotos(data.slug, []);
         }
         categories.add(data.kategoria || '');


### PR DESCRIPTION
## Summary
- Match new pin popup markup to edit popup: photo gallery, add-photo button, difficulty slider, status checkboxes, emoji picker
- Update icon refresh and photo slug handling for new pins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ac4456308330969be36a47dfae61