### PR TITLE
Wyłącz animacje klastrów podczas przybliżania mapy

### DIFF
--- a/index.html
+++ b/index.html
@@ -2762,6 +2762,8 @@ function slugify(str) {
       clusterLayer = L.markerClusterGroup({
         disableClusteringAtZoom: CLUSTER_DISABLE_AT_ZOOM,
         maxClusterRadius: () => 75,
+        animate: false,
+        animateAddingMarkers: false,
         spiderfyOnMaxZoom: true,
         showCoverageOnHover: false,
         iconCreateFunction: cluster => {


### PR DESCRIPTION
### Motivation
- Użytkownik zgłosił lagi podczas przybliżania mapy związane z animacjami klastrów.

### Description
- Dodano `animate: false` oraz `animateAddingMarkers: false` do konfiguracji `L.markerClusterGroup` w `index.html`, aby wyłączyć animacje klastrów podczas zoomu.

### Testing
- Uruchomiono `git diff -- index.html`, `git status --short` oraz wykonano commit; wszystkie polecenia zakończyły się powodzeniem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f098c535dc8330b115daf20ee0575f)