### PR TITLE
Fix trip planner Firebase compat integration, auth timing, and marker-cluster guards

### DIFF
--- a/index.html
+++ b/index.html
@@ -2792,6 +2792,7 @@ function slugify(str) {
             totalChildren += count;
             weightedX += centerPoint.x * count;
             weightedY += centerPoint.y * count;
+            if (typeof cluster.getAllChildMarkers !== 'function') return;
             cluster.getAllChildMarkers().forEach(marker => markerSet.add(marker));
           });
 
@@ -2860,6 +2861,7 @@ function slugify(str) {
         for (const cluster of clusters) {
           const count = cluster.getChildCount();
           if (count >= CLUSTER_MIN_MARKERS) continue;
+          if (typeof cluster.getAllChildMarkers !== 'function') continue;
           const childMarkers = cluster.getAllChildMarkers();
           if (childMarkers.length < 2) continue;
 
@@ -7900,9 +7902,9 @@ function showRoutePopup(pinId, tr, latlng) {
     function getActiveTrip() { return tripPlannerTrips.find(t => t.id === activeTripId) || null; }
     async function loadTrips() {
       if (!db) { console.warn('Trip planner: brak db w loadTrips().'); return; }
-      const user = auth.currentUser;
+      const user = firebase.auth().currentUser;
       if (!user) { console.warn('Trip planner: brak user/auth w loadTrips().'); return; }
-      const snap = await db.collection('trips').where('ownerEmail', '==', user.email).get();
+      const snap = await db.collection('trips').where('ownerEmail', '==', user.email.toLowerCase()).get();
       tripPlannerTrips = [];
       for (const doc of snap.docs) {
         const trip = { id: doc.id, ...doc.data(), days: [] };
@@ -8684,7 +8686,7 @@ function showRoutePopup(pinId, tr, latlng) {
         });
       });
       changedLayers.forEach(layer => {
-        if (layer && typeof layer.refreshClusters === 'function') {
+        if (layer && typeof layer.refreshClusters === 'function' && layer._featureGroup && typeof layer._featureGroup.getLayers === 'function') {
           layer.refreshClusters();
         }
         if (layer && typeof layer.fire === 'function') {
@@ -10169,7 +10171,7 @@ function confirmLayerDelete() {
 
   async function runUpdate(){
     await emojiListReady;
-    const user = auth.currentUser;
+    const user = firebase.auth().currentUser;
     if (!els.preview.checked && !user) { log('⚠️ Musisz być zalogowany, aby zapisywać zmiany.'); return; }
 
     abortFlag = false; els.start.disabled = true; els.stop.disabled = false;
@@ -10246,22 +10248,34 @@ function confirmLayerDelete() {
       renderTripMapLayers();
     }
     document.getElementById('modePinsBtn')?.addEventListener('click', () => setTripMode('pins'));
-    document.getElementById('modeTripBtn')?.addEventListener('click', () => setTripMode('trip'));
+    document.getElementById('modeTripBtn')?.addEventListener('click', async () => {
+      setTripMode('trip');
+      const user = firebase.auth().currentUser;
+      if (!user) { showToast('Najpierw zaloguj się'); return; }
+      await loadTrips();
+    });
     document.getElementById('tripSelect')?.addEventListener('change', e => { activeTripId = e.target.value || null; renderTripPlannerPanel(); renderTripMapLayers(); });
     document.getElementById('tripNewBtn')?.addEventListener('click', async () => {
       if (!db) { console.error('Trip planner: brak db przy tworzeniu tripa.'); return; }
-      const user = auth.currentUser;
-      if (!user) { console.error('Trip planner: brak user/auth przy tworzeniu tripa.'); return alert('Zaloguj się.'); }
+      const user = firebase.auth().currentUser;
+      if (!user) { showToast('Najpierw zaloguj się'); return; }
       const rawName = prompt('Nazwa tripa:', 'Nowy trip');
       const name = (rawName || '').trim();
       if (!name) { console.warn('Trip planner: pusta nazwa tripa.'); return; }
       try {
-        const id = db.collection('trips').doc().id;
-        tripPlannerTrips.push({ id, name, ownerEmail: user.email, days: [] });
-        activeTripId = id;
-        await saveTrip(id);
+        const ref = db.collection('trips').doc();
+        await ref.set({
+          name,
+          description: '',
+          startDate: '',
+          endDate: '',
+          ownerEmail: (user.email || '').toLowerCase(),
+          createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+          updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+        });
+        activeTripId = ref.id;
         await loadTrips();
-        activeTripId = id;
+        activeTripId = ref.id;
         renderTripPlannerPanel();
         renderTripMapLayers();
         showToast('Utworzono trip');
@@ -10296,7 +10310,15 @@ function confirmLayerDelete() {
       tripPrivatePointArmed = false;
       await recalculateTripDay(trip.id, day.id);
     });
-    auth.onAuthStateChanged(() => loadTrips().catch(console.error));
+    let tripPlannerUnauthWarned = false;
+    firebase.auth().onAuthStateChanged(async user => {
+      if (!user) {
+        if (!tripPlannerUnauthWarned) { console.warn('Trip planner: użytkownik niezalogowany — pomijam loadTrips().'); tripPlannerUnauthWarned = true; }
+        return;
+      }
+      tripPlannerUnauthWarned = false;
+      if (tripPlannerMode === 'trip') await loadTrips();
+    });
   emojiBtn.addEventListener('click', ()=>{ backdrop.style.display='block'; });
   els.close.addEventListener('click', ()=>{ backdrop.style.display='none'; if(emojiToolChanged) location.reload(); });
   backdrop.addEventListener('click', (e)=>{ if(e.target===backdrop){ backdrop.style.display='none'; if(emojiToolChanged) location.reload(); } });


### PR DESCRIPTION
### Motivation
- Naprawić błędy tworzenia/ładowania tripów wynikające z mieszania modularnego Firestore z Firebase compat oraz z wywoływania `loadTrips()` zanim użytkownik jest zalogowany (błąd `db.collection is not a function` i ostrzeżenia `brak user/auth`).
- Zapobiec awariom mapy spowodowanym wywołaniem `getAllChildMarkers` na nieprawidłowych obiektach klastra (`Cannot read properties of undefined`).
- Zachować istniejący styl projektu (Firebase compat API) i nie nadpisywać globalnego `db` z `firestore-setup.js`.

### Description
- Zmieniono odwołania do aktualnego użytkownika na `firebase.auth().currentUser` tam, gdzie używa tego Trip Planner (np. `loadTrips`, tworzenie tripa, `runUpdate`).
- Zaimplementowano tworzenie tripa zgodnie z Firebase compat: `const ref = db.collection('trips').doc(); await ref.set({...}); activeTripId = ref.id;` oraz zapis `ownerEmail` jako `user.email.toLowerCase()`; usunięto użycie modularnych funkcji w obszarze trip plannera.
- `loadTrips()` teraz sprawdza `if (!db)` i `if (!user)` i przerywa wykonanie bez spamujących warningów; wejście w tryb `Plan tripu` wywołuje `loadTrips()` tylko jeśli `firebase.auth().currentUser` istnieje, a w przeciwnym wypadku pokazuje toast `Najpierw zaloguj się`.
- Zastąpiono globalny listener `auth.onAuthStateChanged` logiką `firebase.auth().onAuthStateChanged` z jednorazowym ostrzeżeniem, aby nie wywoływać `loadTrips()` bez zalogowanego użytkownika i by ładować tripy po zalogowaniu tylko gdy tryb jest `trip`.
- Dodano defensywne guardy w mechanice klastrów: przed użyciem `cluster.getAllChildMarkers()` sprawdzany jest `typeof cluster.getAllChildMarkers === 'function'`, oraz przy wywołaniu `layer.refreshClusters()` sprawdzane są wewnętrzne struktury (`layer._featureGroup` i `getLayers`), aby uniknąć wywołań na niestandardowych/pustych warstwach.

### Testing
- Uruchomiono wyszukiwanie wzorców w zmodyfikowanym pliku: `rg -n "loadTrips\(|tripNewBtn|modeTripBtn|onAuthStateChanged|refreshClusters|getAllChildMarkers" index.html` i potwierdzono obecność oczekiwanych zmian w obszarze Trip Planner (sukces).
- Sprawdzono, że w sekcji Trip Planner nie pozostały modularne wywołania Firestore poprzez `rg -n "getFirestore\(|addDoc\(|getDocs\(|setDoc\(|\bdoc\(" index.html` i potwierdzono brak modularnych funkcji w kodzie trip plannera (sukces).
- Przejrzano lokalny diff (`git diff`) i potwierdzono, że zmiany ograniczają się do obsługi trip plannera i logiki klastrów (sukces).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a796eb188330885c5d7a3b049b79)