### PR TITLE
Adjust mobile status grid sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -397,6 +397,13 @@
 }
 
 @media (max-width: 600px) {
+  .status-grid {
+    grid-template-columns: 1fr;
+    gap: 2px 4px;
+  }
+  .status-grid label {
+    font-size: 0.9em;
+  }
   .status-emoji {
     font-size: 0.8em;
   }


### PR DESCRIPTION
## Summary
- make status grid more compact on small screens by switching to a single column and smaller fonts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f03e89a08330b43be8c103cc3005