### PR TITLE
Fix map recenter after search

### DIFF
--- a/index.html
+++ b/index.html
@@ -3060,6 +3060,11 @@ function showRoutePopup(pinId, tr, latlng) {
     });
 
     function showSearchMarker(lat, lng, label) {
+      if (followGps) {
+        followGps = false;
+        const btn = document.getElementById('gpsFollowBtn');
+        if (btn) btn.style.display = 'block';
+      }
       if (searchLayer) {
         map.removeLayer(searchLayer.layer);
         delete warstwy['wyszukane'];


### PR DESCRIPTION
## Summary
- Stop following GPS after performing a geosearch to keep map at searched location

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c01b160f048330b4f01eeca8092925