### PR TITLE
Allow specifying WMS layer name and configure TrueOrtho base layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1817,9 +1817,9 @@ function emojiHtml(str) {
         });
       }
 
-      function wmsLayer(url) {
+      function wmsLayer(url, layerName = 'Raster') {
         return L.tileLayer.wms(url, {
-          layers: 'Raster',
+          layers: layerName,
           format: 'image/jpeg',
           transparent: false,
           version: '1.3.0',
@@ -1839,7 +1839,7 @@ function emojiHtml(str) {
         'orto-wmts-hi': { create: () => wmtsLayer(WMTS_HI_URL), fallback: 'orto-wms-hi' },
         'orto-wms-std': { create: () => wmsLayer(WMS_STD_URL), fallback: 'orto-wmts-std' },
         'orto-wms-hi': { create: () => wmsLayer(WMS_HI_URL), fallback: 'orto-wmts-hi' },
-        'true-orto': { create: () => wmsLayer(WMS_TRUE_URL) }
+        'true-orto': { create: () => wmsLayer(WMS_TRUE_URL, 'TrueOrtho') }
       };
 
       const overlays = {


### PR DESCRIPTION
## Summary
- Make `wmsLayer` accept an optional layer name parameter and pass it to the WMS request
- Register TrueOrtho base layer using the proper layer name

## Testing
- `npm test` *(fails: package.json missing)*


------
https://chatgpt.com/codex/tasks/task_e_68c027f838b48330bb080f28c70e2b84