### PR TITLE
Adjust marker clustering threshold to start above 50 markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1754,6 +1754,7 @@ function slugify(str) {
     const PINTEREST_LAYER_NAME = 'pinterest_diane_g';
     const PINTEREST_PINS_COLLECTION = 'pinterest_diane_g';
     const CLUSTER_DISABLE_AT_ZOOM = 8; // skupiaj pinezki aż do średniego przybliżenia mapy
+    const CLUSTER_MIN_MARKERS = 50; // klastruj dopiero, gdy warstwa ma ponad 50 pinezek
     const BIG_CLUSTER_COUNT = 500;
 
     const shouldRestoreLayerState = localStorage.getItem(LAYER_STATE_PRESERVE_FLAG_KEY) === '1';
@@ -1842,9 +1843,11 @@ function slugify(str) {
       if (!L.markerClusterGroup) {
         return L.layerGroup();
       }
-      return L.markerClusterGroup({
+
+      let clusterLayer = null;
+      clusterLayer = L.markerClusterGroup({
         disableClusteringAtZoom: CLUSTER_DISABLE_AT_ZOOM,
-        maxClusterRadius: 55,
+        maxClusterRadius: () => (clusterLayer && clusterLayer.getLayers().length > CLUSTER_MIN_MARKERS ? 55 : 1),
         spiderfyOnMaxZoom: true,
         showCoverageOnHover: false,
         iconCreateFunction: cluster => {
@@ -1858,6 +1861,8 @@ function slugify(str) {
           });
         }
       });
+
+      return clusterLayer;
     }
 
     const bulkPanel = document.getElementById('bulk-pin-panel');


### PR DESCRIPTION
### Motivation
- Clustering grouped very small nearby sets of pins (e.g. 2 pins) which is undesirable; clustering should only activate for larger layers.
- Make clustering opt-in based on layer size so UX remains uncluttered for small datasets.

### Description
- Added `CLUSTER_MIN_MARKERS = 50` to control the minimum number of markers in a layer required to enable clustering.
- Reworked `createPinLayer()` to return a `L.markerClusterGroup` with `maxClusterRadius` set to a function that returns `55` only when the layer has more than `CLUSTER_MIN_MARKERS`, otherwise it returns `1` to effectively disable clustering for small layers.
- Preserved the existing cluster icon sizing and other cluster behaviors for layers exceeding the threshold.

### Testing
- Ran `git diff -- index.html` to inspect the change and `git status --short` to verify working tree state, both succeeded.
- Committed the change with `git add index.html && git commit -m "Adjust marker clustering to start above 50 markers"`, which succeeded.
- No project unit or integration tests were present or executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9db24ea8c8330a8a3cc43c988d889)