### PR TITLE
Fix false "Zapisz edycję mapy" visibility on initial load

### DIFF
--- a/index.html
+++ b/index.html
@@ -3476,6 +3476,20 @@ function slugify(str) {
 
     function updateSaveButton() {
       const pending = hasUnsavedChanges();
+      console.log("SAVE BUTTON DEBUG", {
+        pending,
+        hasUnsavedPinChanges: hasUnsavedPinChanges(),
+        zmianyDoZapisaniaKeys: Object.keys(zmianyDoZapisania),
+        zmianyDoZapisania,
+        nowePinezkiLength: nowePinezki.length,
+        nowePinezki,
+        pinsToDeleteLength: pinsToDelete.length,
+        layersToAddLength: layersToAdd.length,
+        layersToDeleteLength: layersToDelete.length,
+        layerOrderChanged,
+        layerEmojiChangesKeys: Object.keys(layerEmojiChanges),
+        layerDefaultVisibilityChangesKeys: Object.keys(layerDefaultVisibilityChanges)
+      });
       shouldWarnBeforeUnload = pending;
       const btn = document.getElementById('saveChanges');
       if (!btn) return;
@@ -6547,11 +6561,15 @@ function zaladujPinezkiZFirestore() {
       try {
         const localPinsRaw = JSON.parse(localStorage.getItem('nowePinezki')) || [];
         const invalidPins = [];
+        const MAX_LOCAL_PIN_AGE_MS = 1000 * 60 * 60 * 24 * 2;
+        const nowTs = Date.now();
         nowePinezki = (Array.isArray(localPinsRaw) ? localPinsRaw : []).filter(p => {
           const lat = Number(p?.lat);
           const lng = Number(p?.lng);
           const hasName = Boolean((p?.nazwa || p?.name || '').toString().trim());
-          const valid = p && typeof p === 'object' && Number.isFinite(lat) && Number.isFinite(lng) && hasName;
+          const createdAt = Number(p?.dataDodania || p?.createdAt || 0);
+          const isFreshEnough = Number.isFinite(createdAt) && createdAt > 0 && (nowTs - createdAt) <= MAX_LOCAL_PIN_AGE_MS;
+          const valid = p && typeof p === 'object' && Number.isFinite(lat) && Number.isFinite(lng) && hasName && isFreshEnough;
           if (!valid) invalidPins.push(p);
           return valid;
         });


### PR DESCRIPTION
### Motivation
- Po odświeżeniu strony przycisk „Zapisz edycję mapy” pojawiał się mimo braku edycji z powodu wykrywania „pending” na starcie; celem jest ukrycie przycisku jeśli nie było realnych zmian. 
- Trzeba było dodać diagnostykę, aby jednoznacznie ustalić, która flaga powoduje `pending === true` przy inicjalnym ładowaniu.

### Description
- Dodano szczegółowy debug log w funkcji `updateSaveButton()` wyświetlający wszystkie kluczowe zmienne wpływające na stan zapisu (pole `SAVE BUTTON DEBUG`).
- Zmieniono ładowanie lokalnych nowych pinezek w `loadNewPinsFromLocal()` tak, by filtrować nie tylko niepoprawne wpisy, ale też odrzucać stare/zanieczyszczone wpisy z `localStorage` starsze niż 48 godzin (`MAX_LOCAL_PIN_AGE_MS`), dzięki czemu stare „śmieciowe” `nowePinezki` nie powodują natychmiastowego ustawienia stanu niesave.
- Zmiany ograniczone wyłącznie do `index.html` i nie dotykają Trip Plannera ani innych funkcji aplikacji; zachowano dotychczasowe zachowanie: realne edycje (pinezka/warstwa/dodanie pinezki) nadal ustawiają stan niesave.

### Testing
- Nie znaleziono zautomatyzowanego zestawu testów w repozytorium, więc nie uruchomiono testów automatycznych.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ce1ae7808330ad7ca572e3c0e55c)