### PR TITLE
Fix popup closing after edge marker auto-pan

### DIFF
--- a/index.html
+++ b/index.html
@@ -2611,11 +2611,13 @@ function slugify(str) {
         if (marker.options?.zIndexOffset) {
           clone.setZIndexOffset(marker.options.zIndexOffset);
         }
-        const popup = marker.getPopup();
-        if (popup) {
-          clone.bindPopup(popup.getContent(), popup.options || {});
-        }
-        clone.on('click', () => marker.fire('click'));
+        // Popup should always belong to the original marker.
+        // If clone has its own popup, it gets destroyed on cluster refresh
+        // after auto-pan/moveend and closes unexpectedly.
+        clone.on('click', () => {
+          marker.fire('click');
+          marker.openPopup();
+        });
         return clone;
       }
 


### PR DESCRIPTION
### Motivation
- Clicking a pin near the map edge triggered an auto-pan which rebuilt small-cluster clone markers and closed popups unexpectedly. 
- The change ensures popup lifecycle is owned by the original marker so popups remain open when the view is auto-panned and clone layers are refreshed.

### Description
- Stopped binding popup content to clone markers inside `buildSingleMarkerClone` so clones are ephemeral and do not own popup DOM. 
- Changed clone click handler to delegate the event to the original marker via `marker.fire('click')` and explicitly call `marker.openPopup()`. 
- Added comments explaining why popup ownership must stay on the original marker to avoid closure on cluster/overlay refresh.

### Testing
- Located and inspected relevant code paths with `rg` and `sed` to verify the `popup` / `autoPan` / `buildSingleMarkerClone` interactions succeeded. 
- Verified the code diff with `git -C /workspace/ExploMapa diff -- index.html`, which showed the intended changes and completed successfully. 
- Committed the change with `git -C /workspace/ExploMapa commit -m "Fix popup closing after edge marker auto-pan"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2e7d5b808330b35f2b6a6c7bbcc6)