### PR TITLE
Poprawa filtrów kategorii i odświeżania pinezek na mapie

### DIFF
--- a/index.html
+++ b/index.html
@@ -1528,7 +1528,6 @@ img.emoji {
     }
 
     #status-lista > div,
-    #kategorie-lista > div,
     #kraje-lista > div,
     .filter-check-row {
       display: flex;
@@ -1562,6 +1561,43 @@ img.emoji {
       transform: translateY(0);
       vertical-align: middle;
       flex-shrink: 0;
+    }
+
+    #mainCategoryFilters {
+      margin-top: 0;
+    }
+
+    #mainCategoryFilters .main-category-options {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 6px;
+    }
+
+    #mainCategoryFilters .main-category-options label {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      min-width: 0;
+      white-space: nowrap;
+      font-size: 12px;
+    }
+
+    #kategorie-lista .main-category-section {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 2px;
+      margin-bottom: 6px;
+    }
+
+    #kategorie-lista .main-category-section > div {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-height: 22px;
+      line-height: 1.15;
+      margin: 0;
+      padding: 1px 0;
     }
 
     #geosearch-suggestions,
@@ -1717,16 +1753,18 @@ img.emoji {
         <option value="nameAsc">Sortuj alfabetycznie A→Z</option>
         <option value="nameDesc">Sortuj alfabetycznie Z→A</option>
       </select>
-      <div id="mainCategoryFilters" class="main-category-filters">
-        <div class="main-category-title">Kategoria główna</div>
-        <label><input type="checkbox" id="maincat-urbex" checked> URBEX</label>
-        <label><input type="checkbox" id="maincat-turystyczne" checked> TURYSTYCZNE</label>
-      </div>
       <div id="desktopFiltersDropdown" class="open-mobile">
         <button id="desktopFiltersToggle" type="button" aria-expanded="false" aria-controls="desktopFiltersContent">
           Filtry szczegółowe <span class="desktop-filter-indicator">▼</span>
         </button>
         <div id="desktopFiltersContent">
+          <div id="mainCategoryFilters" class="main-category-filters">
+            <div class="main-category-title">Kategoria główna</div>
+            <div class="main-category-options">
+              <label><input type="checkbox" id="maincat-urbex" checked> URBEX</label>
+              <label><input type="checkbox" id="maincat-turystyczne" checked> TURYSTYCZNE</label>
+            </div>
+          </div>
           <details id="filterKategorie">
             <summary>Filtruj kategorie</summary>
             <div id="kategorie-lista"></div>
@@ -8228,6 +8266,7 @@ function showRoutePopup(pinId, tr, latlng) {
 
     function updateMarkerVisibility() {
       const paddedBounds = map ? map.getBounds().pad(0.15) : null;
+      const changedLayers = new Set();
       Object.values(warstwy).forEach(w => {
         w.lista.forEach(p => {
           if (!p.marker) return;
@@ -8236,14 +8275,24 @@ function showRoutePopup(pinId, tr, latlng) {
           if (visible) {
             if (!w.layer.hasLayer(p.marker)) {
               w.layer.addLayer(p.marker);
+              changedLayers.add(w.layer);
             }
           } else {
             if (w.layer.hasLayer(p.marker)) {
               w.layer.removeLayer(p.marker);
+              changedLayers.add(w.layer);
             }
           }
           updatePlanVisibilityForPin(p);
         });
+      });
+      changedLayers.forEach(layer => {
+        if (layer && typeof layer.refreshClusters === 'function') {
+          layer.refreshClusters();
+        }
+        if (layer && typeof layer.fire === 'function') {
+          layer.fire('animationend');
+        }
       });
     }
 


### PR DESCRIPTION
### Motivation
- Przeniesienie wyboru kategorii głównej do kontenera „Filtry szczegółowe” aby wszystkie opcje filtrów były logicznie pogrupowane i mieściły się w panelu.
- Ułożenie checkboxów głównych kategorii obok siebie żeby nie zajmowały dodatkowego wiersza w wąskim kontenerze.
- Naprawa wyświetlania kategorii szczegółowych (zwłaszcza urbexowych), które wcześniej renderowały się poziomo i wychodziły poza panel.
- Usunięcie sytuacji, w której po zmianie kategorii głównej na mapie pozostawały niepoprawne/nieodświeżone pinezki aż do zmiany zoomu.

### Description
- Przeniesiono blok HTML wyboru kategorii głównej (`#mainCategoryFilters`) do sekcji `#desktopFiltersContent` i opakowano checkboxy w kontener `.main-category-options` (plik: `index.html`).
- Dodano CSS dla `#mainCategoryFilters .main-category-options` aby ustawić siatkę dwukolumnową i zmniejszyć odstępy, oraz dostosowano styl `#kategorie-lista .main-category-section` do układu pionowego, żeby kategorie szczegółowe były renderowane w kolumnie (plik: `index.html`).
- W `updateMarkerVisibility()` dodano kolekcję zmienionych warstw (`changedLayers`) i po modyfikacji widoczności markerów wywoływane jest `layer.refreshClusters()` jeśli dostępne oraz `layer.fire('animationend')` aby wymusić odświeżenie klastrów/nakładek, dzięki czemu mapa natychmiast pokazuje poprawne pinezki (plik: `index.html`).
- Zakres zmian: pojedynczy plik `index.html` (HTML + CSS + drobna logika JS w `updateMarkerVisibility`).

### Testing
- Uruchomiono wyszukiwanie w repozytorium poleceniem `rg -n "id=\"mainCategoryFilters\"|function updateMarkerVisibility" index.html` aby potwierdzić obecność nowych fragmentów i test zakończył się pomyślnie.
- Sprawdzono różnicę zmian przez `git diff` i dokonano zatwierdzenia zmian poleceniem `git commit`, które zakończyło się sukcesem.
- Przejrzano plik `index.html` aby upewnić się, że CSS i nowy kod JS zostały dodane w oczekiwych miejscach (automatyczne wyszukiwania powiodły się).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb41efedd483308b05a4ea10f48489)