### PR TITLE
Ujednolicenie wysokości przycisków popup i zmniejszenie odstępu w wierszu edycji

### DIFF
--- a/index.html
+++ b/index.html
@@ -676,27 +676,36 @@ body, #sidebar, #basemap-switcher {
 .popup-edit-btn {
   position: static;
   margin-left: auto;
+  min-height: 24px;
+  padding: 2px 8px;
+  line-height: 1.2;
 }
 .popup-edit-row {
   display: flex;
   justify-content: flex-end;
-  margin-top: 6px;
+  align-items: center;
+  margin-top: 0;
+  margin-bottom: 2px;
 }
 .popup-route-actions {
   display: flex;
   gap: 6px;
-  margin-top: 5px;
+  margin-top: 0;
 }
 
 .popup-route-btn,
 .popup-direct-route-btn {
   flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: #2b2b2b;
   border: 1px solid #444;
   border-radius: 4px;
   color: #f0f0f0;
   cursor: pointer;
   font-size: 12px;
+  min-height: 28px;
   padding: 4px 6px;
 }
 


### PR DESCRIPTION
### Motivation
- Zmniejszyć nadmierne pionowe odstępy w popupie i dopasować wysokości elementów akcji, aby interfejs wyglądał spójniej.
- Sprawić, by przycisk edycji był wyrównany pionowo z elementami `.popup-info-item` i podciągnąć zawartość poniżej.
- Ujednolicić tła przycisków tras, aby `popup-route-btn popup-route-add-btn` i `popup-direct-route-btn popup-route-direct-btn` miały tę samą wizualną wysokość.

### Description
- Dodano `min-height: 24px`, `padding: 2px 8px` i `line-height: 1.2` do `.popup-edit-btn` aby zmniejszyć jego wysokość i zwęzić wygląd.
- Zmieniono `.popup-edit-row` na `align-items: center`, `margin-top: 0` i `margin-bottom: 2px` aby zredukować odstęp i wyrównać pionowo zawartość.
- Ustawiono `margin-top: 0` dla `.popup-route-actions` aby usunąć dodatkową pionową przerwę nad przyciskami tras.
- Dla `.popup-route-btn` i `.popup-direct-route-btn` dodano `display: flex`, `align-items: center`, `justify-content: center` oraz `min-height: 28px` aby tła przycisków miały jednakową wysokość i tekst był wycentrowany.

### Testing
- Nie uruchamiano testów runtime, ponieważ zmiana dotyczy tylko CSS/markup; sprawdzono zmiany przez różnicę pliku za pomocą `git -C /workspace/ExploMapa diff -- index.html` i inspekcję pliku.
- Wykonano `git -C /workspace/ExploMapa add index.html && git -C /workspace/ExploMapa commit -m "Adjust popup button alignment and spacing"` i commit zakończył się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a251f21c833088ed4eb06c95dc26)