### PR TITLE
Fix unsaved state detection for pin deletions

### DIFF
--- a/index.html
+++ b/index.html
@@ -2290,6 +2290,7 @@ function slugify(str) {
       return (
         Object.keys(zmianyDoZapisania).length > 0 ||
         nowePinezki.length > 0 ||
+        pinsToDelete.length > 0 ||
         layerChanges ||
         routeChanges
       );


### PR DESCRIPTION
### Motivation
- Deleting a pin did not mark the app as having unsaved changes, so the `Zapisz zmiany` button did not appear after removing a pin and the deletion was not deferred to the save step.

### Description
- Add `pinsToDelete.length > 0` to `hasUnsavedChanges()` in `index.html` so deletions set the unsaved state and the save button is shown, ensuring actual Firestore deletions occur only after clicking `Zapisz zmiany`.

### Testing
- No automated test suite is configured for this repository, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77d2bf6f08330bf23e19c75a4bf21)