### PR TITLE
Add trip-day date UI with autosave and trip range recalculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -7897,6 +7897,52 @@ function showRoutePopup(pinId, tr, latlng) {
       return `${h}h ${m}m`;
     }
     function formatTripDistance(meters) { return `${Math.round((meters || 0) / 1000)} km`; }
+    function formatTripHeaderDate(isoDate) {
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(isoDate || '')) return '';
+      const [year, month, day] = isoDate.split('-');
+      return `${day}.${month}.${year}`;
+    }
+    function recalculateTripDateRange(trip) {
+      if (!trip) return;
+      const dayDates = (trip.days || [])
+        .map(day => (day?.date || '').trim())
+        .filter(value => /^\d{4}-\d{2}-\d{2}$/.test(value))
+        .sort();
+      trip.startDate = dayDates[0] || '';
+      trip.endDate = dayDates[dayDates.length - 1] || '';
+    }
+    function addDaysToIsoDate(isoDate, daysToAdd) {
+      const baseDate = new Date(`${isoDate}T00:00:00Z`);
+      baseDate.setUTCDate(baseDate.getUTCDate() + daysToAdd);
+      const year = baseDate.getUTCFullYear();
+      const month = String(baseDate.getUTCMonth() + 1).padStart(2, '0');
+      const day = String(baseDate.getUTCDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    }
+    function showCreateTripDialog() {
+      return new Promise(resolve => {
+        const overlay = document.createElement('div');
+        overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:20000;';
+        overlay.innerHTML = `<div style="background:#1d2028;border:1px solid #3a3f4a;border-radius:10px;padding:12px;min-width:280px;">
+          <h3 style="margin:0 0 10px 0;">Nowy trip</h3>
+          <label>Nazwa<br><input id="tripCreateName" type="text" style="width:100%"></label><br>
+          <label>Liczba dni<br><input id="tripCreateDays" type="number" min="1" value="3" style="width:100%"></label><br>
+          <label>📅 Start<br><input id="tripCreateStart" type="date" style="width:100%"></label><br>
+          <label>📅 Koniec<br><input id="tripCreateEnd" type="date" style="width:100%"></label><br>
+          <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:10px;"><button id="tripCreateCancel" type="button">Anuluj</button><button id="tripCreateOk" type="button">Utwórz</button></div>
+        </div>`;
+        document.body.appendChild(overlay);
+        overlay.querySelector('#tripCreateCancel')?.addEventListener('click', () => { overlay.remove(); resolve(null); });
+        overlay.querySelector('#tripCreateOk')?.addEventListener('click', () => {
+          const name = (overlay.querySelector('#tripCreateName')?.value || '').trim();
+          const daysCount = parseInt(overlay.querySelector('#tripCreateDays')?.value || '', 10);
+          const startDate = (overlay.querySelector('#tripCreateStart')?.value || '').trim();
+          const endDate = (overlay.querySelector('#tripCreateEnd')?.value || '').trim();
+          overlay.remove();
+          resolve({ name, daysCount, startDate, endDate });
+        });
+      });
+    }
     function getActiveTrip() { return tripPlannerTrips.find(t => t.id === activeTripId) || null; }
 function getTripPointEmoji(p) {
       const emojiVal = p?.emojiSnapshot || p?.emoji || '';
@@ -7966,6 +8012,7 @@ function getTripPointEmoji(p) {
           day.points = pts.docs.map(x => ({ id: x.id, ...x.data() }));
           trip.days.push(day);
         }
+        recalculateTripDateRange(trip);
         tripPlannerTrips.push(trip);
       }
       if (!activeTripId && tripPlannerTrips[0]) activeTripId = tripPlannerTrips[0].id;
@@ -8094,11 +8141,13 @@ function getTripPointEmoji(p) {
       sel.innerHTML = '<option value="">Wybierz trip</option>' + tripPlannerTrips.map(t => `<option value="${t.id}" ${t.id===activeTripId?'selected':''}>${t.name}</option>`).join('');
       const trip = getActiveTrip();
       if (!trip) { box.innerHTML = '<div>Brak aktywnego tripa.</div>'; return; }
-      box.innerHTML = `<div><b>${trip.name}</b></div><button id="tripAddDayBtn" type="button">+ Dodaj dzień</button><button id="tripAddPrivatePointBtn" type="button">+ Punkt tylko do tripa</button>` + trip.days.map((d, idx) => {
+      const tripRange = trip.startDate && trip.endDate ? `<div><small>${formatTripHeaderDate(trip.startDate)} → ${formatTripHeaderDate(trip.endDate)}</small></div>` : '';
+      box.innerHTML = `<div><b>${trip.name}</b></div>${tripRange}<button id="tripAddDayBtn" type="button">+ Dodaj dzień</button><button id="tripAddPrivatePointBtn" type="button">+ Punkt tylko do tripa</button>` + trip.days.map((d, idx) => {
         const summary = d.routeSummary || {};
         const points = (d.points || []).sort((a,b)=>(a.order||0)-(b.order||0));
         const ptsHtml = points.map((p, i) => `<div class="trip-point-item"><span class="trip-point-name">${i+1}. ${getTripPointEmoji(p)} ${p.name || p.nameSnapshot || 'Punkt'}</span> <span class="trip-point-meta">(${p.pointType || 'inny'})</span> <button data-day="${d.id}" data-point="${p.id}" data-dir="-1">↑</button><button data-day="${d.id}" data-point="${p.id}" data-dir="1">↓</button></div>${i < (d.routeSegments||[]).length ? `<div class="trip-segment-row">↓ Trasa: ${formatTripDuration(d.routeSegments[i].durationSeconds)} / ${formatTripDistance(d.routeSegments[i].distanceMeters)}</div>` : ''}`).join('');
-        return `<div class="trip-day-card ${d.highlight ? 'trip-active-day' : 'trip-muted-day'}" data-day-card="${d.id}"><div class="trip-day-header"><b>Dzień ${idx+1}: ${d.name || ''}</b><input class="trip-color-input" type="color" data-day-color="${d.id}" value="${d.color || '#ff3b3b'}"><button data-day-focus="${d.id}">Podświetl</button></div><div class="trip-day-summary">Jazda: ${formatTripDuration(summary.durationSeconds || 0)} | Zwiedzanie: ${formatTripDuration(summary.visitSeconds || 0)} | Razem: ${formatTripDuration(summary.totalSeconds || 0)} | Dystans: ${formatTripDistance(summary.distanceMeters || 0)}</div>${ptsHtml}</div>`;
+        const dayHeaderDate = d.date ? ` • 📅 ${formatTripHeaderDate(d.date)}` : '';
+        return `<div class="trip-day-card ${d.highlight ? 'trip-active-day' : 'trip-muted-day'}" data-day-card="${d.id}"><div class="trip-day-header"><b>Dzień ${idx+1}: ${d.name || ''}${dayHeaderDate}</b><label>📅 <input type="date" data-day-date="${d.id}" value="${d.date || ''}"></label><input class="trip-color-input" type="color" data-day-color="${d.id}" value="${d.color || '#ff3b3b'}"><button data-day-focus="${d.id}">Podświetl</button></div><div class="trip-day-summary">Jazda: ${formatTripDuration(summary.durationSeconds || 0)} | Zwiedzanie: ${formatTripDuration(summary.visitSeconds || 0)} | Razem: ${formatTripDuration(summary.totalSeconds || 0)} | Dystans: ${formatTripDistance(summary.distanceMeters || 0)}</div>${ptsHtml}</div>`;
       }).join('');
     }
 
@@ -10293,20 +10342,41 @@ function confirmLayerDelete() {
       const compatDb = getCompatDb();
       const user = firebase.auth().currentUser;
       if (!compatDb || !user) { showToast('Najpierw zaloguj się'); return; }
-      const rawName = prompt('Nazwa tripa:', 'Nowy trip');
-      const name = (rawName || '').trim();
+      const formData = await showCreateTripDialog();
+      if (!formData) return;
+      const { name, daysCount, startDate, endDate } = formData;
       if (!name) { console.warn('Trip planner: pusta nazwa tripa.'); return; }
+      if (!Number.isFinite(daysCount) || daysCount < 1) { showToast('Podaj poprawną liczbę dni'); return; }
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(startDate) || !/^\d{4}-\d{2}-\d{2}$/.test(endDate)) { showToast('Podaj poprawne daty'); return; }
+      const expectedEndDate = addDaysToIsoDate(startDate, daysCount - 1);
+      if (expectedEndDate !== endDate) {
+        showToast('Zakres dat musi odpowiadać liczbie dni tripa');
+        return;
+      }
       try {
         const ref = compatDb.collection('trips').doc();
         await ref.set({
           name,
           description: '',
-          startDate: '',
-          endDate: '',
+          startDate,
+          endDate,
           ownerEmail: (user.email || '').toLowerCase(),
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
           updatedAt: firebase.firestore.FieldValue.serverTimestamp()
         });
+        for (let i = 0; i < daysCount; i++) {
+          const dayDate = addDaysToIsoDate(startDate, i);
+          await compatDb.collection('trips').doc(ref.id).collection('days').doc(`day_${Date.now()}_${i}`).set({
+            name: `Dzień ${i + 1}`,
+            date: dayDate,
+            order: i,
+            color: '#ff3b3b',
+            visible: true,
+            routeSummary: {},
+            routeSegments: [],
+            updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+          }, { merge: true });
+        }
         activeTripId = ref.id;
         await loadTrips();
         activeTripId = ref.id;
@@ -10341,6 +10411,16 @@ function confirmLayerDelete() {
         renderTripMapLayers();
         await recalculateTripDay(trip.id, d.id);
       }
+    });
+    document.getElementById('tripActiveBox')?.addEventListener('change', async (e) => {
+      const trip = getActiveTrip(); if (!trip) return;
+      if (!e.target.dataset.dayDate) return;
+      const day = trip.days.find(x => x.id === e.target.dataset.dayDate); if (!day) return;
+      day.date = (e.target.value || '').trim();
+      recalculateTripDateRange(trip);
+      await saveTrip(trip.id);
+      renderTripPlannerPanel();
+      renderTripMapLayers();
     });
     map?.on('click', async e => {
       if (!tripPrivatePointArmed || tripPlannerMode !== 'trip' || currentTool === 'pinTool' || drawingRoute) return;


### PR DESCRIPTION
### Motivation

- Days were the intended source-of-truth for trip dates but there was no UI to set per-day dates and trip start/end remained empty.
- The goal is to let users pick a native date per day, persist it immediately, and keep trip start/end synchronized to day dates.

### Description

- Added a native `input type="date"` to each `trip-day-card` header, and render the selected day date in the day title as `DD.MM.YYYY`.
- Implemented autosave: delegated `change` listener writes `day.date` in `YYYY-MM-DD` to the trip/day documents via existing `saveTrip` and refreshes the panel and map layers.
- Added helpers: `formatTripHeaderDate`, `recalculateTripDateRange`, and `addDaysToIsoDate`; trip range (`startDate`/`endDate`) is recomputed as the min/max of valid day dates or set to empty strings if none exist.
- Reworked trip creation to use a modal with native date pickers and number-of-days, then auto-create day documents with sequential dates so day dates are the source of truth.

### Testing

- Static diff and file inspection were performed using `git diff` and excerpts printed with `sed`/`nl` to verify new functions and injected `input type="date"` elements, and these checks succeeded.
- Loading flow was validated by printing the updated `renderTripPlannerPanel` and `loadTrips` sections to confirm `recalculateTripDateRange` is invoked, and these checks succeeded.
- PR creation tooling was invoked to prepare the change for review and the PR metadata was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b1eeb28483308fe8f85ae947b0fc)