### PR TITLE
Dodaj Ctrl‑klik izolujący widoczność warstw i filtrów oraz loader przy renderze pinezek

### DIFF
--- a/index.html
+++ b/index.html
@@ -6905,6 +6905,18 @@ function showRoutePopup(pinId, tr, latlng) {
       meta.innerHTML = `Krajów łącznie: <strong>${countries.size}</strong>${loading ? '<span class="country-inline-loader" title="Wczytywanie krajów"></span>' : ''}`;
     }
 
+    function handleCtrlExclusiveToggle(event, checkboxes, onApply) {
+      const isExclusive = !!(event && (event.ctrlKey || event.metaKey));
+      if (!isExclusive) return false;
+      event.preventDefault();
+      event.stopPropagation();
+      checkboxes.forEach(ch => {
+        ch.checked = ch === event.currentTarget;
+      });
+      if (typeof onApply === 'function') onApply();
+      return true;
+    }
+
     function updateStatusFilter() {
       const container = document.getElementById('status-lista');
       if (!container) return;
@@ -6942,6 +6954,14 @@ function showRoutePopup(pinId, tr, latlng) {
         div.appendChild(chk);
         div.appendChild(lbl);
         container.appendChild(div);
+        chk.addEventListener('click', (event) => {
+          handleCtrlExclusiveToggle(event, Array.from(container.querySelectorAll('.status-item input')), () => {
+            selectedStatuses = new Set([s.key]);
+            const all = document.getElementById('status-all');
+            if (all) all.checked = false;
+            generujListeWarstw();
+          });
+        });
         chk.addEventListener('change', () => {
           selectedStatuses = new Set(Array.from(container.querySelectorAll('.status-item input')).filter(c => c.checked).map(c => c.value));
           const all = document.getElementById('status-all');
@@ -6996,6 +7016,14 @@ function showRoutePopup(pinId, tr, latlng) {
         div.appendChild(chk);
         div.appendChild(lbl);
         container.appendChild(div);
+        chk.addEventListener('click', (event) => {
+          handleCtrlExclusiveToggle(event, Array.from(container.querySelectorAll('.kat-item input')), () => {
+            selectedCategories = new Set([cat]);
+            const all = document.getElementById('kategorie-all');
+            if (all) all.checked = false;
+            generujListeWarstw();
+          });
+        });
         chk.addEventListener('change', () => {
           selectedCategories = new Set(
             Array.from(container.querySelectorAll('.kat-item input')).filter(c => c.checked).map(c => c.value)
@@ -7049,6 +7077,15 @@ function showRoutePopup(pinId, tr, latlng) {
         div.appendChild(chk);
         div.appendChild(lbl);
         container.appendChild(div);
+        chk.addEventListener('click', (event) => {
+          handleCtrlExclusiveToggle(event, Array.from(container.querySelectorAll('.country-item input')), () => {
+            countryFilterTouched = true;
+            selectedCountries = new Set([country]);
+            const all = document.getElementById('kraje-all');
+            if (all) all.checked = false;
+            generujListeWarstw();
+          });
+        });
         chk.addEventListener('change', () => {
           countryFilterTouched = true;
           selectedCountries = new Set(
@@ -7072,9 +7109,16 @@ function showRoutePopup(pinId, tr, latlng) {
     function scheduleMarkerVisibilityUpdate() {
       if (markerViewportUpdateScheduled) return;
       markerViewportUpdateScheduled = true;
+      showLoading();
       requestAnimationFrame(() => {
-        markerViewportUpdateScheduled = false;
-        updateMarkerVisibility();
+        requestAnimationFrame(() => {
+          markerViewportUpdateScheduled = false;
+          try {
+            updateMarkerVisibility();
+          } finally {
+            hideLoading();
+          }
+        });
       });
     }
 
@@ -7145,6 +7189,28 @@ function showRoutePopup(pinId, tr, latlng) {
           map.removeLayer(warstwy[nazwa].layer);
         }
         checkbox.checked = warstwy[nazwa].visible;
+        checkbox.addEventListener('click', (event) => {
+          const layerCheckboxes = Array.from(lista.querySelectorAll('.warstwa h3 > span:first-child > input[type="checkbox"]'));
+          handleCtrlExclusiveToggle(event, layerCheckboxes, () => {
+            layerCheckboxes.forEach(ch => {
+              const layerName = ch.closest('.warstwa')?.dataset?.nazwa;
+              if (!layerName || !warstwy[layerName]) return;
+              warstwy[layerName].visible = ch.checked;
+              if (ch.checked) {
+                warstwy[layerName].layer.addTo(map);
+              } else {
+                map.removeLayer(warstwy[layerName].layer);
+              }
+              if (!warstwy[layerName].temporary) {
+                setLayerVisibilityState(layerName, ch.checked);
+              }
+            });
+            allLayersVisible = Object.values(warstwy).every(w => w.visible);
+            if (toggleVisibilityBtn) {
+              toggleVisibilityBtn.textContent = allLayersVisible ? 'Ukryj wszystkie warstwy' : 'Pokaż wszystkie warstwy';
+            }
+          });
+        });
         checkbox.onchange = () => {
           warstwy[nazwa].visible = checkbox.checked;
           if (checkbox.checked) {


### PR DESCRIPTION
### Motivation
- Umożliwić szybkie „izolowanie” jednej warstwy lub jednego filtra przez przytrzymanie `Ctrl`/`⌘` podczas kliku w checkbox, bez zmiany innych grup ustawień.
- Poinformować użytkownika o ładowaniu markerów podczas przeliczania widoczności po przesunięciu mapy, pokazując ten sam loader co dla kafelków.

### Description
- Dodano pomocniczą funkcję `handleCtrlExclusiveToggle(event, checkboxes, onApply)` obsługującą tryb solo dla `Ctrl`/`⌘`+klików.
- Podpięto `Ctrl`/`⌘`+klik do checkboxów filtrowania (statusy, kategorie, kraje) tak, by każda grupa mogła zostać ograniczona do jednego zaznaczenia niezależnie od innych grup.
- Podpięto `Ctrl`/`⌘`+klik do checkboxów widoczności warstw w liście warstw, tak aby kliknięty checkbox pozostał `checked`, a pozostałe zostały `unchecked`, przy jednoczesnej aktualizacji stanu warstw i tekstu przycisku globalnej widoczności.
- Zmieniono `scheduleMarkerVisibilityUpdate()` żeby wywoływało `showLoading()` przed odświeżeniem widoczności markerów i `hideLoading()` w `finally`, przy użyciu zagnieżdżonych `requestAnimationFrame` dla bezpiecznego renderu.
- Wszystkie zmiany znajdują się w `index.html` i mają lokalny wpływ na zachowanie list warstw i filtrów oraz na UX podczas renderowania pinezek.

### Testing
- Uruchomiono `git diff --check` w repozytorium i nie wykryto błędów whitespace (sukces).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c78f12708330b6d2300f01d007b3)