### PR TITLE
Fix layer separator rendering after layer drag-and-drop

### DIFF
--- a/index.html
+++ b/index.html
@@ -6724,8 +6724,8 @@ function zaladujPinezkiZFirestore() {
           const lista = document.getElementById('lista-warstw');
           lista.insertBefore(draggedLayer, div);
           saveLayerOrder({ markChange: false });
-          updateLayerNumbers();
           autosaveLayerOrderToFirestore(loadLayerOrder());
+          generujListeWarstw();
         }
       });
 
@@ -6752,8 +6752,8 @@ function zaladujPinezkiZFirestore() {
         document.removeEventListener('pointerup', endPointerDrag);
         document.removeEventListener('pointercancel', endPointerDrag);
         saveLayerOrder({ markChange: false });
-        updateLayerNumbers();
         autosaveLayerOrderToFirestore(loadLayerOrder());
+        generujListeWarstw();
       };
       handle.addEventListener('pointerdown', (event) => {
         if (event.button !== 0 && event.pointerType !== 'touch') return;
@@ -9453,9 +9453,11 @@ function getTripPointEmoji(p) {
 
         div.appendChild(listaP);
         lista.appendChild(div);
-        const sep = document.createElement('hr');
-        sep.className = 'layer-separator';
-        lista.appendChild(sep);
+        if (idx < finalNazwy.length - 1) {
+          const sep = document.createElement('hr');
+          sep.className = 'layer-separator';
+          lista.appendChild(sep);
+        }
       });
       saveLayerOrder({ markChange: false });
       updateLayerNumbers();


### PR DESCRIPTION
### Motivation
- Drag & drop left `.layer-separator` elements in stale positions, producing empty or misplaced separators after reordering layers. 
- Separators must be generated as part of the list render so the DOM always reflects the current order (no trailing/orphan separators).

### Description
- After both HTML5 `drop` and pointer-based drag end paths the code now calls `generujListeWarstw()` to re-render the entire layers list after saving order and autosaving to Firestore. 
- Separator nodes are created only when `idx < finalNazwy.length - 1`, so an `<hr class="layer-separator">` is inserted only between layers and never after the last one. 
- Removed redundant local `updateLayerNumbers()` calls around the immediate DnD handlers because `generujListeWarstw()` updates numbering as part of the full render. 

### Testing
- Executed repository inspections and diffs using `rg`/`sed` to locate related code and confirm changes, which completed successfully. 
- Applied automated file edits with the included Python script (performed the replacements) and the script ran successfully. 
- Verified the patch via `git diff -- index.html | sed -n '1,200p'` and committed with `git commit -m "Fix layer separator rendering after layer drag and drop"`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ebd61dbc8330baaad36924b57099)