### PR TITLE
Expose basemap selector on mobile via collapsible sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,12 +557,14 @@ body, #sidebar, #basemap-switcher {
 }
 
 #toggleLayers { display: none; }
+#toggleBasemaps { display: none; }
 
 @media (max-width: 700px) {
   #map { left: 0 !important; right: 0 !important; }
   #sidebar { position: fixed; transform: translateX(-100%); transition: transform 0.3s ease; width: 260px; z-index: 1500; }
   #sidebar.show { transform: translateX(0); }
-  #basemap-switcher { display: none; }
+  #basemap-switcher { position: fixed; top: 0; right: 0; transform: translateX(100%); transition: transform 0.3s ease; height: 100%; z-index: 1500; }
+  #basemap-switcher.show { transform: translateX(0); }
   #narzedzia { left: 10px; top: 140px; }
   #geosearch-container { left: 10px; right: 10px; top: 90px; }
   #gpsFollowBtn {
@@ -580,6 +582,7 @@ body, #sidebar, #basemap-switcher {
   #exportKML { display: none; }
   .leaflet-control-zoom { left: 10px; }
   #toggleLayers { position: fixed; top: 10px; left: 10px; z-index: 1600; background: #2b2b2b; color: #f0f0f0; border: 1px solid #444; padding: 5px 10px; display: block; }
+  #toggleBasemaps { position: fixed; top: 10px; right: 10px; z-index: 1600; background: #2b2b2b; color: #f0f0f0; border: 1px solid #444; padding: 5px 10px; display: block; }
 }
 
 /* --- FIX: normalny rozmiar ikon statusu na mobile i desktop --- */
@@ -705,6 +708,7 @@ img.emoji {
   </div>
   <div id="map"></div>
   <button id="toggleLayers">☰ Warstwy</button>
+  <button id="toggleBasemaps">☰ Mapy</button>
   <div id="basemap-switcher">
     <h3>Rodzaj mapy</h3>
     <strong>Bazy</strong><br>
@@ -954,9 +958,7 @@ function slugify(str) {
       document.getElementById("ekran-logowania").style.display = "none";
       document.getElementById("map").style.display = "block";
       document.getElementById("sidebar").style.display = "block";
-      if (window.innerWidth > 700) {
-        document.getElementById("basemap-switcher").style.display = "block";
-      }
+      document.getElementById("basemap-switcher").style.display = "block";
       initMap();
       loadLayersFromFirestore().then(() => {
         if (window.innerWidth <= 700) {
@@ -1106,6 +1108,13 @@ function slugify(str) {
     if (toggleLayersBtn && sidebarEl) {
       toggleLayersBtn.addEventListener("click", () => {
         sidebarEl.classList.toggle("show");
+      });
+    }
+    const toggleBasemapsBtn = document.getElementById("toggleBasemaps");
+    const basemapSwitcherEl = document.getElementById("basemap-switcher");
+    if (toggleBasemapsBtn && basemapSwitcherEl) {
+      toggleBasemapsBtn.addEventListener("click", () => {
+        basemapSwitcherEl.classList.toggle("show");
       });
     }
     const addLayerBtn = document.getElementById('addLayerBtn');


### PR DESCRIPTION
## Summary
- make basemap switcher slide in/out on mobile
- add mobile toggle button for basemap panel
- ensure basemap switcher renders for all screen sizes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bff86d554083309aba61fe800bce24