### PR TITLE
Center map on popups

### DIFF
--- a/index.html
+++ b/index.html
@@ -1517,6 +1517,17 @@ function emojiHtml(str) {
       rysowaneTrasy.addTo(map);
       routingLayer = L.layerGroup().addTo(map);
 
+      // Ensure popups are fully visible by centering the map on them
+      map.on('popupopen', e => {
+        const mapRect = map.getContainer().getBoundingClientRect();
+        const popupRect = e.popup._container.getBoundingClientRect();
+        const offset = [
+          popupRect.left + popupRect.width / 2 - (mapRect.left + mapRect.width / 2),
+          popupRect.top + popupRect.height / 2 - (mapRect.top + mapRect.height / 2)
+        ];
+        map.panBy(offset, { animate: true });
+      });
+
       const sat = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
         attribution: 'Esri'
       });


### PR DESCRIPTION
## Summary
- center map on opened popups ensuring entire popup is visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b68119fc8330ba416bcae0837af6