### PR TITLE
Podniesienie paska wyszukiwania i narzędzi w wersji mobilnej

### DIFF
--- a/index.html
+++ b/index.html
@@ -569,8 +569,8 @@ body, #sidebar, #basemap-switcher {
   #sidebar.show { transform: translateX(0); }
   #basemap-switcher { position: fixed; top: 0; right: 0; transform: translateX(100%); transition: transform 0.3s ease; height: 100%; z-index: 1500; }
   #basemap-switcher.show { transform: translateX(0); }
-  #narzedzia { left: 10px; top: 140px; }
-  #geosearch-container { left: 10px; right: 10px; top: 90px; }
+  #narzedzia { left: 10px; top: 120px; }
+  #geosearch-container { left: 10px; right: 10px; top: 70px; }
   #gpsFollowBtn {
     position: fixed;
     bottom: 20px;

--- a/style.css
+++ b/style.css
@@ -302,7 +302,7 @@
 }
 
 @media (max-width: 700px) {
-  #geosearch { top: 90px; left: 10px; right: 10px; }
+  #geosearch { top: 70px; left: 10px; right: 10px; }
   #gpsFollowBtn {
     position: fixed;
     bottom: 20px;
@@ -315,7 +315,7 @@
     border-radius: 4px;
     display: none;
   }
-  #narzedzia { top: 140px; left: 10px; }
+  #narzedzia { top: 120px; left: 10px; }
   #saveChanges {
     top: 10px;
     left: 50%;


### PR DESCRIPTION
## Summary
- Przesunięto w górę o 20 px pasek wyszukiwania adresów wraz z przyciskiem lupy w widoku mobilnym.
- Podniesiono o 20 px zestaw ikon narzędzi w wersji mobilnej.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c02c2582588330bd12f5949724e2b1