### PR TITLE
Define escapeHtml helper to fix duplicate pins modal crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -9815,6 +9815,19 @@ function getTripPointEmoji(p) {
       });
     }
 
+    function escapeHtml(str) {
+      return String(str || '').replace(/[&<>'"]/g, c => {
+        switch (c) {
+          case '&': return '&amp;';
+          case '<': return '&lt;';
+          case '>': return '&gt;';
+          case '"': return '&quot;';
+          case "'": return '&#39;';
+          default: return c;
+        }
+      });
+    }
+
     function buildKml(pins) {
       const placemarks = pins.map(p => {
         const name = escapeXml(p.nazwa);


### PR DESCRIPTION
### Motivation
- Opening the duplicate-pins modal caused `ReferenceError: escapeHtml is not defined` because `renderDuplicatePinsList()` used an undefined helper when building HTML snippets.

### Description
- Added a new `function escapeHtml(str)` in `index.html` that escapes `& < > " '` to HTML entities.
- Placed the helper near the existing `escapeXml` implementation so it is available before `renderDuplicatePinsList()` is invoked.
- `renderDuplicatePinsList()` now safely uses `escapeHtml` for `pinId`, `name`, and `layer` when composing the duplicate list markup to prevent runtime errors and XSS-ish output.

### Testing
- No automated test suite was executed for this change.
- Verified by repository search with `rg -n "renderDuplicatePinsList|openDuplicatePinsModal|escapeHtml" -S .` and by inspecting the resulting diff to confirm the helper is inserted before duplicate-list rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a030c28e84883309b737120b82a40a8)