### PR TITLE
Shrink status pin icons on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,6 +478,14 @@ body, #sidebar, #basemap-switcher {
   bottom: auto;
   z-index: 20;
 }
+
+@media (max-width: 600px) {
+  .status-icon {
+    transform: scale(0.33);
+    transform-origin: top left;
+  }
+}
+
 .checkmark-obrys {
   filter: drop-shadow(0 0 0.5px black) drop-shadow(1px 1px 0 black) drop-shadow(-1px -1px 0 black);
   border-radius: 2px;


### PR DESCRIPTION
## Summary
- scale down status pin icons on mobile for better fit

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b6e0d7d72c8330b6dbf943dc012987