### PR TITLE
Handle highlight updates on zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -1807,6 +1807,10 @@ function emojiHtml(str) {
     function initMap() {
       L.Popup.prototype.options.maxWidth = 800;
       map = L.map('map', { crs: L.CRS.EPSG3857 }).setView([52.1, 20.9], 7);
+      map.on('zoomend', () => {
+        if (!highlightedMarker || !pinHighlightCircle) return;
+        setMarkerHighlight(highlightedMarker);
+      });
       const highlightPane = map.createPane('pinHighlightPane');
       const markerPane = map.getPane('markerPane');
       const markerPaneZIndex = markerPane && markerPane.style && markerPane.style.zIndex


### PR DESCRIPTION
## Summary
- refresh the active marker highlight whenever the map zoom changes
- skip unnecessary work when no marker highlight is active

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3187b76b8833099402c11e2ea8d32