### PR TITLE
Offset geosearch suggestions to avoid overlapping tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -1013,6 +1013,9 @@ body.mobile-layout #geosearch-container {
   z-index: 200;
   display: flex !important;
 }
+body.mobile-layout #geosearch-suggestions {
+  left: 52px;
+}
 body.mobile-layout #gpsFollowBtn {
   position: fixed;
   bottom: 20px;
@@ -1066,6 +1069,9 @@ body.mobile-layout #toggleBasemaps {
     top: calc(env(safe-area-inset-top, 0px) + 52px);
     z-index: 200;
     display: flex !important;
+  }
+  #geosearch-suggestions {
+    left: 52px;
   }
   #gpsFollowBtn {
     position: fixed;


### PR DESCRIPTION
### Motivation
- Prevent the `#geosearch-suggestions` dropdown from being covered by the tools panel (`#narzedzia`) on narrow/mobile layouts so suggestions appear to the right of the tools.

### Description
- Added mobile-specific CSS in `index.html` to set `left: 52px` for `#geosearch-suggestions` under both `body.mobile-layout` and the `@media (max-width: 700px)` rule.

### Testing
- Verified the new CSS selectors are present in `index.html` using `rg`/file inspection and confirmed the rules were written as expected (succeeded).
- No automated test suite was run because this is a styling-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb521cd0148330ab640bdd5f19553a)