### PR TITLE
Adjust mobile pin saving layer requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -4491,7 +4491,7 @@ function confirmLayerDelete() {
       const layer = layerInput.value.trim();
       const missing = [];
       if (!name) missing.push('Wpisz nazwę pinezki');
-      if (!layer) missing.push('Wybierz warstwę');
+      if (currentTool === 'pin' && !layer) missing.push('Wybierz warstwę');
       if (missing.length) { alert(missing.join('\n')); return; }
       if (currentTool === 'pin') {
         saveCenterPin({


### PR DESCRIPTION
## Summary
- avoid requiring layer selection when saving GPS-based pins on mobile
- keep layer requirement when the pin tool is active so existing validation remains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d978aaa6f0833080e8e5766ba73162