### PR TITLE
Przywrócenie działania przycisków w modalu usuwania

### DIFF
--- a/index.html
+++ b/index.html
@@ -4060,6 +4060,21 @@ toggleBtn.style.verticalAlign = "top";
 
     document.getElementById('exportKML').addEventListener('click', exportPinsToKML);
 
+  let pendingDeletePinId = null;
+
+  document.addEventListener('click', e => {
+    if (e.target && e.target.id === 'deleteConfirmYes') {
+      if (pendingDeletePinId != null) {
+        deletePinLocal(pendingDeletePinId);
+      } else {
+        closeDeleteModal();
+      }
+    }
+    if (e.target && e.target.id === 'deleteConfirmNo') {
+      closeDeleteModal();
+    }
+  });
+
   document.addEventListener("DOMContentLoaded", () => {
     twemoji.parse(document.body, {
       folder: "svg",
@@ -4076,8 +4091,6 @@ toggleBtn.style.verticalAlign = "top";
 
     const delModal = document.getElementById('deleteModal');
     if (delModal) {
-      document.getElementById('deleteConfirmYes').addEventListener('click', () => deletePinLocal(deletePinId));
-      document.getElementById('deleteConfirmNo').addEventListener('click', closeDeleteModal);
       delModal.addEventListener('click', e => {
         if (e.target === delModal) closeDeleteModal();
       });
@@ -4198,11 +4211,10 @@ toggleBtn.style.verticalAlign = "top";
     return finalPhotos;
   }
 
-  let deletePinId = null;
   function openDeleteModal(id) {
-    deletePinId = id;
     const modal = document.getElementById('deleteModal');
     if (modal) {
+      pendingDeletePinId = id;
       const txt = modal.querySelector('#deleteModalContent div');
       const p = wszystkiePinezki.find(pp => pp.id === id);
       if (txt && p) txt.textContent = `Czy na pewno chcesz usunąć pinezkę ${p.nazwa}?`;
@@ -4211,14 +4223,19 @@ toggleBtn.style.verticalAlign = "top";
   }
 
   function closeDeleteModal() {
-    deletePinId = null;
     const modal = document.getElementById('deleteModal');
-    if (modal) modal.style.display = 'none';
+    if (modal) {
+      pendingDeletePinId = null;
+      modal.style.display = 'none';
+    }
   }
 
   function deletePinLocal(id, record = true) {
-    const p = wszystkiePinezki.find(pp => pp.id === id);
-    if (!p) return;
+    const p = wszystkiePinezki.find(pp => String(pp.id) === String(id));
+    if (!p) {
+      closeDeleteModal();
+      return;
+    }
     const layerName = p.warstwa || 'Inne';
     const backup = {
       pin: p,


### PR DESCRIPTION
## Summary
- wprowadzono globalne przechowywanie identyfikatora pinezki przeznaczonej do usunięcia
- dodano delegowane nasłuchiwanie kliknięć na przyciskach TAK/NIE oraz domknięcie modalu po kliknięciu tła

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e37253b4588330a6d086569fda6b83