### PR TITLE
Add PWA manifest configuration for GitHub Pages deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,13 @@
   <meta charset="UTF-8" />
   <title>ExploRide – Wielka Mapa Urbexu</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="manifest" href="manifest.webmanifest">
-  <meta name="theme-color" content="#0f131b" />
+  <link rel="manifest" href="/ExploMapa/manifest.json" />
+  <meta name="theme-color" content="#000000" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
   <link rel="stylesheet" href="style.css" />
-  <link rel="icon" type="image/png" sizes="1080x1080" href="fav1080.png">
-<link rel="apple-touch-icon" sizes="1080x1080" href="fav1080.png">
-<link rel="manifest" href="manifest.json">
+  <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
+<link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
   <script src="https://twemoji.maxcdn.com/v/latest/twemoji.min.js" crossorigin="anonymous"></script>
   <style>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "ExploMapa",
+  "short_name": "ExploMapa",
+  "start_url": "/ExploMapa/",
+  "scope": "/ExploMapa/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/ExploMapa/fav1080.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/ExploMapa/fav1080.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a dedicated `manifest.json` configured for the `/ExploMapa/` GitHub Pages scope and using the existing PWA icon asset
- update `index.html` to reference the new manifest, adjust the theme color, and ensure icon links use absolute paths

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd2abe1a108330931b68b6d9e6da21