### PR TITLE
Add heading arrow to mobile GPS marker

### DIFF
--- a/index.html
+++ b/index.html
@@ -4301,10 +4301,33 @@ function confirmLayerDelete() {
 
   const isMobile = window.matchMedia('(max-width: 768px)').matches;
 
+  const GPS_ARROW_BASE_TRANSFORM = 'translate(-50%, calc(-50% - 8px))';
   let currentLocation = null;
   let currentMarker = null;
-  const gpsIcon = L.divIcon({className:'gps-marker'});
+  const gpsIcon = L.divIcon({
+    className: 'gps-marker',
+    html: '<div class="gps-arrow"></div><div class="gps-dot"></div>',
+    iconSize: [24, 24],
+    iconAnchor: [12, 12]
+  });
   let followGps = true;
+
+  function updateGpsHeading(heading) {
+    if (!currentMarker) return;
+    const markerEl = currentMarker.getElement();
+    if (!markerEl) return;
+    const arrow = markerEl.querySelector('.gps-arrow');
+    if (!arrow) return;
+
+    if (typeof heading === 'number' && !Number.isNaN(heading)) {
+      const normalized = (heading + 360) % 360;
+      arrow.style.transform = `${GPS_ARROW_BASE_TRANSFORM} rotate(${normalized}deg)`;
+      markerEl.classList.add('has-heading');
+    } else {
+      arrow.style.transform = `${GPS_ARROW_BASE_TRANSFORM} rotate(0deg)`;
+      markerEl.classList.remove('has-heading');
+    }
+  }
 
   function initGeolocation() {
     if (!navigator.geolocation) return;
@@ -4314,11 +4337,19 @@ function confirmLayerDelete() {
     }
     navigator.geolocation.watchPosition(pos => {
       currentLocation = [pos.coords.latitude, pos.coords.longitude];
+      const heading = pos.coords.heading;
+      let markerCreated = false;
       if (!currentMarker) {
         currentMarker = L.marker(currentLocation, {icon: gpsIcon}).addTo(map);
         map.setView(currentLocation, 16);
+        markerCreated = true;
       } else {
         currentMarker.setLatLng(currentLocation);
+      }
+      if (markerCreated) {
+        requestAnimationFrame(() => updateGpsHeading(heading));
+      } else {
+        updateGpsHeading(heading);
       }
       if (followGps) {
         map.setView(currentLocation, map.getZoom());

--- a/style.css
+++ b/style.css
@@ -285,12 +285,43 @@
 }
 
 .gps-marker {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  pointer-events: none;
+}
+
+.gps-marker .gps-dot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
   width: 12px;
   height: 12px;
   background: #0080ff;
   border-radius: 50%;
   box-shadow: 0 0 0 0 rgba(0,128,255,0.7);
   animation: gps-pulse 2s infinite;
+  transform: translate(-50%, -50%);
+}
+
+.gps-marker .gps-arrow {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-bottom: 10px solid #0080ff;
+  transform: translate(-50%, calc(-50% - 8px)) rotate(0deg);
+  transform-origin: 50% calc(100% + 6px);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  filter: drop-shadow(0 0 4px rgba(0,128,255,0.4));
+}
+
+.gps-marker.has-heading .gps-arrow {
+  opacity: 0.9;
 }
 
 @keyframes gps-pulse {


### PR DESCRIPTION
## Summary
- add an arrow overlay to the GPS marker to indicate the device heading on mobile
- update geolocation handling to rotate the arrow based on heading information
- refresh marker styling so the location dot and arrow render together cleanly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3a01632d08330a6f9fea774c2894d