### PR TITLE
Improve mobile Google sign-in reliability

### DIFF
--- a/index.html
+++ b/index.html
@@ -1609,15 +1609,36 @@ function slugify(str) {
       return isMobileUa || isStandalonePwa;
     }
 
+    async function signInWithBestMethod(provider) {
+      const auth = firebase.auth();
+      const popupFallbackCodes = new Set([
+        "auth/popup-blocked",
+        "auth/popup-closed-by-user",
+        "auth/operation-not-supported-in-this-environment"
+      ]);
+      const preferRedirect = shouldUseRedirectSignIn();
+
+      if (!preferRedirect) {
+        return auth.signInWithPopup(provider);
+      }
+
+      try {
+        return await auth.signInWithPopup(provider);
+      } catch (popupErr) {
+        if (!popupFallbackCodes.has(popupErr?.code)) throw popupErr;
+        return auth.signInWithRedirect(provider);
+      }
+    }
+
+    firebase.auth().setPersistence(firebase.auth.Auth.Persistence.LOCAL).catch(err => {
+      console.warn("Nie udało się ustawić trwałej sesji logowania:", err);
+    });
+
     document.getElementById("loginBtn").addEventListener("click", async () => {
       const provider = new firebase.auth.GoogleAuthProvider();
       provider.setCustomParameters({ prompt: "select_account" });
       try {
-        if (shouldUseRedirectSignIn()) {
-          await firebase.auth().signInWithRedirect(provider);
-          return;
-        }
-        await firebase.auth().signInWithPopup(provider);
+        await signInWithBestMethod(provider);
       } catch (err) {
         console.error("Błąd logowania:", err);
         alert("Nie udało się uruchomić logowania Google. Spróbuj ponownie.");


### PR DESCRIPTION
### Motivation
- Mobile/PWA users reported that the map either did not display or took a very long time to show after Google sign-in, and mobile behavior should match desktop by keeping users authenticated.

### Description
- Add `signInWithBestMethod(provider)` which prefers `signInWithPopup` and only falls back to `signInWithRedirect` for common popup-related error codes on devices that prefer redirect.
- Set Firebase Auth persistence to `firebase.auth.Auth.Persistence.LOCAL` to keep sessions across page reloads and reduce repeated logins.
- Replace the `#loginBtn` handler to call the new `signInWithBestMethod` helper instead of the previous hard-coded popup/redirect branching.

### Testing
- Ran `git diff --check` which reported no issues.
- Ran `git status --short` and confirmed only `index.html` was modified.
- Performed a basic syntax/scan to ensure no unresolved identifiers were introduced and the updated login flow is syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7548253688330939ba6aa59faa536)