### PR TITLE
Remove NASA and Sentinel basemaps, add Geoportal WMS overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -688,11 +688,11 @@ img.emoji {
     <h3>Rodzaj mapy</h3>
     <label><input type="radio" name="basemap" value="osm"> Mapa podstawowa</label><br>
     <label><input type="radio" name="basemap" value="sat" checked> Esri World Imagery</label><br>
-    <label><input type="radio" name="basemap" value="nasa"> NASA GIBS (VIIRS City Lights)</label><br>
-    <label><input type="radio" name="basemap" value="sentinel"> Sentinel-2 Cloudless</label><br>
-    <label><input type="radio" name="basemap" value="geo"> Ortofotomapa (Geoportal)</label><br>
     <label><input type="radio" name="basemap" value="hill"> Cieniowanie + miasta + drogi</label><br>
-    <label><input type="radio" name="basemap" value="hist"> Mapa historyczna (Geoportal)</label>
+    <label><input type="radio" name="basemap" value="hist"> Mapa historyczna (Geoportal)</label><br>
+    <div class="layer-separator"></div>
+    <strong>Nakładki</strong><br>
+    <label><input type="checkbox" id="overlay-orto"> Ortofotomapa (Geoportal)</label>
 
     <h3>Widok ulic</h3>
     <label><input type="radio" name="streets" value="full" checked> Wszystkie ulice</label><br>
@@ -1698,18 +1698,9 @@ function emojiHtml(str) {
       const sat = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
         attribution: 'Esri'
       });
-      const nasa = L.tileLayer('https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/VIIRS_CityLights_2012/default/2012-01-01/GoogleMapsCompatible_Level8/{z}/{y}/{x}.jpg', {
-        attribution: 'NASA GIBS',
-        maxNativeZoom: 8,
-        maxZoom: 8
-      });
-      const sentinel = L.tileLayer('https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2020_3857/default/g/{z}/{y}/{x}.jpg', {
-        attribution: 'Sentinel-2 cloudless &copy; EOX',
-        maxNativeZoom: 14
-      });
       const orto = L.tileLayer.wms('https://mapy.geoportal.gov.pl/wss/service/PZGIK/ORTO/WMSServer', {
         layers: 'Raster',
-        format: 'image/jpeg',
+        format: 'image/png',
         transparent: false,
         version: '1.3.0',
         crs: L.CRS.EPSG3857,
@@ -1748,9 +1739,6 @@ function emojiHtml(str) {
           baseLayer.off('loading', showLoading);
           baseLayer.off('load', hideLoading);
           baseLayer = (radio.value === 'sat') ? sat :
-                      (radio.value === 'nasa') ? nasa :
-                      (radio.value === 'sentinel') ? sentinel :
-                      (radio.value === 'geo') ? orto :
                       (radio.value === 'hill') ? hill :
                       (radio.value === 'hist') ? hist : osm;
           baseLayer.on('loading', showLoading);
@@ -1764,6 +1752,14 @@ function emojiHtml(str) {
           }
           currentBase = radio.value;
         });
+      });
+
+      document.getElementById('overlay-orto').addEventListener('change', e => {
+        if (e.target.checked) {
+          orto.addTo(map);
+        } else {
+          map.removeLayer(orto);
+        }
       });
 
       document.querySelectorAll('input[name="streets"]').forEach(radio => {


### PR DESCRIPTION
## Summary
- drop NASA and Sentinel basemap options
- fix Geoportal orthophoto via WMS PNG layer and expose as optional overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe75c95608330916bf23242d1e476