### PR TITLE
Ensure popups open for marker clones from small clusters using `zoomToShowLayer`

### DIFF
--- a/index.html
+++ b/index.html
@@ -2712,6 +2712,13 @@ function slugify(str) {
         // If clone has its own popup, it gets destroyed on cluster refresh
         // after auto-pan/moveend and closes unexpectedly.
         clone.on('click', () => {
+          if (clusterLayer && typeof clusterLayer.zoomToShowLayer === 'function') {
+            clusterLayer.zoomToShowLayer(marker, () => {
+              marker.fire('click');
+              marker.openPopup();
+            });
+            return;
+          }
           marker.fire('click');
           marker.openPopup();
         });


### PR DESCRIPTION
### Motivation
- Some pins rendered as clones of cluster children (visually appearing as standalone pins) did not open their popups unless the map was zoomed in enough because the original marker was still managed/hidden by the cluster layer. 
- The goal is to make popup opening reliable for those pseudo-single markers by ensuring the cluster reveals the original marker first.

### Description
- Added a check in `buildSingleMarkerClone` so the clone's click handler calls `clusterLayer.zoomToShowLayer(marker, callback)` when available to reveal the original marker before firing click and opening the popup in `index.html`.
- Kept the existing fallback path that directly fires `marker.fire('click')` and `marker.openPopup()` when the clustering helper is not present.

### Testing
- No automated test suite is configured for this repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6a5dfb3c83308b41222943fee6ab)