### PR TITLE
Enable Enter route submission with validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3571,6 +3571,8 @@ function showRoutePopup(pinId, tr, latlng) {
       const btn = document.getElementById('routeCalculate');
       const useCurrent = document.getElementById('routeUseCurrent');
       const clearBtn = document.getElementById('routeClear');
+      const startInput = document.getElementById('routeStart');
+      const endInput = document.getElementById('routeEnd');
 
       function updateRouteClearButton() {
         if (!clearBtn) return;
@@ -3578,13 +3580,32 @@ function showRoutePopup(pinId, tr, latlng) {
         clearBtn.disabled = !hasRoute;
       }
 
+      async function handleRouteSubmission() {
+        const start = startInput?.value.trim();
+        const end = endInput?.value.trim();
+
+        if (!start) {
+          alert('wprowadź punkt początkowy trasy');
+          startInput?.focus();
+          return;
+        }
+
+        if (!end) {
+          alert('wprowadź punkt końcowy trasy');
+          endInput?.focus();
+          return;
+        }
+
+        const mode = document.querySelector('input[name="routeMode"]:checked')?.value || 'driving';
+        await showRoute(start, end, mode);
+        updateRouteClearButton();
+      }
+
       if (clearBtn) {
         clearBtn.addEventListener('click', () => {
           if (routingLayer) {
             routingLayer.clearLayers();
           }
-          const startInput = document.getElementById('routeStart');
-          const endInput = document.getElementById('routeEnd');
           if (startInput) startInput.value = '';
           if (endInput) endInput.value = '';
           updateRouteClearButton();
@@ -3600,9 +3621,8 @@ function showRoutePopup(pinId, tr, latlng) {
           useCurrent.textContent = '…';
           navigator.geolocation.getCurrentPosition(pos => {
             const { latitude, longitude } = pos.coords;
-            const input = document.getElementById('routeStart');
-            if (input) {
-              input.value = `${latitude.toFixed(6)}, ${longitude.toFixed(6)}`;
+            if (startInput) {
+              startInput.value = `${latitude.toFixed(6)}, ${longitude.toFixed(6)}`;
             }
             useCurrent.textContent = '📍';
             useCurrent.disabled = false;
@@ -3615,16 +3635,15 @@ function showRoutePopup(pinId, tr, latlng) {
       }
       updateRouteClearButton();
       if (!btn) return;
-      btn.addEventListener('click', async () => {
-        const start = document.getElementById('routeStart').value.trim();
-        const end = document.getElementById('routeEnd').value.trim();
-        if (!start || !end) {
-          alert('Podaj adresy obu punktów');
-          return;
-        }
-        const mode = document.querySelector('input[name="routeMode"]:checked')?.value || 'driving';
-        await showRoute(start, end, mode);
-        updateRouteClearButton();
+      btn.addEventListener('click', handleRouteSubmission);
+      [startInput, endInput].forEach(input => {
+        if (!input) return;
+        input.addEventListener('keydown', e => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            handleRouteSubmission();
+          }
+        });
       });
     }
 


### PR DESCRIPTION
## Summary
- allow submitting the route search by pressing Enter in either input
- add detailed prompts when the start or end point is missing
- reuse cached inputs for geolocation and clearing actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3cd351cdc83309793cec2388161b8