### PR TITLE
Dostosuj wygląd i agregację klastrów markerów

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,17 +506,20 @@
           drop-shadow(0 0 1px black)
           drop-shadow(0 0 1px black);
 }
-    .marker-cluster,
-    .marker-cluster div {
-      background: rgba(24, 24, 24, 0.92);
-      border: 2px solid #7bd3ff;
+    .custom-cluster-icon {
+      background: rgba(128, 128, 128, 0.5);
+      border: 2px solid #ff2d2d;
+      border-radius: 50%;
       color: #fff;
       font-weight: 700;
-      box-shadow: 0 0 12px rgba(0, 0, 0, 0.45);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0.35);
     }
-    .marker-cluster-large,
-    .marker-cluster-large div {
-      border-color: #ffb86c;
+    .custom-cluster-icon span {
+      color: #fff;
+      line-height: 1;
     }
     .emoji-inline {
 width: 15px;
@@ -2231,7 +2234,7 @@ function slugify(str) {
     const PINTEREST_LAYER_NAME = 'pinterest_diane_g';
     const PINTEREST_PINS_COLLECTION = 'pinterest_diane_g';
     const CLUSTER_DISABLE_AT_ZOOM = 8; // skupiaj pinezki aż do średniego przybliżenia mapy
-    const CLUSTER_MIN_MARKERS = 50; // klastruj dopiero, gdy warstwa ma ponad 50 pinezek
+    const CLUSTER_MIN_MARKERS = 1; // klastruj już od małej liczby pinezek
     const BIG_CLUSTER_COUNT = 500;
 
     const shouldRestoreLayerState = localStorage.getItem(LAYER_STATE_PRESERVE_FLAG_KEY) === '1';
@@ -2324,16 +2327,15 @@ function slugify(str) {
       let clusterLayer = null;
       clusterLayer = L.markerClusterGroup({
         disableClusteringAtZoom: CLUSTER_DISABLE_AT_ZOOM,
-        maxClusterRadius: () => (clusterLayer && clusterLayer.getLayers().length > CLUSTER_MIN_MARKERS ? 55 : 1),
+        maxClusterRadius: () => (clusterLayer && clusterLayer.getLayers().length >= CLUSTER_MIN_MARKERS ? 75 : 1),
         spiderfyOnMaxZoom: true,
         showCoverageOnHover: false,
         iconCreateFunction: cluster => {
           const count = cluster.getChildCount();
           const size = count >= BIG_CLUSTER_COUNT ? 56 : count >= 100 ? 46 : 38;
-          const className = count >= BIG_CLUSTER_COUNT ? 'marker-cluster marker-cluster-large' : 'marker-cluster marker-cluster-medium';
           return L.divIcon({
-            html: `<div><span>${count}</span></div>`,
-            className,
+            html: `<span>${count}</span>`,
+            className: 'custom-cluster-icon',
             iconSize: L.point(size, size)
           });
         }


### PR DESCRIPTION
### Motivation
- Zmiana ma wyeliminować podwójny/czworokątny efekt ikon klastrów i pokazać pojedyncze kółko z numerem, białym napisem i czerwoną obwódką oraz szarym wnętrzem 50% przezroczystości. 
- Klastrowanie ma być bardziej agresywne, tak żeby blisko położone pinezki częściej grupowały się w jedno kółko.

### Description
- Zastąpiono dotychczasowe style `.marker-cluster`/`.marker-cluster-large` nową klasą `custom-cluster-icon` z `background: rgba(128,128,128,0.5)`, `border: 2px solid #ff2d2d`, `border-radius: 50%` oraz wyśrodkowanym białym licznikiem w `<span>` (zmiana w `index.html`).
- Zmieniono generowanie ikony w `iconCreateFunction` tak, że zwracany `L.divIcon` ma `html: '<span>${count}</span>'` i `className: 'custom-cluster-icon'` (usuńcie efekt „podwójnego kółka”).
- Dostosowano zachowanie agregacji: `CLUSTER_MIN_MARKERS` ustawiono na `1`, a `maxClusterRadius` zwiększono do `75` i używa warunku `>=`, co powoduje częstsze łączenie bliskich markerów (zmiany w `index.html`).
- Zmiany są ograniczone do jednego pliku: `index.html`.

### Testing
- Uruchomiono `git diff --check`, który przeszedł pomyślnie.
- Sprawdzono stan repo z `git status --short`, który wykazał zmodyfikowany tylko plik `index.html`.
- Zmiany zostały zatwierdzone (`git commit`) bez błędów; brak automatycznych testów interfejsu do uruchomienia w tym środowisku.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e9e43238833089612c5692f0dfd2)