### PR TITLE
Fix pins saved to newly created layer instead of "Inne"

### DIFF
--- a/index.html
+++ b/index.html
@@ -8676,6 +8676,14 @@ toggleBtn.style.verticalAlign = "top";
           btn.textContent = `Zapisywanie… (${doneAll}/${totalAll})`;
         };
 
+        const orderList = loadLayerOrder();
+        const pendingLayerNames = [...new Set(
+          nowePinezki
+            .map(p => (p.warstwa || '').trim())
+            .filter(Boolean)
+        )];
+        await Promise.all(pendingLayerNames.map(name => ensureLayerEntry(name, orderList)));
+
         const updatePromises = Object.entries(zmianyDoZapisania).map(async ([id, data]) => {
           const p = wszystkiePinezki.find(pp => pp.id === id);
           if (!p || !p.firebaseId) return;
@@ -8752,7 +8760,6 @@ toggleBtn.style.verticalAlign = "top";
           return Promise.resolve();
         });
 
-        const orderList = loadLayerOrder();
         const layerUpdates = Object.keys(warstwy).map(name => {
           const order = orderList.indexOf(name);
           const docId = layerDocs[name];


### PR DESCRIPTION
### Motivation
- There was a bug where creating a new layer while adding a pin would create the layer record but the pin payload could be saved before the layer document existed, causing `warstwa`/`warstwaId` to be `null` and the pin to appear under "Inne". 
- The change ensures layer documents exist in Firestore before assembling and writing pin payloads so `resolveLayerInfo(...)` can return the correct `warstwaId`.

### Description
- Before building add/update payloads the code now collects pending layer names from `nowePinezki` and awaits `ensureLayerEntry(name, orderList)` for each to pre-create missing layer documents. 
- The `orderList` is loaded once into a local `orderList` variable and reused for the pre-creation step and later `layerUpdates` to keep ordering consistent. 
- Changes are confined to `zapiszZmiany()` in `index.html` around the block that assembles `updatePromises`/`addPromises` so new layers exist prior to pin writes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae35e5ebc83309efd460cc73ba592)