### PR TITLE
Fix tworzenia tripa i widoczności panelu planera

### DIFF
--- a/index.html
+++ b/index.html
@@ -758,6 +758,19 @@ body, #sidebar, #basemap-switcher {
 .trip-color-input { width:32px; height:24px; padding:0; border:0; background:none; }
 .trip-active-day { box-shadow:0 0 0 1px var(--ui-accent) inset; }
 .trip-muted-day { opacity:.7; }
+body.trip-planner-mode #sidebarTopControls,
+body.trip-planner-mode #pinTotalCounter,
+body.trip-planner-mode #lista-warstw,
+body.trip-planner-mode #emojiToolBtn,
+body.trip-planner-mode #syncBtn {
+  display: none !important;
+}
+body.trip-planner-mode .trip-planner-panel {
+  display: block !important;
+}
+body:not(.trip-planner-mode) .trip-planner-panel {
+  display: none !important;
+}
 
 .popup-route-btn,
 .popup-direct-route-btn {
@@ -7886,8 +7899,9 @@ function showRoutePopup(pinId, tr, latlng) {
     function formatTripDistance(meters) { return `${Math.round((meters || 0) / 1000)} km`; }
     function getActiveTrip() { return tripPlannerTrips.find(t => t.id === activeTripId) || null; }
     async function loadTrips() {
+      if (!db) { console.warn('Trip planner: brak db w loadTrips().'); return; }
       const user = auth.currentUser;
-      if (!user) return;
+      if (!user) { console.warn('Trip planner: brak user/auth w loadTrips().'); return; }
       const snap = await db.collection('trips').where('ownerEmail', '==', user.email).get();
       tripPlannerTrips = [];
       for (const doc of snap.docs) {
@@ -7906,6 +7920,7 @@ function showRoutePopup(pinId, tr, latlng) {
       renderTripMapLayers();
     }
     async function saveTrip(tripId) {
+      if (!db) { console.warn('Trip planner: brak db w saveTrip().'); return; }
       const trip = tripPlannerTrips.find(t => t.id === tripId); if (!trip) return;
       await db.collection('trips').doc(tripId).set({ name: trip.name, description: trip.description || '', startDate: trip.startDate || '', endDate: trip.endDate || '', ownerEmail: trip.ownerEmail, createdAt: trip.createdAt || firebase.firestore.FieldValue.serverTimestamp(), updatedAt: firebase.firestore.FieldValue.serverTimestamp() }, { merge: true });
       for (const [di, day] of (trip.days || []).entries()) {
@@ -10226,8 +10241,7 @@ function confirmLayerDelete() {
       tripPlannerMode = mode;
       document.getElementById('modePinsBtn')?.classList.toggle('active', mode === 'pins');
       document.getElementById('modeTripBtn')?.classList.toggle('active', mode === 'trip');
-      document.getElementById('sidebarTopControls').style.display = mode === 'pins' ? '' : 'none';
-      document.getElementById('tripPlannerPanel').style.display = mode === 'trip' ? '' : 'none';
+      document.body.classList.toggle('trip-planner-mode', mode === 'trip');
       document.getElementById('toggleLayers').textContent = mode === 'trip' ? '☰ Plan tripu' : '☰ Warstwy';
       renderTripMapLayers();
     }
@@ -10235,11 +10249,25 @@ function confirmLayerDelete() {
     document.getElementById('modeTripBtn')?.addEventListener('click', () => setTripMode('trip'));
     document.getElementById('tripSelect')?.addEventListener('change', e => { activeTripId = e.target.value || null; renderTripPlannerPanel(); renderTripMapLayers(); });
     document.getElementById('tripNewBtn')?.addEventListener('click', async () => {
-      const user = auth.currentUser; if (!user) return alert('Zaloguj się.');
-      const name = prompt('Nazwa tripa:', 'Nowy trip'); if (!name) return;
-      const id = db.collection('trips').doc().id;
-      tripPlannerTrips.push({ id, name, ownerEmail: user.email, days: [] }); activeTripId = id;
-      await saveTrip(id); renderTripPlannerPanel();
+      if (!db) { console.error('Trip planner: brak db przy tworzeniu tripa.'); return; }
+      const user = auth.currentUser;
+      if (!user) { console.error('Trip planner: brak user/auth przy tworzeniu tripa.'); return alert('Zaloguj się.'); }
+      const rawName = prompt('Nazwa tripa:', 'Nowy trip');
+      const name = (rawName || '').trim();
+      if (!name) { console.warn('Trip planner: pusta nazwa tripa.'); return; }
+      try {
+        const id = db.collection('trips').doc().id;
+        tripPlannerTrips.push({ id, name, ownerEmail: user.email, days: [] });
+        activeTripId = id;
+        await saveTrip(id);
+        await loadTrips();
+        activeTripId = id;
+        renderTripPlannerPanel();
+        renderTripMapLayers();
+        showToast('Utworzono trip');
+      } catch (err) {
+        console.error('Trip planner: błąd zapisu Firestore przy tworzeniu tripa.', err);
+      }
     });
     document.getElementById('tripActiveBox')?.addEventListener('click', async (e) => {
       const trip = getActiveTrip(); if (!trip) return;


### PR DESCRIPTION
### Motivation
- Naprawa regresji, przez którą kliknięcie `+ Nowy trip` nie tworzyło widocznego/aktywnego tripa i panel planera nie odświeżał się poprawnie.
- W trybie „Plan tripu” trzeba ukryć elementy listy warstw/pinezki, aby lewy sidebar pokazywał tylko panel planera.

### Description
- Dodano CSS `body.trip-planner-mode` i reguły, które ukrywają `#sidebarTopControls`, `#pinTotalCounter`, `#lista-warstw`, `#emojiToolBtn`, `#syncBtn` oraz wymuszają wyświetlenie `.trip-planner-panel` w trybie planera i ukrycie go poza trybem.
- Zmieniono `setTripMode` tak, by przełączać klasę na `body` zamiast manipulować wyłącznie pojedynczymi inline `style`ami, dzięki czemu przełącznik pozostaje widoczny i zachowanie sidebaru jest spójne.
- Ulepszono handler `tripNewBtn` tak, by weryfikował `db` i `auth.currentUser`, robił `trim()` nazwy, logował błędy (`console.warn`/`console.error`) przy brakach/niepowodzeniach, tworzył dokument w kolekcji `trips`, ustawiało `activeTripId`, wywoływało `saveTrip(id)` i `loadTrips()` oraz odświeżało panel/mapę i pokazywało toast `Utworzono trip` po sukcesie.
- Dodano defensywne logi w `loadTrips()` i `saveTrip()` przy braku `db` lub `user` oraz obsługę błędu zapisu Firestore w handlerze tworzenia tripa, bez zmiany istniejących struktur kolekcji ani innych funkcji mapy.

### Testing
- Automated tests: none were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a019e4d0d308330886846c4dec19ef5)