### PR TITLE
Add GPS start shortcut and travel mode selection for routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,31 @@
       z-index: 1550;
       pointer-events: auto;
     }
+    .route-input-group {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 6px;
+    }
+    .route-input-group input[type="text"] {
+      flex: 1;
+    }
+    .route-input-group button {
+      background: #2b2b2b;
+      border: 1px solid #444;
+      border-radius: 4px;
+      color: #f0f0f0;
+      cursor: pointer;
+      padding: 4px 8px;
+      font-size: 18px;
+      line-height: 1;
+    }
+    .route-mode-options {
+      margin: 6px 0 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
     #route-editor {
       position: absolute;
       top: 0;
@@ -769,8 +794,17 @@ img.emoji {
 
     <div id="route-controls">
       <h3>Wyznacz trasę</h3>
-      <input type="text" id="routeStart" placeholder="Punkt początkowy"><br>
-      <input type="text" id="routeEnd" placeholder="Punkt końcowy"><br>
+      <div class="route-input-group">
+        <input type="text" id="routeStart" placeholder="Punkt początkowy">
+        <button id="routeUseCurrent" type="button" title="Ustaw moją lokalizację">📍</button>
+      </div>
+      <div class="route-input-group">
+        <input type="text" id="routeEnd" placeholder="Punkt końcowy">
+      </div>
+      <div class="route-mode-options">
+        <label><input type="radio" name="routeMode" value="driving" checked> Trasa samochodowa</label>
+        <label><input type="radio" name="routeMode" value="walking"> Trasa piesza</label>
+      </div>
       <button id="routeCalculate">Pokaż trasę</button>
     </div>
     <h3>Historia edycji</h3>
@@ -3482,8 +3516,42 @@ function showRoutePopup(pinId, tr, latlng) {
       });
     }
 
+    function parseCoordinateInput(value) {
+      if (!value) return null;
+      const match = value.match(/^\s*(-?\d+(?:\.\d+)?)\s*[,;]\s*(-?\d+(?:\.\d+)?)\s*$/);
+      if (!match) return null;
+      const lat = parseFloat(match[1]);
+      const lon = parseFloat(match[2]);
+      if (Number.isNaN(lat) || Number.isNaN(lon)) return null;
+      return [lat, lon];
+    }
+
     function initRouteSearch() {
       const btn = document.getElementById('routeCalculate');
+      const useCurrent = document.getElementById('routeUseCurrent');
+      if (useCurrent) {
+        useCurrent.addEventListener('click', () => {
+          if (!navigator.geolocation) {
+            alert('Twoja przeglądarka nie wspiera geolokalizacji');
+            return;
+          }
+          useCurrent.disabled = true;
+          useCurrent.textContent = '…';
+          navigator.geolocation.getCurrentPosition(pos => {
+            const { latitude, longitude } = pos.coords;
+            const input = document.getElementById('routeStart');
+            if (input) {
+              input.value = `${latitude.toFixed(6)}, ${longitude.toFixed(6)}`;
+            }
+            useCurrent.textContent = '📍';
+            useCurrent.disabled = false;
+          }, () => {
+            alert('Nie udało się pobrać lokalizacji');
+            useCurrent.textContent = '📍';
+            useCurrent.disabled = false;
+          });
+        });
+      }
       if (!btn) return;
       btn.addEventListener('click', async () => {
         const start = document.getElementById('routeStart').value.trim();
@@ -3492,34 +3560,40 @@ function showRoutePopup(pinId, tr, latlng) {
           alert('Podaj adresy obu punktów');
           return;
         }
-        await showRoute(start, end);
+        const mode = document.querySelector('input[name="routeMode"]:checked')?.value || 'driving';
+        await showRoute(start, end, mode);
       });
     }
 
     async function geocodeAddress(addr) {
+      const coords = parseCoordinateInput(addr);
+      if (coords) return coords;
       const resp = await fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(addr)}`);
       const data = await resp.json();
       if (!data || !data[0]) throw new Error('Nie znaleziono adresu');
       return [parseFloat(data[0].lat), parseFloat(data[0].lon)];
     }
 
-    async function showRoute(startAddr, endAddr) {
+    async function showRoute(startAddr, endAddr, mode = 'driving') {
       try {
+        const startCoords = parseCoordinateInput(startAddr);
+        const endCoords = parseCoordinateInput(endAddr);
         if (window.google && google.maps && google.maps.DirectionsService) {
           const directionsService = new google.maps.DirectionsService();
           const res = await directionsService.route({
-            origin: startAddr,
-            destination: endAddr,
-            travelMode: google.maps.TravelMode.DRIVING
+            origin: startCoords ? { lat: startCoords[0], lng: startCoords[1] } : startAddr,
+            destination: endCoords ? { lat: endCoords[0], lng: endCoords[1] } : endAddr,
+            travelMode: mode === 'walking' ? google.maps.TravelMode.WALKING : google.maps.TravelMode.DRIVING
           });
           const pts = res.routes[0].overview_path.map(p => [p.lat(), p.lng()]);
           routingLayer.clearLayers();
           const line = L.polyline(pts, {color: '#ff0000', weight: 4, className: 'route-line'}).addTo(routingLayer);
           map.fitBounds(line.getBounds());
         } else {
-          const [sLat, sLon] = await geocodeAddress(startAddr);
-          const [eLat, eLon] = await geocodeAddress(endAddr);
-          const url = `https://router.project-osrm.org/route/v1/driving/${sLon},${sLat};${eLon},${eLat}?overview=full&geometries=geojson`;
+          const [sLat, sLon] = startCoords || await geocodeAddress(startAddr);
+          const [eLat, eLon] = endCoords || await geocodeAddress(endAddr);
+          const osrmProfile = mode === 'walking' ? 'walking' : 'driving';
+          const url = `https://router.project-osrm.org/route/v1/${osrmProfile}/${sLon},${sLat};${eLon},${eLat}?overview=full&geometries=geojson`;
           const r = await fetch(url);
           const json = await r.json();
           if (!json.routes || !json.routes[0]) throw new Error('Brak trasy');


### PR DESCRIPTION
## Summary
- add a GPS shortcut button next to the start point field to fill it with the current location
- introduce styling hooks for the new route inputs and mode selectors
- support choosing between driving and walking directions and handle raw coordinate inputs in routing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcf6db18b88330b8a8cbb8d7c0eb41