### PR TITLE
Load Leaflet before MarkerCluster to restore marker clustering

### DIFF
--- a/index.html
+++ b/index.html
@@ -1396,10 +1396,10 @@ img.emoji {
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
-  <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
   <script src="offline-uploads.js"></script>
   <script src="firestore-setup.js"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
   <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
   <script src="leaflet-tilelayer-wmts.js"></script>
 


### PR DESCRIPTION
### Motivation
- Naprawa nie działającego grupowania markerów, ponieważ plugin `leaflet.markercluster.js` był ładowany przed biblioteką `leaflet.js`, przez co `L.markerClusterGroup` nie była rejestrowana.

### Description
- Przeniesiono include skryptu `leaflet.markercluster.js` w `index.html`, aby ładował się po `leaflet.js` i umożliwić poprawną inicjalizację klastra markerów.

### Testing
- Uruchomiono sprawdzenia pliku przy pomocy `rg -n "leaflet\.js|leaflet\.markercluster" index.html` oraz `nl -ba index.html | sed -n '1390,1420p'`, które potwierdziły poprawną kolejność ładowania skryptów (oba polecenia zakończyły się sukcesem).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9cefa3e408330ab61fbe310b30dc0)