### PR TITLE
Fix false 'Save map edits' button state after loading pins

### DIFF
--- a/index.html
+++ b/index.html
@@ -3440,6 +3440,13 @@ function slugify(str) {
       });
     }
 
+    function hasUnsavedPinChanges() {
+      return Object.values(zmianyDoZapisania).some(change => {
+        if (!change || typeof change !== 'object') return false;
+        return Object.keys(change).length > 0;
+      });
+    }
+
     function hasUnsavedChanges() {
       const layerChanges =
         layersToAdd.length > 0 ||
@@ -3447,9 +3454,9 @@ function slugify(str) {
         layerOrderChanged ||
         Object.keys(layerEmojiChanges).length > 0 ||
         Object.keys(layerDefaultVisibilityChanges).length > 0;
-      const routeChanges = window.localTrasy.length > 0;
+      const routeChanges = Array.isArray(window.localTrasy) && window.localTrasy.length > 0;
       return (
-        Object.keys(zmianyDoZapisania).length > 0 ||
+        hasUnsavedPinChanges() ||
         nowePinezki.length > 0 ||
         pinsToDelete.length > 0 ||
         layerChanges ||


### PR DESCRIPTION
### Motivation
- Loading pins could create empty placeholder objects in `zmianyDoZapisania` which were counted as unsaved edits and incorrectly showed the "Zapisz edycję mapy" button.

### Description
- Add `hasUnsavedPinChanges()` to treat only pin-change entries that actually contain keys as unsaved changes.
- Update `hasUnsavedChanges()` to use `hasUnsavedPinChanges()` and harden route detection to `Array.isArray(window.localTrasy) && window.localTrasy.length > 0` to avoid false positives.

### Testing
- Located and reviewed usage sites with `rg` and inspected surrounding code with `sed` to ensure the new helper and conditional are placed correctly.
- Applied the patch with a small Python edit script and verified the changed lines with `nl`/file inspection, and no errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d4c81e3c83308c783613e75d807c)