### PR TITLE
Fix geosearch suggestions horizontal position on desktop and mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -548,7 +548,7 @@ width: 15px;
     #geosearch-suggestions {
       position: absolute;
       top: 100%;
-      left: 0;
+      left: 52px;
       right: 42px;
       background: #2b2b2be0;
       border: 1px solid #444;
@@ -1013,6 +1013,9 @@ body.mobile-layout #geosearch-container {
   z-index: 200;
   display: flex !important;
 }
+body.mobile-layout #geosearch-suggestions {
+  left: 52px;
+}
 body.mobile-layout #gpsFollowBtn {
   position: fixed;
   bottom: 20px;
@@ -1066,6 +1069,9 @@ body.mobile-layout #toggleBasemaps {
     top: calc(env(safe-area-inset-top, 0px) + 52px);
     z-index: 200;
     display: flex !important;
+  }
+  #geosearch-suggestions {
+    left: 52px;
   }
   #gpsFollowBtn {
     position: fixed;


### PR DESCRIPTION
### Motivation
- The geosearch suggestions dropdown was positioned at `left: 0`, causing alignment issues with the search input; this change aligns the suggestions with the input across desktop and mobile layouts.

### Description
- Updated `#geosearch-suggestions` to `left: 52px` in the main stylesheet and added the same rule inside `body.mobile-layout` and the `@media (max-width: 700px)` block to ensure consistent horizontal positioning across layouts.

### Testing
- Ran `npm run lint` and `npm test` to validate styling and unit checks, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb521cd0148330ab640bdd5f19553a)