### PR TITLE
Preserve layer collapse state when applying/undoing layer edits

### DIFF
--- a/index.html
+++ b/index.html
@@ -7319,6 +7319,7 @@ function zaladujPinezkiZFirestore() {
           }
         });
       }
+      persistAllLayerCollapseStates();
       generujListeWarstw();
       updateSaveButton();
       closeLayerEditor();
@@ -7347,6 +7348,7 @@ function zaladujPinezkiZFirestore() {
             zmianyDoZapisania[pin.id] = data;
             pin.unsaved = true;
           });
+          persistAllLayerCollapseStates();
           generujListeWarstw();
           updateSaveButton();
         },
@@ -7369,6 +7371,7 @@ function zaladujPinezkiZFirestore() {
               pin.unsaved = true;
             });
           }
+          persistAllLayerCollapseStates();
           generujListeWarstw();
           updateSaveButton();
         }


### PR DESCRIPTION
### Motivation
- Naprawić problem polegający na tym, że po edycji warstwy i kliknięciu „Zastosuj” stany zwinięcia/rozwinięcia warstw były nadpisywane i warstwy nagle się rozwijały.

### Description
- Zapisuję bieżące stany zwinięcia warstw wywołaniem `persistAllLayerCollapseStates()` bezpośrednio przed przebudowaniem listy warstw (`generujListeWarstw()`) w głównym przebiegu zapisywania edycji oraz w akcjach `undo` i `redo` edycji warstwy.

### Testing
- Weryfikacja różnicy pliku przez `git diff -- index.html` zakończona poprawnym rezultatem; zmiany zastosowano i dodano do commita `git commit` bez błędów.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02dd94766483308d2222b61a36f2bc)