### PR TITLE
Guard Twemoji parsing during DOM setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -4061,10 +4061,16 @@ toggleBtn.style.verticalAlign = "top";
     document.getElementById('exportKML').addEventListener('click', exportPinsToKML);
 
   document.addEventListener("DOMContentLoaded", () => {
-    twemoji.parse(document.body, {
-      folder: "svg",
-      ext: ".svg"
-    });
+    if (window.twemoji && typeof window.twemoji.parse === 'function') {
+      try {
+        window.twemoji.parse(document.body, {
+          folder: "svg",
+          ext: ".svg"
+        });
+      } catch (err) {
+        console.warn('twemoji.parse failed', err);
+      }
+    }
     const modal = document.getElementById('photoModal');
     if (modal) {
       modal.addEventListener('click', e => {


### PR DESCRIPTION
## Summary
- guard the Twemoji parsing step so DOM initialization continues even if the CDN script fails
- ensure the delete confirmation modal buttons stay responsive so pin removals are recorded locally until saved

## Testing
- manual Playwright verification of delete modal yes/no buttons

------
https://chatgpt.com/codex/tasks/task_e_68e3879655648330bee39938790a539e