### PR TITLE
Fix Enter geosearch to use top suggestion result

### DIFF
--- a/index.html
+++ b/index.html
@@ -6097,14 +6097,31 @@ function showRoutePopup(pinId, tr, latlng) {
 
     function initGeoSearch() {
       const input = document.getElementById('geosearch');
-      const btn = document.getElementById('geosearchBtn');
       const form = document.getElementById('geosearch-container');
       const suggestions = document.getElementById('geosearch-suggestions');
       if (!input) return;
 
+      async function fetchNominatimSuggestions(q, limit = 5) {
+        const response = await fetch(`https://nominatim.openstreetmap.org/search?format=json&limit=${limit}&q=${encodeURIComponent(q)}`);
+        return response.json();
+      }
+
       async function executeSearch(q) {
         try {
-          const result = await geocodeQuery(q);
+          let result = null;
+          const topSuggestion = await fetchNominatimSuggestions(q, 1);
+          const firstSuggestion = topSuggestion?.[0];
+
+          if (firstSuggestion) {
+            result = {
+              lat: parseFloat(firstSuggestion.lat),
+              lng: parseFloat(firstSuggestion.lon),
+              label: firstSuggestion.display_name
+            };
+          } else {
+            result = await geocodeQuery(q);
+          }
+
           if (!result) {
             alert('Nie znaleziono adresu');
             return;
@@ -6128,10 +6145,6 @@ function showRoutePopup(pinId, tr, latlng) {
       if (form) {
         form.addEventListener('submit', handleSearch);
       }
-      if (btn) {
-        btn.addEventListener('pointerup', handleSearch);
-      }
-      input.addEventListener('keydown', e => { if (e.key === 'Enter') handleSearch(e); });
       input.addEventListener('search', handleSearch);
 
       input.addEventListener('focus', () => {
@@ -6152,8 +6165,7 @@ function showRoutePopup(pinId, tr, latlng) {
         if (!suggestions) return;
         if (!q) { suggestions.style.display = 'none'; return; }
         debounce = setTimeout(() => {
-          fetch(`https://nominatim.openstreetmap.org/search?format=json&limit=5&q=${encodeURIComponent(q)}`)
-            .then(r => r.json())
+          fetchNominatimSuggestions(q, 5)
             .then(data => {
               suggestions.innerHTML = '';
               data.forEach(item => {


### PR DESCRIPTION
### Motivation
- Naprawić niespójne zachowanie wyszukiwarki, gdzie naciśnięcie Enter przenosiło do innej lokalizacji niż kliknięcie pierwszej pozycji w `geosearch-suggestions`.

### Description
- Dodano pomocniczą funkcję `fetchNominatimSuggestions(q, limit)` i użyto jej do pobierania wyników Nominatim zarówno przy podpowiedziach, jak i przy wyszukiwaniu po Enterze w `index.html`.
- Zmieniono `executeSearch` tak, by najpierw próbował użyć pierwszego wyniku z Nominatim (`limit=1`) i tylko gdy go brak, fallbackował do istniejącej `geocodeQuery`.
- Usunięto zdublowane ścieżki wywołania wyszukiwania (`keydown Enter` i `pointerup` na przycisku) i uproszczono flow do obsługi przez `submit`/`search` oraz wspólną funkcję pobierania podpowiedzi.

### Testing
- Uruchomiono `git diff --check` i nie wykryto problemów.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e759ad2dc8833089dde61f9a3eb244)