### PR TITLE
Fix mobile trip planner visibility and always-show "Załaduj pinezki" button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1916,8 +1916,8 @@ img.emoji {
         <button type="button" id="importKmlBtn" class="kml-import-btn">importuj z .kml</button>
         <input type="file" id="importKmlInput" accept=".kml" style="display:none;">
       </div>
-      <button id="loadPinsBtn">Załaduj pinezki</button>
       </div>
+      <button id="loadPinsBtn">Załaduj pinezki</button>
       <div id="tripPlannerPanel" class="trip-planner-panel" style="display:none;">
         <h3>Plan tripu</h3>
         <div class="trip-select-row">
@@ -10653,6 +10653,8 @@ function confirmLayerDelete() {
       document.getElementById('modePinsBtn')?.classList.toggle('active', mode === 'pins');
       document.getElementById('modeTripBtn')?.classList.toggle('active', mode === 'trip');
       document.body.classList.toggle('trip-planner-mode', mode === 'trip');
+      const tripPanel = document.getElementById('tripPlannerPanel');
+      if (tripPanel) tripPanel.style.display = mode === 'trip' ? 'block' : 'none';
       document.getElementById('toggleLayers').textContent = mode === 'trip' ? '☰ Plan tripu' : '☰ Warstwy';
       renderTripMapLayers();
       applyTripPlannerPinVisibility();


### PR DESCRIPTION
### Motivation
- Na mobilnych urządzeniach tryb "Plan tripu" nie był widoczny po kliknięciu z powodu ukrywania zawartości w rozwijanym kontenerze, a przycisk `#loadPinsBtn` był schowany w tym samym kontenerze i wymagał rozwinięcia, więc trzeba zapewnić natychmiastową widoczność panelu i przycisku.

### Description
- Przeniesiono przycisk `#loadPinsBtn` poza kontener `#sidebarTopControls` w `index.html`, aby był zawsze widoczny na mobile; oraz zmieniono funkcję `setTripMode` tak, by bezpośrednio ustawiać widoczność panelu `#tripPlannerPanel` (`style.display = 'block'|'none'`).

### Testing
- Weryfikowano zmiany za pomocą przeszukania kodu i inspekcji pliku (`rg`, `sed`), potwierdzono zmiany przez `git diff -- index.html`, wykonano `git commit`, oraz utworzono PR przy użyciu skryptu `make_pr`, a wszystkie te kroki zakończyły się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02d42ea1848330bbeac9aff72ade2e)