### PR TITLE
Synchronizuj nazwy punktów w Planie tripu po edycji pinezki

### DIFF
--- a/index.html
+++ b/index.html
@@ -6144,7 +6144,7 @@ function zaladujPinezkiZFirestore() {
       }
     }
 
-    function zapiszLokalnie(id) {
+    async function zapiszLokalnie(id) {
       const nameVal = document.getElementById("enazwa").value.trim();
       const layerVal = document.getElementById("ewarstwa").value.trim();
       const missing = [];
@@ -6208,6 +6208,7 @@ function zaladujPinezkiZFirestore() {
       if (p) {
         const oldSlug = p.slug;
         applyPinData(p, nowa);
+        await syncTripPointSnapshotsForPin(p);
         refreshCategoryCollectionsFromPins();
         updateCategoryFilter();
         getPinMainCategory(p);
@@ -8265,6 +8266,39 @@ function getTripPointEmoji(p) {
         for (const [pi, point] of (safeDay.points || []).entries()) await dayRef.collection('points').doc(point.id).set({ ...point, order: pi }, { merge: true });
       }
       showToast('Zapisano trip');
+    }
+    async function syncTripPointSnapshotsForPin(pin) {
+      if (!pin || !Array.isArray(tripPlannerTrips) || !tripPlannerTrips.length) return;
+      const pinId = String(pin.id ?? '');
+      const pinFirebaseId = String(pin.firebaseId ?? '');
+      const pinLegacyId = String(pin.IDpinezki ?? '');
+      const changedTripIds = new Set();
+      tripPlannerTrips.forEach(trip => {
+        (trip.days || []).forEach(day => {
+          (day.points || []).forEach(point => {
+            if (point?.type === 'custom' || point?.tripOnly) return;
+            const pointPinId = String(point.pinId ?? '');
+            const pointFirebaseId = String(point.pinFirebaseId ?? '');
+            const matchesPin =
+              (pinId && pointPinId && pointPinId === pinId) ||
+              (pinFirebaseId && pointFirebaseId && pointFirebaseId === pinFirebaseId) ||
+              (pinLegacyId && pointPinId && pointPinId === pinLegacyId);
+            if (!matchesPin) return;
+            if (point.nameSnapshot !== pin.nazwa || point.emojiSnapshot !== (pin.emoji || '')) {
+              point.nameSnapshot = pin.nazwa;
+              point.emojiSnapshot = pin.emoji || '';
+              changedTripIds.add(trip.id);
+            }
+          });
+        });
+      });
+      if (!changedTripIds.size) return;
+      for (const tripId of changedTripIds) {
+        await saveTrip(tripId);
+      }
+      renderTripPlannerPanel();
+      renderTripMapLayers();
+      applyTripPlannerPinVisibility();
     }
     async function recalculateTripDay(tripId, dayId) {
       const trip = tripPlannerTrips.find(t => t.id === tripId); const day = trip?.days?.find(d => d.id === dayId);


### PR DESCRIPTION
### Motivation
- Po edycji pinezki jej nowa nazwa nie była propagowana do punktów w „Planie tripu”, więc lista/trasa dalej wyświetlała stare snapshoty nazwy/emoji.

### Description
- Zmieniono `zapiszLokalnie` na asynchroniczną (`async`) i po zastosowaniu danych pinezki wywołuje nową funkcję synchronizacji snapshotów tripów.
- Dodano `syncTripPointSnapshotsForPin(pin)`, która wyszukuje powiązane punkty tripów (po `pinId`, `pinFirebaseId` i legacy `IDpinezki`) i aktualizuje `nameSnapshot` oraz `emojiSnapshot` tam, gdzie to potrzebne.
- Funkcja zapisuje tylko zmienione tripy przez `saveTrip(...)` i następnie odświeża panel trip plannera oraz warstwy mapy przez `renderTripPlannerPanel()`, `renderTripMapLayers()` i `applyTripPlannerPinVisibility()`.

### Testing
- Wykonano automatyczne przeszukanie pliku kodu (`rg`) i wyświetlenie odpowiednich fragmentów pliku (`nl`/`sed`) aby potwierdzić poprawne wstawienie i wywołanie nowej funkcji, i te kontrole zakończyły się pomyślnie.
- Sprawdzono zmiany w pliku przez porównanie zawartości (inspekcja diff/wycinków) i potwierdzono, że `syncTripPointSnapshotsForPin` jest wywoływana po `applyPinData(p, nowa)`; kontrola zakończona pomyślnie.
- Nie uruchamiano zautomatyzowanych testów jednostkowych, ponieważ repozytorium nie zawiera testów dla tej ścieżki; zmiana jest zweryfikowana przez powyższe kontrole plików i odświeżenie UI wywołane w kodzie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0305a3f2ec8330912787cdf7787fd3)