### PR TITLE
Add PWA offline support scaffolding

### DIFF
--- a/firestore-setup.js
+++ b/firestore-setup.js
@@ -1,0 +1,109 @@
+// Firebase and PWA setup
+// Replace placeholders with real Firebase config before deployment
+const firebaseConfig = {
+  apiKey: 'FIREBASE_API_KEY',
+  authDomain: 'FIREBASE_AUTH_DOMAIN',
+  projectId: 'FIREBASE_PROJECT_ID',
+  storageBucket: 'FIREBASE_STORAGE_BUCKET',
+  appId: 'FIREBASE_APP_ID'
+};
+
+if (!firebase.apps.length) {
+  firebase.initializeApp(firebaseConfig);
+}
+const db = firebase.firestore();
+const auth = firebase.auth();
+const storage = firebase.storage();
+
+// expose for existing scripts
+window.db = db;
+window.auth = auth;
+window.storage = storage;
+
+if (db.enablePersistence) {
+  db.enablePersistence({ synchronizeTabs: true }).catch(console.error);
+}
+auth.setPersistence(firebase.auth.Auth.Persistence.LOCAL);
+
+const provider = new firebase.auth.GoogleAuthProvider();
+window.signInWithGoogle = () => auth.signInWithPopup(provider);
+
+auth.onAuthStateChanged(user => {
+  if (user && user.email !== 'eksplorajder@gmail.com') {
+    alert('Brak dostępu dla ' + user.email);
+  }
+});
+
+window.addPinOffline = async function({ lat, lng, name, opis, warstwa, emoji }){
+  const now = firebase.firestore.FieldValue.serverTimestamp();
+  return db.collection('pinezki2').add({
+    lat,
+    lng,
+    nazwa: name,
+    opis,
+    warstwa,
+    emoji,
+    createdAt: now,
+    updatedAt: now
+  });
+};
+
+window.getCurrentPositionOnce = function() {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation) return reject(new Error('Brak geolokalizacji'));
+    navigator.geolocation.getCurrentPosition(pos => {
+      resolve({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+    }, reject);
+  });
+};
+
+window.renderSyncQueueCount = function(count){
+  const el = document.getElementById('syncCount');
+  if (el) el.textContent = count;
+};
+
+window.showBanner = function(text, type='info'){
+  const el = document.getElementById('banner');
+  if (!el) return;
+  el.textContent = text;
+  el.className = 'banner ' + type;
+  el.style.display = 'block';
+};
+
+window.showOfflineBar = function(show){
+  const el = document.getElementById('offlineBar');
+  if (el) el.style.display = show ? 'block' : 'none';
+};
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}
+
+window.addEventListener('offline', () => {
+  showOfflineBar(true);
+  showBanner('Offline', 'error');
+});
+window.addEventListener('online', () => {
+  showOfflineBar(false);
+  showBanner('Połączono – synchronizuję…', 'info');
+  flushQueuedUploads({}).then(() => {
+    showBanner('Zsynchronizowano', 'success');
+  }).catch(() => {
+    showBanner('Błąd synchronizacji – spróbuj ponownie', 'error');
+  });
+});
+
+const syncBtn = document.getElementById('syncBtn');
+if (syncBtn) {
+  syncBtn.addEventListener('click', async () => {
+    showBanner('Synchronizuję…', 'info');
+    try {
+      await flushQueuedUploads({});
+      showBanner('Zsynchronizowano', 'success');
+    } catch (e) {
+      showBanner('Błąd synchronizacji – spróbuj ponownie', 'error');
+    }
+  });
+}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <title>ExploRide – Wielka Mapa Urbexu</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="manifest" href="manifest.webmanifest">
+  <meta name="theme-color" content="#0f131b" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
   <link rel="stylesheet" href="style.css" />
@@ -531,6 +533,8 @@ body, #sidebar, #basemap-switcher {
   </style>
 </head>
 <body>
+  <div id="offlineBar" style="display:none;position:fixed;top:0;left:0;right:0;background:#cc0000;color:#fff;text-align:center;padding:4px;z-index:2000;">Offline</div>
+  <div id="banner" style="display:none;position:fixed;top:40px;left:50%;transform:translateX(-50%);background:#333;color:#fff;padding:6px 12px;border-radius:4px;z-index:2000;"></div>
   <div id="ekran-logowania"><button id="loginBtn">Zaloguj się przez Google</button></div>
   <div id="loading"><div class="loader"></div></div>
   <div id="sidebar">
@@ -558,6 +562,7 @@ body, #sidebar, #basemap-switcher {
       <button id="loadPinsBtn">Załaduj pinezki</button>
       <div id="lista-warstw"></div>
       <button id="emojiToolBtn">Emoji Tool</button>
+      <button id="syncBtn">Synchronizuj (<span id="syncCount">0</span>)</button>
     </div>
   </div>
   <input type="text" id="geosearch" placeholder="Szukaj adresu lub współrzędnych...">
@@ -614,7 +619,8 @@ body, #sidebar, #basemap-switcher {
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
-  <script src="firebase-init.js"></script>
+  <script src="offline-uploads.js"></script>
+  <script src="firestore-setup.js"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
 

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "ExploRide – Wielka Mapa Urbexu",
+  "short_name": "ExploMapa",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0f131b",
+  "icons": [
+    {
+      "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cmVjdCB3aWR0aD0iNTEyIiBoZWlnaHQ9IjUxMiIgZmlsbD0iIzBmMTMxYiIvPjwvc3ZnPg==",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cmVjdCB3aWR0aD0iNTEyIiBoZWlnaHQ9IjUxMiIgZmlsbD0iIzBmMTMxYiIvPjwvc3ZnPg==",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/offline-uploads.js
+++ b/offline-uploads.js
@@ -1,0 +1,83 @@
+(function(){
+  const DB_NAME = 'offlineUploads';
+  const STORE = 'files';
+  let dbPromise = null;
+
+  function openDB(){
+    if (dbPromise) return dbPromise;
+    dbPromise = new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, 1);
+      req.onupgradeneeded = () => {
+        req.result.createObjectStore(STORE, { keyPath: 'id' });
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    return dbPromise;
+  }
+
+  async function withStore(mode, cb){
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, mode);
+      const store = tx.objectStore(STORE);
+      const result = cb(store);
+      tx.oncomplete = () => resolve(result);
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async function getCount(){
+    return withStore('readonly', store => store.count());
+  }
+
+  async function queuePhotoUpload({ file, pinId, path }){
+    const id = Date.now() + '-' + Math.random().toString(36).slice(2);
+    await withStore('readwrite', store => {
+      store.put({ id, pinId, path, name: file.name, type: file.type, blob: file, addedAt: Date.now() });
+    });
+    const count = await getCount();
+    if (window.renderSyncQueueCount) window.renderSyncQueueCount(count);
+  }
+
+  async function getAll(){
+    return withStore('readonly', store => store.getAll());
+  }
+
+  async function remove(id){
+    return withStore('readwrite', store => store.delete(id));
+  }
+
+  async function flushQueuedUploads({ onProgress } = {}){
+    const items = await getAll();
+    let done = 0;
+    for (const item of items){
+      try {
+        const refPath = item.path || `pins/${item.pinId}/${item.name}`;
+        const storageRef = firebase.storage().ref().child(refPath);
+        await storageRef.put(item.blob);
+        await remove(item.id);
+        done++;
+        if (onProgress) onProgress(done, items.length);
+      } catch (err){
+        console.error('flush upload error', err);
+        throw err;
+      }
+    }
+    const count = await getCount();
+    if (window.renderSyncQueueCount) window.renderSyncQueueCount(count);
+    return done;
+  }
+
+  window.queuePhotoUpload = queuePhotoUpload;
+  window.flushQueuedUploads = flushQueuedUploads;
+
+  window.addEventListener('online', () => {
+    flushQueuedUploads({}).catch(()=>{});
+  });
+
+  openDB().then(async () => {
+    const count = await getCount();
+    if (window.renderSyncQueueCount) window.renderSyncQueueCount(count);
+  });
+})();

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,44 @@
+const CACHE_NAME = 'explomapa-v1';
+const RUNTIME_CACHE = 'runtime-v1';
+const APP_SHELL = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/manifest.webmanifest',
+  '/firestore-setup.js',
+  '/offline-uploads.js'
+];
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(APP_SHELL))
+  );
+  self.skipWaiting();
+});
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(k => k !== CACHE_NAME && k !== RUNTIME_CACHE).map(k => caches.delete(k))
+    ))
+  );
+  self.clients.claim();
+});
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  const url = new URL(event.request.url);
+  if (url.origin === location.origin) {
+    event.respondWith(
+      caches.match(event.request).then(resp => resp || fetch(event.request))
+    );
+    return;
+  }
+  if (url.hostname.includes('tile') || url.pathname.includes('/tiles/')) {
+    event.respondWith(
+      caches.open(RUNTIME_CACHE).then(cache =>
+        fetch(event.request).then(res => {
+          cache.put(event.request, res.clone());
+          return res;
+        }).catch(() => cache.match(event.request))
+      )
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add manifest with inline SVG icons for PWA installation
- implement basic service worker with shell and tile caching
- introduce Firebase setup with offline persistence and sync helpers
- queue offline uploads via IndexedDB and add sync UI hooks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d988e7ec8330b8ee5fdbea083eff