### PR TITLE
Dodaj wybór kategorii głównej dla całej warstwy w panelu edycji

### DIFF
--- a/index.html
+++ b/index.html
@@ -2006,6 +2006,12 @@ img.emoji {
     <input type="text" id="layerEditName" placeholder="Nazwa warstwy"><br>
     <input type="number" id="layerEditOrder" min="1" style="width:70px;"> <button id="layerEditSave" onclick="applyLayerEdits()">Zastosuj</button><br>
     <input id="layerEditEmoji" placeholder="Emoji warstwy" style="width:100%"><br>
+    <label for="layerEditMainCategory">Kategoria główna wszystkich pinezek w warstwie</label><br>
+    <select id="layerEditMainCategory" style="width:100%">
+      <option value="">— Bez zmian —</option>
+      <option value="URBEX">URBEX</option>
+      <option value="TURYSTYCZNE">TURYSTYCZNE</option>
+    </select><br>
     <div id="layerEditDefaultVisibility">
       <div>Domyślna widoczność:</div>
       <label><input type="radio" name="layerDefaultVisibility" id="layerDefaultVisible" value="visible"> Domyślnie pokazana</label><br>
@@ -7013,6 +7019,8 @@ function zaladujPinezkiZFirestore() {
       const idx = order.indexOf(name);
       document.getElementById('layerEditOrder').value = idx >= 0 ? idx + 1 : (order.length + 1);
       document.getElementById('layerEditEmoji').value = warstwy[name].emoji || '';
+      const mainCategoryInput = document.getElementById('layerEditMainCategory');
+      if (mainCategoryInput) mainCategoryInput.value = '';
       const defaultVisible = getLayerDefaultVisible(name);
       const defaultVisibleInput = document.getElementById('layerDefaultVisible');
       const defaultHiddenInput = document.getElementById('layerDefaultHidden');
@@ -7038,6 +7046,7 @@ function zaladujPinezkiZFirestore() {
       const newName = document.getElementById('layerEditName').value.trim();
       const newOrder = parseInt(document.getElementById('layerEditOrder').value, 10);
       const newEmoji = document.getElementById('layerEditEmoji').value.trim();
+      const newMainCategory = (document.getElementById('layerEditMainCategory')?.value || '').trim();
       const defaultVisibleInput = document.getElementById('layerDefaultVisible');
       const defaultHiddenInput = document.getElementById('layerDefaultHidden');
       if (!defaultVisibleInput || !defaultHiddenInput || (!defaultVisibleInput.checked && !defaultHiddenInput.checked)) {
@@ -7059,6 +7068,22 @@ function zaladujPinezkiZFirestore() {
         warstwy[editedLayer].defaultVisible = newDefaultVisible;
         layerDefaultVisibilityChanges[editedLayer] = newDefaultVisible;
       }
+      const layerPins = warstwy[editedLayer] && Array.isArray(warstwy[editedLayer].lista) ? warstwy[editedLayer].lista : [];
+      const previousMainCategories = {};
+      let changedMainCategoryCount = 0;
+      if (MAIN_CATEGORY_OPTIONS.includes(newMainCategory)) {
+        layerPins.forEach(pin => {
+          previousMainCategories[pin.id] = getPinMainCategory(pin);
+          if (previousMainCategories[pin.id] !== newMainCategory) {
+            pin.kategoriaGlowna = newMainCategory;
+            const pending = zmianyDoZapisania[pin.id] || {};
+            pending.kategoriaGlowna = newMainCategory;
+            zmianyDoZapisania[pin.id] = pending;
+            pin.unsaved = true;
+            changedMainCategoryCount += 1;
+          }
+        });
+      }
       generujListeWarstw();
       updateSaveButton();
       closeLayerEditor();
@@ -7077,6 +7102,15 @@ function zaladujPinezkiZFirestore() {
             updateMarkersForLayer(oldState.name);
           }
           warstwy[oldState.name].defaultVisible = oldState.defaultVisible;
+          Object.entries(previousMainCategories).forEach(([pinId, prevMainCategory]) => {
+            const pin = wszystkiePinezki.find(pp => pp.id === pinId);
+            if (!pin || !MAIN_CATEGORY_OPTIONS.includes(prevMainCategory)) return;
+            pin.kategoriaGlowna = prevMainCategory;
+            const data = zmianyDoZapisania[pin.id] || {};
+            data.kategoriaGlowna = prevMainCategory;
+            zmianyDoZapisania[pin.id] = data;
+            pin.unsaved = true;
+          });
           generujListeWarstw();
           updateSaveButton();
         },
@@ -7088,10 +7122,24 @@ function zaladujPinezkiZFirestore() {
             updateMarkersForLayer(newState.name);
           }
           warstwy[newState.name].defaultVisible = newState.defaultVisible;
+          if (MAIN_CATEGORY_OPTIONS.includes(newMainCategory)) {
+            const layer = warstwy[newState.name];
+            const pins = layer && Array.isArray(layer.lista) ? layer.lista : [];
+            pins.forEach(pin => {
+              pin.kategoriaGlowna = newMainCategory;
+              const data = zmianyDoZapisania[pin.id] || {};
+              data.kategoriaGlowna = newMainCategory;
+              zmianyDoZapisania[pin.id] = data;
+              pin.unsaved = true;
+            });
+          }
           generujListeWarstw();
           updateSaveButton();
         }
       }, 'Edytowano warstwę ' + newState.name);
+      if (changedMainCategoryCount > 0) {
+        showToast(`Ustawiono kategorię główną ${newMainCategory} dla ${changedMainCategoryCount} pinezek.`);
+      }
     }
 
     function applyRenameLayer(oldName, newName) {


### PR DESCRIPTION
### Motivation
- Umożliwić szybką, masową zmianę `kategoriaGlowna` dla wszystkich pinezek należących do danej warstwy bez ręcznej edycji każdej pinezki.
- Zintegrować tę operację z istniejącym edytorem warstw i mechanizmem undo/redo, aby zachować spójność stanu aplikacji.

### Description
- Dodano pole wyboru `Kategoria główna wszystkich pinezek w warstwie` (`<select id="layerEditMainCategory">`) do panelu `Edycja warstwy` z opcjami `— Bez zmian —`, `URBEX` i `TURYSTYCZNE`.
- Przy otwieraniu edytora warstwy pole jest resetowane do `''` żeby domyślnie nie nadpisywać kategorii; to ustawienie wykonuje `showLayerEditor`.
- W `applyLayerEdits()` odczytywana jest wybrana wartość `newMainCategory` i gdy należy do `MAIN_CATEGORY_OPTIONS` wszystkie pinezki z `warstwy[editedLayer].lista` otrzymują `pin.kategoriaGlowna = newMainCategory`, zmiany są zapisywane do `zmianyDoZapisania`, pinezki oznaczane są jako `unsaved`, oraz zliczana jest liczba zmienionych pinezek.
- Rozszerzono `pushAction` (undo/redo) dla edycji warstwy tak, aby przy cofaniu/ponawianiu przywracać i ponownie ustawiać poprzednie/nowe wartości `kategoriaGlowna` dla pinezek, a po operacji wyświetlany jest `showToast` z liczbą zmienionych pinezek.

### Testing
- Zmiany zostały zastosowane patchem i zapisane w repozytorium co potwierdzono poleceniem `git -C /workspace/ExploMapa status --short` (sukces).
- Plik `index.html` został dodany i zatwierdzony przy pomocy `git -C /workspace/ExploMapa add index.html && git -C /workspace/ExploMapa commit -m "Dodaj masową zmianę kategorii głównej w edycji warstwy"` (sukces).
- Wyświetlono fragmenty pliku w celu weryfikacji lokalizacji wstawień przy pomocy `nl -ba /workspace/ExploMapa/index.html | sed -n '2000,2035p;7004,7148p'` (sukces).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbd35370248330ba422a85ec212ac2)