### PR TITLE
Add map date badge and map source year handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -659,6 +659,19 @@ img.emoji {
       cursor: pointer;
     }
 
+    #map-date-controls {
+      margin-bottom: 5px;
+      font-size: 12px;
+    }
+    #map-date-badge {
+      background: #444;
+      padding: 2px 4px;
+      border-radius: 4px;
+    }
+    #map-year-select {
+      margin-left: 5px;
+    }
+
   </style>
 </head>
 <body>
@@ -715,6 +728,7 @@ img.emoji {
   <button id="toggleBasemaps">☰ Mapy</button>
   <div id="basemap-switcher">
     <h3>Rodzaj mapy</h3>
+    <div id="map-date-controls"><span id="map-date-badge"></span><select id="map-year-select" style="display:none;"></select></div>
     <details>
       <summary><strong>Bazy</strong></summary>
       <label><input type="radio" name="basemap" value="osm"> Mapa podstawowa</label><br>
@@ -724,6 +738,8 @@ img.emoji {
       <label><input type="radio" name="basemap" value="orto-wmts-hi"> Orto HighRes (WMTS – HighResolution)<button type="button" class="info-btn" data-info="WMTS szybkie kafle">i</button></label><br>
       <label><input type="radio" name="basemap" value="orto-wms-std"> Orto (WMS – Standard)<button type="button" class="info-btn" data-info="WMS pełny render">i</button></label><br>
       <label><input type="radio" name="basemap" value="orto-wms-hi"> Orto HighRes (WMS – HighResolution)<button type="button" class="info-btn" data-info="WMS pełny render">i</button></label><br>
+      <label><input type="radio" name="basemap" value="orto-wms-std-time"> Orto archiwalne (WMS Time – Standard)</label><br>
+      <label><input type="radio" name="basemap" value="orto-wms-hi-time"> Orto archiwalne (WMS Time – HighRes)</label><br>
       <label><input type="radio" name="basemap" value="true-orto"> True Ortho (WMS)<button type="button" class="info-btn" data-info="TrueOrtho – brak zniekształceń od wysokości">i</button></label><br>
       <label><input type="radio" name="basemap" value="otm-trails"> OpenTopoMap + Szlaki (Waymarked)</label><br>
     </details>
@@ -1809,6 +1825,8 @@ function emojiHtml(str) {
       const WMS_TRUE_URL = 'https://mapy.geoportal.gov.pl/wss/service/PZGIK/ORTO/WMS/TrueOrtho';
       const WMS_ARCH_STD_URL = 'https://mapy.geoportal.gov.pl/wss/service/PZGIK/ORTO/WMS/StandardResolutionTime';
       const WMS_ARCH_HI_URL = 'https://mapy.geoportal.gov.pl/wss/service/PZGIK/ORTO/WMS/HighResolutionTime';
+      const WMS_STD_TIME_URL = WMS_ARCH_STD_URL;
+      const WMS_HI_TIME_URL = WMS_ARCH_HI_URL;
 
       function wmtsLayer(url) {
         if (!L.tileLayer.wmts) throw new Error('Brak wtyczki WMTS');
@@ -1842,6 +1860,8 @@ function emojiHtml(str) {
         'orto-wmts-hi': { create: () => wmtsLayer(WMTS_HI_URL), fallback: 'orto-wms-hi' },
         'orto-wms-std': { create: () => wmsLayer(WMS_STD_URL), fallback: 'orto-wmts-std' },
         'orto-wms-hi': { create: () => wmsLayer(WMS_HI_URL), fallback: 'orto-wmts-hi' },
+        'orto-wms-std-time': { create: () => wmsLayer(WMS_STD_TIME_URL) },
+        'orto-wms-hi-time': { create: () => wmsLayer(WMS_HI_TIME_URL) },
         // TrueOrtho WMS layer uses the default 'Raster' layer name
         // Removing the explicit layer parameter fixes loading issues
         'true-orto': { create: () => wmsLayer(WMS_TRUE_URL) }
@@ -1853,6 +1873,146 @@ function emojiHtml(str) {
       };
       overlays.archStd.on('tileerror', () => showToast('Sprawdź parametry warstwy (layers/CRS/format).'));
       overlays.archHi.on('tileerror', () => showToast('Sprawdź parametry warstwy (layers/CRS/format).'));
+
+      const mapDateBadgeEl = document.getElementById('map-date-badge');
+      const mapYearSelect = document.getElementById('map-year-select');
+      const timeLayerYears = {};
+
+      function to3857(latlng) {
+        return L.CRS.EPSG3857.project(latlng);
+      }
+      function to4326(point) {
+        return L.CRS.EPSG3857.unproject(point);
+      }
+      function boundsToExtent4326(bounds) {
+        const sw = to4326(to3857(bounds.getSouthWest()));
+        const ne = to4326(to3857(bounds.getNorthEast()));
+        return [sw.lng, sw.lat, ne.lng, ne.lat].join(',');
+      }
+
+      function resetMapDateControls() {
+        if (mapYearSelect) {
+          mapYearSelect.style.display = 'none';
+          mapYearSelect.innerHTML = '';
+          mapYearSelect.onchange = null;
+        }
+        if (mapDateBadgeEl) mapDateBadgeEl.textContent = '';
+        if (map) map.off('click', handleEsriIdentify);
+      }
+
+      function setBadge(text) {
+        if (mapDateBadgeEl) mapDateBadgeEl.textContent = text;
+      }
+
+      async function initGeoportalTime(layerKey, url) {
+        try {
+          let years = timeLayerYears[url];
+          if (!years) {
+            const res = await fetch(`${url}?service=WMS&request=GetCapabilities&version=1.3.0`);
+            if (!res.ok) throw new Error('cap');
+            const text = await res.text();
+            const xml = new DOMParser().parseFromString(text, 'text/xml');
+            if (xml.querySelector('ServiceException')) throw new Error('service');
+            const dim = xml.querySelector('Dimension[name="time"], Extent[name="time"]');
+            if (!dim) throw new Error('cap');
+            years = dim.textContent.split(',').map(s => s.trim()).filter(Boolean).sort((a, b) => b.localeCompare(a));
+            timeLayerYears[url] = years;
+          }
+          const saved = localStorage.getItem(`ortoTimeYear:${layerKey}`);
+          const year = (saved && years.includes(saved)) ? saved : years[0];
+          years.forEach(y => {
+            const opt = document.createElement('option');
+            opt.value = y;
+            opt.textContent = y;
+            mapYearSelect.appendChild(opt);
+          });
+          mapYearSelect.value = year;
+          mapYearSelect.style.display = 'inline-block';
+          setBadge(`Orto: ${year}`);
+          baseLayer.setParams({ time: year });
+          mapYearSelect.onchange = () => {
+            const newYear = mapYearSelect.value;
+            const prevYear = baseLayer.options.time;
+            setBadge(`Orto: ${newYear}`);
+            const onError = () => {
+              showToast('Błąd WMS (Time). Sprawdź parametry warstwy.');
+              baseLayer.setParams({ time: prevYear });
+              mapYearSelect.value = prevYear;
+              setBadge(`Orto: ${prevYear}`);
+              baseLayer.off('tileerror', onError);
+              baseLayer.off('load', onLoad);
+            };
+            const onLoad = () => {
+              baseLayer.off('tileerror', onError);
+              baseLayer.off('load', onLoad);
+              localStorage.setItem(`ortoTimeYear:${layerKey}`, newYear);
+            };
+            baseLayer.on('tileerror', onError);
+            baseLayer.on('load', onLoad);
+            baseLayer.setParams({ time: newYear });
+          };
+        } catch (e) {
+          if (e.message === 'service') {
+            showToast('Błąd WMS (Time). Sprawdź parametry warstwy.');
+          } else {
+            showToast('Nie udało się pobrać listy lat. Spróbuj ponownie.');
+          }
+          setBadge('Orto: mozaika (brak jednego roku)');
+          if (mapYearSelect) mapYearSelect.style.display = 'none';
+        }
+      }
+
+      async function handleEsriIdentify(e) {
+        const { lat, lng } = e.latlng;
+        const size = map.getSize();
+        const bounds = map.getBounds();
+        const params = new URLSearchParams({
+          f: 'json',
+          geometry: `${lng},${lat}`,
+          geometryType: 'esriGeometryPoint',
+          sr: 4326,
+          tolerance: 1,
+          mapExtent: boundsToExtent4326(bounds),
+          imageDisplay: `${size.x},${size.y},96`,
+          returnGeometry: false
+        });
+        try {
+          const res = await fetch(`https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/identify?${params.toString()}`);
+          if (!res.ok) throw new Error('id');
+          const data = await res.json();
+          let dateStr = null;
+          if (data.results && data.results.length && data.results[0].attributes) {
+            const attrs = data.results[0].attributes;
+            const field = ['AcquisitionDate','SRCDATE','SRC_DATE','Best','Captured','Date'].find(k => attrs[k]);
+            if (field) {
+              dateStr = attrs[field];
+              const d = new Date(dateStr);
+              if (!isNaN(d)) dateStr = d.toISOString().split('T')[0];
+            }
+          }
+          const content = dateStr ? `Esri – data pozyskania: ${dateStr}` : 'Esri – data pozyskania: brak metadanych';
+          L.popup().setLatLng(e.latlng).setContent(content).openOn(map);
+          setBadge(dateStr ? `Esri: ${dateStr}` : 'Esri: brak metadanych');
+        } catch (err) {
+          showToast('Nie udało się pobrać metadanych Esri dla tego punktu.');
+        }
+      }
+
+      function updateMapDateUI(key) {
+        resetMapDateControls();
+        if (key === 'orto-wms-std-time') {
+          initGeoportalTime(key, WMS_STD_TIME_URL);
+        } else if (key === 'orto-wms-hi-time') {
+          initGeoportalTime(key, WMS_HI_TIME_URL);
+        } else if (['orto-wmts-std','orto-wmts-hi','orto-wms-std','orto-wms-hi','true-orto'].includes(key)) {
+          setBadge('Orto: mozaika (brak jednego roku)');
+        } else if (key === 'sat') {
+          setBadge('Esri: kliknij w mapę, aby sprawdzić datę');
+          map.on('click', handleEsriIdentify);
+        } else if (key === 'otm-trails') {
+          setBadge('Topo (OSM): brak daty');
+        }
+      }
 
       function switchBaseLayer(key, isFallback = false) {
         const def = baseLayerDefs[key] || baseLayerDefs['osm'];
@@ -1886,14 +2046,20 @@ function emojiHtml(str) {
             key = 'osm';
           }
         }
-        baseTileErrorHandler = () => {
-          if (def.fallback && !isFallback) {
-            showToast('Sprawdź parametry warstwy (layers/CRS/format). Przełączam na WMS/WMTS.');
-            switchBaseLayer(def.fallback, true);
-          } else {
-            showToast('Błąd ładowania warstwy.');
-          }
-        };
+        if (key === 'orto-wms-std-time' || key === 'orto-wms-hi-time') {
+          baseTileErrorHandler = () => {
+            showToast('Błąd WMS (Time). Sprawdź parametry warstwy.');
+          };
+        } else {
+          baseTileErrorHandler = () => {
+            if (def.fallback && !isFallback) {
+              showToast('Sprawdź parametry warstwy (layers/CRS/format). Przełączam na WMS/WMTS.');
+              switchBaseLayer(def.fallback, true);
+            } else {
+              showToast('Błąd ładowania warstwy.');
+            }
+          };
+        }
         baseLayer.on('tileerror', baseTileErrorHandler);
         baseLayer.on('loading', showLoading);
         baseLayer.on('load', hideLoading);
@@ -1917,6 +2083,7 @@ function emojiHtml(str) {
           if (roadsLayer) roadsLayer.addTo(map);
         }
         currentBase = key;
+        updateMapDateUI(key);
       }
 
       roadsLayer = roadsFull;


### PR DESCRIPTION
## Summary
- show map source badge and optional year selector in basemap panel
- add support for Geoportal WMS Time layers with year selection and localStorage
- fetch Esri World Imagery acquisition date on map click
- display generic date info for other basemaps

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c343b9eb8c833090d9ffad69d0e9ad