### PR TITLE
Przycisk rozwijania warstwy: tekstowe symbole stanu ▶/▼

### DIFF
--- a/index.html
+++ b/index.html
@@ -8580,9 +8580,13 @@ function showRoutePopup(pinId, tr, latlng) {
         const toggleBtn = document.createElement("button");
         toggleBtn.type = "button";
         toggleBtn.className = "layer-control-btn toggle-btn";
-        toggleBtn.innerHTML = '<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 6l5 5 5-5"/></svg>';
         toggleBtn.setAttribute('aria-label', 'Rozwiń / zwiń warstwę');
-        if (warstwy[nazwa].collapsed) toggleBtn.classList.add('is-collapsed');
+        const updateLayerToggleSymbol = () => {
+          const isCollapsed = !!warstwy[nazwa].collapsed;
+          toggleBtn.textContent = isCollapsed ? "▶" : "▼";
+          toggleBtn.classList.toggle('is-collapsed', isCollapsed);
+        };
+        updateLayerToggleSymbol();
         const controls = document.createElement("span");
         if (!warstwy[nazwa].temporary) {
           const editBtn = document.createElement("button");
@@ -8746,7 +8750,7 @@ function showRoutePopup(pinId, tr, latlng) {
           }
           warstwy[nazwa].collapsed = !warstwy[nazwa].collapsed;
           listaP.classList.toggle("ukryta");
-          toggleBtn.classList.toggle('is-collapsed', listaP.classList.contains("ukryta"));
+          updateLayerToggleSymbol();
           setLayerCollapseState(nazwa, warstwy[nazwa].collapsed);
         };
         toggleBtn.addEventListener('pointerup', toggleLayerCollapse);


### PR DESCRIPTION
### Motivation
- Przyciski rozwijania warstw powinny wizualnie odzwierciedlać aktualny stan (zwinięta/rozwinięta) i używać prostych symboli tekstowych zamiast SVG.

### Description
- W `index.html` dodano funkcję pomocniczą `updateLayerToggleSymbol()` która ustawia `toggleBtn.textContent` na `▶` gdy warstwa jest zwinięta i na `▼` gdy rozwinięta oraz synchronizuje klasę `is-collapsed`; zastąpiono wcześniejsze `innerHTML` z SVG i wywołano tę funkcję przy renderze listy warstw oraz po zmianie stanu w `toggleLayerCollapse`.

### Testing
- Nie uruchomiono zautomatyzowanych testów dla tej zmiany.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbd1b36f4c833092441e37da1bf905)