### PR TITLE
Fix removal of pins when saving changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3015,7 +3015,7 @@ function zaladujPinezkiZFirestore() {
       const prevZmiany = Object.assign({}, zmianyDoZapisania);
       const prevNowe = nowePinezki.slice();
       layerData.lista.forEach(p => {
-        if (p.firebaseId) pinsToDelete.push(p.id);
+        if (p.firebaseId) pinsToDelete.push({ id: p.id, firebaseId: p.firebaseId });
         const idxN = nowePinezki.indexOf(p);
         if (idxN > -1) nowePinezki.splice(idxN, 1);
         delete zmianyDoZapisania[p.id];
@@ -3796,8 +3796,12 @@ toggleBtn.style.verticalAlign = "top";
           p.photos = await savePhotosForPin(firebaseId, p.slug, localPhotos, [], onProgress);
         });
 
-        const deletePinPromises = pinsToDelete.map(id => {
-          const p = wszystkiePinezki.find(pp => pp.id === id);
+        const deletePinPromises = pinsToDelete.map(info => {
+          const firebaseId = info && info.firebaseId;
+          if (firebaseId) {
+            return db.collection('pinezki2').doc(firebaseId).delete().catch(()=>{});
+          }
+          const p = wszystkiePinezki.find(pp => pp.id === (info ? info.id : info));
           if (p && p.firebaseId) return db.collection('pinezki2').doc(p.firebaseId).delete().catch(()=>{});
           return Promise.resolve();
         });
@@ -4056,7 +4060,7 @@ toggleBtn.style.verticalAlign = "top";
       prevZmiany: Object.assign({}, zmianyDoZapisania),
       prevAll: wszystkiePinezki.slice()
     };
-    if (p.firebaseId) pinsToDelete.push(p.id);
+    if (p.firebaseId) pinsToDelete.push({ id: p.id, firebaseId: p.firebaseId });
     const idxN = nowePinezki.indexOf(p);
     if (idxN > -1) nowePinezki.splice(idxN, 1);
     delete zmianyDoZapisania[p.id];


### PR DESCRIPTION
## Summary
- track firebase identifiers for pins that are deleted locally
- ensure the save routine deletes pins from Firestore using the stored identifiers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd082466248330a035f904f8f62e5d