### PR TITLE
Zwiększ próg klastrowania markerów (z 6 do 12)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1753,7 +1753,7 @@ function slugify(str) {
     const LAYER_STATE_PRESERVE_FLAG_KEY = 'warstwaPreserveStateOnce';
     const PINTEREST_LAYER_NAME = 'pinterest_diane_g';
     const PINTEREST_PINS_COLLECTION = 'pinterest_diane_g';
-    const CLUSTER_DISABLE_AT_ZOOM = 6; // Polska (~z6+) pokazuje pełne pinezki
+    const CLUSTER_DISABLE_AT_ZOOM = 12; // skupiaj pinezki aż do średniego przybliżenia mapy
     const BIG_CLUSTER_COUNT = 500;
 
     const shouldRestoreLayerState = localStorage.getItem(LAYER_STATE_PRESERVE_FLAG_KEY) === '1';


### PR DESCRIPTION
### Motivation
- Markery nie grupowały się przy zwykłym oddaleniu mapy, więc trzeba przesunąć próg wyłączający klastrowanie, aby pinezki były sklejane przy dalszym widoku.

### Description
- Zmieniono wartość `CLUSTER_DISABLE_AT_ZOOM` w `index.html` z `6` na `12`, co utrzymuje grupowanie markerów aż do bliższego przybliżenia mapy.

### Testing
- Uruchomiono `git diff --check`, które zakończyło się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9cccf615c83309298a53b7d04fcea)