### PR TITLE
Fix delete modal interaction when editing pins

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,7 +451,7 @@ body, #sidebar, #basemap-switcher {
   background: rgba(0, 0, 0, 0.8);
   justify-content: center;
   align-items: center;
-  z-index: 2000;
+  z-index: 2147483605;
   color: #fff;
 }
 
@@ -475,7 +475,7 @@ body, #sidebar, #basemap-switcher {
   background: rgba(0, 0, 0, 0.8);
   justify-content: center;
   align-items: center;
-  z-index: 2000;
+  z-index: 2147483605;
   color: #fff;
 }
 #layerDeleteModalContent {


### PR DESCRIPTION
## Summary
- raise the delete and layer delete modal z-index so they sit above the edit popup
- ensure confirm and cancel buttons remain clickable when removing pins during editing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e37aa5256c8330869ae3e78960aba9