### PR TITLE
Shrink status icons in mobile pin editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -1801,12 +1801,12 @@ function zaladujPinezkiZFirestore() {
           <div class="trudnosc-value" id="etrudnoscLabel" style="color:${trudnoscColor(p.trudnosc ?? 3)}">${trudnoscText(p.trudnosc ?? 3)}</div>
         </div>
         <div class="status-grid">
-          <label><input type="checkbox" id="enieaktywne" ${p.nieaktywne ? 'checked' : ''}> Niedostępne ⛔</label>
-          <label><input type="checkbox" id="ezamkniete" ${p.zamkniete ? 'checked' : ''}> Zamknięte 🔐</label>
-          <label><input type="checkbox" id="etajne" ${p.tajne ? 'checked' : ''}> Tajne 🤫</label>
-          <label><input type="checkbox" id="edoSprawdzenia" ${p.doSprawdzenia ? 'checked' : ''}> Do sprawdzenia ❔</label>
-          <label><input type="checkbox" id="ezwiedzone" ${p.zwiedzone ? 'checked' : ''}> Zwiedzone <img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Green_check.svg" width="16" height="16" class="checkmark-obrys"></label>
-          <label><input type="checkbox" id="ewyroznione" ${p.wyroznione ? 'checked' : ''}> Wyróżnione ⭐</label>
+          <label><input type="checkbox" id="enieaktywne" ${p.nieaktywne ? 'checked' : ''}> Niedostępne <span class="status-emoji">⛔</span></label>
+          <label><input type="checkbox" id="ezamkniete" ${p.zamkniete ? 'checked' : ''}> Zamknięte <span class="status-emoji">🔐</span></label>
+          <label><input type="checkbox" id="etajne" ${p.tajne ? 'checked' : ''}> Tajne <span class="status-emoji">🤫</span></label>
+          <label><input type="checkbox" id="edoSprawdzenia" ${p.doSprawdzenia ? 'checked' : ''}> Do sprawdzenia <span class="status-emoji">❔</span></label>
+          <label><input type="checkbox" id="ezwiedzone" ${p.zwiedzone ? 'checked' : ''}> Zwiedzone <img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Green_check.svg" class="status-emoji checkmark-obrys"></label>
+          <label><input type="checkbox" id="ewyroznione" ${p.wyroznione ? 'checked' : ''}> Wyróżnione <span class="status-emoji">⭐</span></label>
         </div>
         <button onclick="zapiszLokalnie('${id}')">💾 Zapisz</button>
         <button id="deleteBtn-${id}">🗑️</button>
@@ -1996,12 +1996,12 @@ attachPopupHandlers(p.marker, p);
           <div class="trudnosc-value" id="trudnoscNewLabel" style="color:${trudnoscColor(3)}">${trudnoscText(3)}</div>
         </div>
         <div class="status-grid">
-          <label><input type="checkbox" id="nieaktywneNew"> Niedostępne ⛔</label>
-          <label><input type="checkbox" id="zamknieteNew"> Zamknięte 🔐</label>
-          <label><input type="checkbox" id="tajneNew"> Tajne 🤫</label>
-          <label><input type="checkbox" id="doSprawdzeniaNew"> Do sprawdzenia ❔</label>
-          <label><input type="checkbox" id="zwiedzoneNew"> Zwiedzone <img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Green_check.svg" width="16" height="16" class="checkmark-obrys"></label>
-          <label><input type="checkbox" id="wyroznioneNew"> Wyróżnione ⭐</label>
+          <label><input type="checkbox" id="nieaktywneNew"> Niedostępne <span class="status-emoji">⛔</span></label>
+          <label><input type="checkbox" id="zamknieteNew"> Zamknięte <span class="status-emoji">🔐</span></label>
+          <label><input type="checkbox" id="tajneNew"> Tajne <span class="status-emoji">🤫</span></label>
+          <label><input type="checkbox" id="doSprawdzeniaNew"> Do sprawdzenia <span class="status-emoji">❔</span></label>
+          <label><input type="checkbox" id="zwiedzoneNew"> Zwiedzone <img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Green_check.svg" class="status-emoji checkmark-obrys"></label>
+          <label><input type="checkbox" id="wyroznioneNew"> Wyróżnione <span class="status-emoji">⭐</span></label>
         </div>
         <button id="saveNew">💾 Zapisz</button>
         <button id="cancelNew">Anuluj</button>

--- a/style.css
+++ b/style.css
@@ -385,3 +385,19 @@
 .status-grid label {
   display: block;
 }
+
+.status-emoji {
+  font-size: 1em;
+  line-height: 1em;
+}
+
+.status-emoji.checkmark-obrys {
+  width: 1em;
+  height: 1em;
+}
+
+@media (max-width: 600px) {
+  .status-emoji {
+    font-size: 0.8em;
+  }
+}


### PR DESCRIPTION
## Summary
- Wrap pin status emojis in spans for precise styling
- Scale down status icons on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e87142c48330be0c1fd123cb7ac8