### PR TITLE
Adjust mobile popup styling to match modal

### DIFF
--- a/style.css
+++ b/style.css
@@ -322,6 +322,42 @@
     border-radius: 4px;
     display: none;
   }
+  .leaflet-popup {
+    position: fixed !important;
+    top: 50% !important;
+    left: 50% !important;
+    transform: translate(-50%, -50%) !important;
+    width: 90%;
+    max-width: 500px;
+    padding: 0;
+    margin: 0 !important;
+  }
+  .leaflet-popup-content-wrapper {
+    background: #2b2b2b;
+    border-radius: 8px;
+    padding: 20px;
+    color: #f0f0f0;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+  .leaflet-popup-content {
+    margin: 0 !important;
+    width: auto !important;
+    color: inherit;
+  }
+  .leaflet-popup-close-button {
+    color: #f0f0f0;
+    font-size: 28px;
+    top: 10px;
+    right: 15px;
+  }
+  .leaflet-popup-tip-container {
+    display: none;
+  }
   #narzedzia { top: 120px; left: 10px; }
   #saveChanges {
     top: 10px;


### PR DESCRIPTION
## Summary
- restyle Leaflet popups on small screens to center them and match the modal width
- give popup content the same dark theme, spacing, and typography as the mobile modal
- hide the Leaflet popup tip and enlarge the close button for a cleaner overlay feel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cedf7cb3d08330b5afa127e7077059