### PR TITLE
Poprawka przywracania sesji logowania po ponownym otwarciu na telefonie

### DIFF
--- a/index.html
+++ b/index.html
@@ -1561,6 +1561,7 @@ function slugify(str) {
     }
 
     const ALLOWED_EMAILS = new Set(["eksplorajder@gmail.com"]);
+    const AUTH_REMEMBER_KEY = "exploMapaRememberedAuth";
     let appInitialized = false;
 
     function shouldUseMobileLayout() {
@@ -1634,6 +1635,12 @@ function slugify(str) {
       console.warn("Nie udało się ustawić trwałej sesji logowania:", err);
     });
 
+    const hadRememberedAuth = localStorage.getItem(AUTH_REMEMBER_KEY) === "1";
+    if (hadRememberedAuth) {
+      document.getElementById("loginBtn").textContent = "Sprawdzam zapisane logowanie...";
+      document.getElementById("loginBtn").disabled = true;
+    }
+
     document.getElementById("loginBtn").addEventListener("click", async () => {
       const provider = new firebase.auth.GoogleAuthProvider();
       provider.setCustomParameters({ prompt: "select_account" });
@@ -1645,8 +1652,12 @@ function slugify(str) {
       }
     });
 
-    firebase.auth().onAuthStateChanged(async user => {
+    firebase.auth().onIdTokenChanged(async user => {
+      const loginBtn = document.getElementById("loginBtn");
       if (!user) {
+        localStorage.removeItem(AUTH_REMEMBER_KEY);
+        loginBtn.textContent = "Zaloguj się przez Google";
+        loginBtn.disabled = false;
         showLoginScreen();
         return;
       }
@@ -1654,9 +1665,15 @@ function slugify(str) {
       if (!ALLOWED_EMAILS.has(email)) {
         alert(`Brak dostępu dla konta: ${user.email || "nieznane"}`);
         await firebase.auth().signOut();
+        localStorage.removeItem(AUTH_REMEMBER_KEY);
+        loginBtn.textContent = "Zaloguj się przez Google";
+        loginBtn.disabled = false;
         showLoginScreen();
         return;
       }
+      localStorage.setItem(AUTH_REMEMBER_KEY, "1");
+      loginBtn.textContent = "Zaloguj się przez Google";
+      loginBtn.disabled = false;
       showAuthenticatedApp();
     });
 


### PR DESCRIPTION
### Motivation
- Po pełnym zamknięciu mobilnej przeglądarki aplikacja pokazywała ekran logowania mimo istniejącej sesji, zamiast od razu wyświetlić mapę. 

### Description
- Dodano stałą `AUTH_REMEMBER_KEY` (`exploMapaRememberedAuth`) i zapis/wyczyszczenie tego klucza w `localStorage` w `index.html`.
- Przy starcie sprawdzany jest `AUTH_REMEMBER_KEY` i w razie potrzeby przycisk logowania jest tymczasowo zablokowany z tekstem „Sprawdzam zapisane logowanie...”.
- Zmieniono nasłuch z `firebase.auth().onAuthStateChanged` na `firebase.auth().onIdTokenChanged` oraz zaktualizowano logikę ustawiania/wyczyszczania klucza i stanu przycisku przy zmianie auth. 
- Po pomyślnym uwierzytelnieniu ustawiany jest klucz pamięci sesji, a po wylogowaniu lub braku dostępu klucz jest usuwany i przycisk przywracany do domyślnego stanu. 

### Testing
- Uruchomiono `git diff --check HEAD~1..HEAD` które zwróciło OK.
- Sprawdzono status repo z `git status --short`, który wykazał zmodyfikowany `index.html`.
- Zmiany zostały zapisane w commicie (`Popraw utrzymywanie sesji logowania na mobile`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7639d57108330957c8d1ffc65962e)