### PR TITLE
Cancel previous basemap loading on switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -1811,6 +1811,7 @@ function emojiHtml(str) {
           baseLayer.off('loading', showLoading);
           baseLayer.off('load', hideLoading);
           if (baseTileErrorHandler) baseLayer.off('tileerror', baseTileErrorHandler);
+          if (baseLayer._abortLoading) baseLayer._abortLoading();
           map.removeLayer(baseLayer);
         }
         try {


### PR DESCRIPTION
## Summary
- Abort tile loading of the previous basemap when switching to a new one to stop orphaned requests.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bff40d6ad483308e75a1be1d2065b5