### PR TITLE
Hide basemap switcher on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -793,7 +793,9 @@ function slugify(str) {
       document.getElementById("ekran-logowania").style.display = "none";
       document.getElementById("map").style.display = "block";
       document.getElementById("sidebar").style.display = "block";
-      document.getElementById("basemap-switcher").style.display = "block";
+      if (window.innerWidth > 700) {
+        document.getElementById("basemap-switcher").style.display = "block";
+      }
       initMap();
       loadLayersFromFirestore().then(() => {
         if (window.innerWidth <= 700) {


### PR DESCRIPTION
## Summary
- Prevent basemap switcher from overlaying the map on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bc2affe88330b31cb4d409f102b3