### PR TITLE
Popup: zawsze poniżej paska wyszukiwania i skalowanie na małych widokach

### DIFF
--- a/index.html
+++ b/index.html
@@ -4759,22 +4759,42 @@ function emojiHtml(str) {
         if (!popupEl || !mapEl) return;
 
         const mapRect = mapEl.getBoundingClientRect();
-        const popupRect = popupEl.getBoundingClientRect();
+        const geosearchEl = document.getElementById('geosearch-container');
         const padding = popupAutoPanState.padding;
+        const searchRect = geosearchEl ? geosearchEl.getBoundingClientRect() : null;
+        const geosearchVisible = !!(searchRect && searchRect.width > 0 && searchRect.height > 0);
+        const minTop = geosearchVisible
+          ? Math.max(mapRect.top + padding.top, searchRect.bottom + 8)
+          : mapRect.top + padding.top;
+        const maxRight = mapRect.right - padding.right;
+        const maxBottom = mapRect.bottom - padding.bottom;
+        const maxLeft = mapRect.left + padding.left;
+        const maxWidth = Math.max(1, maxRight - maxLeft);
+        const maxHeight = Math.max(1, maxBottom - minTop);
+
+        popupEl.style.zoom = '';
+        let popupRect = popupEl.getBoundingClientRect();
+        const widthScale = maxWidth / Math.max(1, popupRect.width);
+        const heightScale = maxHeight / Math.max(1, popupRect.height);
+        const popupScale = Math.max(0.55, Math.min(1, widthScale, heightScale));
+        if (popupScale < 1) {
+          popupEl.style.zoom = String(popupScale);
+          popupRect = popupEl.getBoundingClientRect();
+        }
 
         let dx = 0;
         let dy = 0;
 
-        if (popupRect.left < mapRect.left + padding.left) {
-          dx = popupRect.left - (mapRect.left + padding.left);
-        } else if (popupRect.right > mapRect.right - padding.right) {
-          dx = popupRect.right - (mapRect.right - padding.right);
+        if (popupRect.left < maxLeft) {
+          dx = popupRect.left - maxLeft;
+        } else if (popupRect.right > maxRight) {
+          dx = popupRect.right - maxRight;
         }
 
-        if (popupRect.top < mapRect.top + padding.top) {
-          dy = popupRect.top - (mapRect.top + padding.top);
-        } else if (popupRect.bottom > mapRect.bottom - padding.bottom) {
-          dy = popupRect.bottom - (mapRect.bottom - padding.bottom);
+        if (popupRect.top < minTop) {
+          dy = popupRect.top - minTop;
+        } else if (popupRect.bottom > maxBottom) {
+          dy = popupRect.bottom - maxBottom;
         }
 
         popup._autoPanHandledToken = token;
@@ -4811,6 +4831,12 @@ function emojiHtml(str) {
         const token = ++popupAutoPanState.openSeq;
         e.popup._autoPanHandledToken = 0;
         schedulePopupAutopan(e.popup, token);
+      });
+      map.on('resize', () => {
+        if (!map || !map._popup || !map._popup.isOpen()) return;
+        const token = ++popupAutoPanState.openSeq;
+        map._popup._autoPanHandledToken = 0;
+        schedulePopupAutopan(map._popup, token);
       });
       map.on('zoomend', () => {
         if (!highlightedMarker || !pinHighlightCircle) return;


### PR DESCRIPTION
### Motivation
- Popup pinezki czasami nachodził na pasek wyszukiwania lub wychodził poza obszar widoczny przy małych rozdzielczościach, co utrudnia interakcję i odczyt treści.

### Description
- Zmieniono `panMapAfterPopupOpen` tak, żeby górna krawędź popupu była liczona względem dolnej krawędzi `#geosearch-container`, dzięki czemu popup zawsze pojawia się poniżej paska wyszukiwania.
- Obliczany jest teraz dostępny obszar dla popupu (z uwzględnieniem paddingu mapy i paska wyszukiwania) oraz dostosowywana jest skala popupu przez ustawienie `popupEl.style.zoom` jeśli jego rozmiar przekracza dostępny obszar.
- Dostosowano obliczenia przesunięcia (`dx`, `dy`) do nowych granic widoku, tak aby następować poprawne przewinięcie mapy po otwarciu popupu.
- Dodano obsługę zdarzenia `map.on('resize')`, które ponownie przelicza pozycję i skalę aktualnie otwartego popupu po zmianie rozmiaru okna.

### Testing
- Wykonano wyszukiwanie w źródłach, aby zlokalizować funkcję obsługi popupów i potwierdzić modyfikowane miejsca, i operacja zakończyła się pomyślnie.
- Zastosowano patch na `index.html` i potwierdzono, że plik zawiera wprowadzone zmiany (wstawiono i usunięto linie zgodnie z diffem), operacja zakończyła się pomyślnie.
- Wyciągnięto fragmenty pliku z okolic zmienionego kodu w celu automatycznej weryfikacji, które również zakończyły się pomyślnie.
- Sprawdzono, że po stronie aplikacji mechanizm planowania autopanów używa zaktualizowanych obliczeń (poprawne wywołania w zmodyfikowanym fragmencie kodu zostały odnalezione), wynik pozytywny.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a401ab50833083d1f30dfe210436)