### PR TITLE
Disable GPS recentering on mobile pin selection and raise popup z-index

### DIFF
--- a/index.html
+++ b/index.html
@@ -3663,6 +3663,11 @@ toggleBtn.style.verticalAlign = "top";
           el.innerHTML = (dispEmoji ? emojiHtml(dispEmoji) + ' ' : '') + p.nazwa;
           if (p.unsaved) el.classList.add('unsaved');
           el.onclick = () => {
+            if (isMobile && followGps) {
+              followGps = false;
+              const gpsBtn = document.getElementById('gpsFollowBtn');
+              if (gpsBtn) gpsBtn.style.display = 'block';
+            }
             map.setView([p.lat, p.lng], 16);
             p.marker.openPopup();
             highlightListItem(el);

--- a/style.css
+++ b/style.css
@@ -5,6 +5,11 @@
   z-index: 1000;
 }
 
+.leaflet-pane.leaflet-popup-pane,
+.leaflet-popup {
+  z-index: 2147483600 !important;
+}
+
 #map {
   touch-action: none;
 }


### PR DESCRIPTION
## Summary
- stop the mobile GPS-follow mode when opening a pin from the list so the view stays on the selected spot
- raise the Leaflet popup pane z-index so creation/edit popups are always above tools and the search bar

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd09b0b5248330a70a26e01521a3ff