### PR TITLE
Fix false unsaved map indicator on initial load

### DIFF
--- a/index.html
+++ b/index.html
@@ -3454,13 +3454,13 @@ function slugify(str) {
         layerOrderChanged ||
         Object.keys(layerEmojiChanges).length > 0 ||
         Object.keys(layerDefaultVisibilityChanges).length > 0;
-      const routeChanges = Array.isArray(window.localTrasy) && window.localTrasy.length > 0;
+      // `localTrasy` bywa zanieczyszczone wpisami pomocniczymi po inicjalizacji UI,
+      // dlatego o niezapisanych trasach decydujemy wyłącznie przez realne zmiany pinezek.
       return (
         hasUnsavedPinChanges() ||
         nowePinezki.length > 0 ||
         pinsToDelete.length > 0 ||
-        layerChanges ||
-        routeChanges
+        layerChanges
       );
     }
 


### PR DESCRIPTION
### Motivation
- The Save button (`#saveChanges`) appeared right after opening the page because `hasUnsavedChanges()` considered `window.localTrasy.length`, and `localTrasy` can contain initialization artifacts that produce a false positive.

### Description
- Remove the `localTrasy` length check from `hasUnsavedChanges()` and add an inline comment so unsaved state is determined only from explicit pin/layer/new/delete changes.

### Testing
- Ran quick repository checks (`git diff -- index.html` and `nl -ba index.html | sed -n '3448,3472p'`) to verify the change is present and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e00cc8dc833083d92c3a0245d464)