### PR TITLE
Fix trip point action buttons and unsaved state detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -3440,10 +3440,20 @@ function slugify(str) {
       });
     }
 
+    function hasMeaningfulPendingValue(value) {
+      if (value == null) return false;
+      if (Array.isArray(value)) return value.length > 0;
+      if (typeof value === 'object') return Object.keys(value).length > 0;
+      return true;
+    }
+
     function hasUnsavedPinChanges() {
       return Object.values(zmianyDoZapisania).some(change => {
         if (!change || typeof change !== 'object') return false;
-        return Object.keys(change).length > 0;
+        return Object.entries(change).some(([key, value]) => {
+          if (key === 'marker' || key === 'ui' || key === 'view') return false;
+          return hasMeaningfulPendingValue(value);
+        });
       });
     }
 
@@ -8347,7 +8357,7 @@ function getTripPointEmoji(p) {
       box.innerHTML = `<div><b>${trip.name}</b></div>${tripRange}<button id="tripAddDayBtn" type="button">+ Dodaj dzień</button><button id="tripAddPrivatePointBtn" type="button">+ Punkt tylko do tripa</button><button id="tripDeleteBtn" class="trip-icon-btn" type="button" title="Usuń trip" aria-label="Usuń trip">🗑️</button>` + trip.days.map((d, idx) => {
         const summary = d.routeSummary || {};
         const points = (d.points || []).sort((a,b)=>(a.order||0)-(b.order||0));
-        const ptsHtml = `<div class="trip-point-list">` + points.map((p, i) => `<div class="trip-point-item" data-trip-action="focus-point" data-day-id="${d.id}" data-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}"><span class="trip-point-name">${i+1}. ${getTripPointEmoji(p)} ${p.name || p.nameSnapshot || 'Punkt'}</span> <span class="trip-point-meta">(${p.pointType || 'inny'})</span> <button data-trip-action="move-point-up" data-day-id="${d.id}" data-point-id="${p.id}" data-stop-row-click="1">↑</button><button data-trip-action="move-point-down" data-day-id="${d.id}" data-point-id="${p.id}" data-stop-row-click="1">↓</button><button data-trip-action="delete-point" data-day-id="${d.id}" data-point-id="${p.id}" data-stop-row-click="1" title="Usuń punkt" aria-label="Usuń punkt">🗑️</button></div>${i < (d.routeSegments||[]).length ? `<div class="trip-segment-row">↓ Trasa: ${formatTripDuration(d.routeSegments[i].durationSeconds)} / ${formatTripDistance(d.routeSegments[i].distanceMeters)}</div>` : ''}`).join('') + `</div>`;
+        const ptsHtml = `<div class="trip-point-list">` + points.map((p, i) => `<div class="trip-point-item" data-trip-action="focus-point" data-day-id="${d.id}" data-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}"><span class="trip-point-name">${i+1}. ${getTripPointEmoji(p)} ${p.name || p.nameSnapshot || 'Punkt'}</span> <span class="trip-point-meta">(${p.pointType || 'inny'})</span> <button type="button" data-trip-action="move-point-up" data-day-id="${d.id}" data-point-id="${p.id}" data-stop-row-click="1">↑</button><button type="button" data-trip-action="move-point-down" data-day-id="${d.id}" data-point-id="${p.id}" data-stop-row-click="1">↓</button><button type="button" data-trip-action="delete-point" data-day-id="${d.id}" data-point-id="${p.id}" data-stop-row-click="1" title="Usuń punkt" aria-label="Usuń punkt">🗑️</button></div>${i < (d.routeSegments||[]).length ? `<div class="trip-segment-row">↓ Trasa: ${formatTripDuration(d.routeSegments[i].durationSeconds)} / ${formatTripDistance(d.routeSegments[i].distanceMeters)}</div>` : ''}`).join('') + `</div>`;
         return `<div class="trip-day-card ${d.highlight ? 'trip-active-day' : 'trip-muted-day'}" data-day-card="${d.id}"><div class="trip-day-header"><b>${d.name || `Dzień ${idx+1}`}</b><label><input type="date" data-day-date="${d.id}" value="${d.date || ''}"></label><input class="trip-color-input" type="color" data-day-color="${d.id}" value="${d.color || '#ff3b3b'}"><button data-day-delete="${d.id}" class="trip-icon-btn" title="Usuń dzień" aria-label="Usuń dzień">🗑️</button></div><div class="trip-day-summary">Jazda: ${formatTripDuration(summary.durationSeconds || 0)} | Zwiedzanie: ${formatTripDuration(summary.visitSeconds || 0)} | Razem: ${formatTripDuration(summary.totalSeconds || 0)} | Dystans: ${formatTripDistance(summary.distanceMeters || 0)}</div>${ptsHtml}</div>`;
       }).join('');
       box.querySelectorAll('[data-stop-row-click="1"]').forEach(btn => {
@@ -10628,7 +10638,9 @@ function confirmLayerDelete() {
         renderTripPlannerPanel(); renderTripMapLayers(); applyTripPlannerPinVisibility();
         return;
       }
-      const actionEl = targetEl?.closest('[data-trip-action]');
+      const eventPath = (typeof e.composedPath === 'function') ? e.composedPath() : [];
+      const pathActionEl = eventPath.find(node => node instanceof Element && node.hasAttribute?.('data-trip-action')) || null;
+      const actionEl = pathActionEl || targetEl?.closest('[data-trip-action]');
       if (actionEl) {
         e.preventDefault();
         e.stopPropagation();


### PR DESCRIPTION
### Motivation
- Użytkownicy zgłaszali, że kliknięcia w przyciski listy punktów tripa (`data-trip-action="delete-point"`, `move-point-up`, `move-point-down`) nic nie robią, oraz że po załadowaniu pinezek widoczny jest baner z niezapisanymi zmianami mimo braku realnych edycji.

### Description
- Dodano `hasMeaningfulPendingValue()` oraz zmieniono `hasUnsavedPinChanges()` tak, żeby ignorować puste/techniczne wartości i klucze pomocnicze (`marker`, `ui`, `view`) przy wykrywaniu niezapisanych zmian w `zmianyDoZapisania` w `index.html`.
- Zmieniono generowany markup przycisków w panelu tripa tak, aby przyciski `move-point-up`, `move-point-down` i `delete-point` miały `type="button"`, co zapobiega ich traktowaniu jako submit w kontekstach formularzy.
- Utwardzono delegację zdarzeń kliknięć w `tripActiveBox` przez sprawdzenie `e.composedPath()` (z fallbackem do `closest()`), co zapewnia poprawne odnalezienie elementu posiadającego `data-trip-action` niezależnie od faktycznego targeta kliknięcia.

### Testing
- Weryfikowano zmiany przez przegląd diffu z `git diff -- index.html | sed -n '1,220p'`, który pokazał spodziewane modyfikacje, i polecenie zakończyło się prawidłowo.
- Zrobiono commit z `git add index.html && git commit -m "Fix trip point action buttons and unsaved state detection"`, który zakończył się sukcesem i utworzył zmianę w repozytorium.
- Sprawdzono wstawione fragmenty pliku poleceniami `nl -ba index.html | sed -n '3436,3475p'`, `nl -ba index.html | sed -n '8344,8368p'` oraz `nl -ba index.html | sed -n '10632,10656p'`, które potwierdziły poprawną aplikację zmian.
- Brak automatycznego zestawu testów w repozytorium, więc walidacja przeprowadzona została przez statyczną inspekcję i powyższe polecenia, wszystkie zakończyły się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02c83a980c833086f2c19b93189185)