### PR TITLE
Add two bulk actions for duplicate-pin cleanup modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -774,6 +774,9 @@ body, #sidebar, #basemap-switcher {
 .duplicate-item.is-removed .duplicate-pin-link { color: #a6adbc; text-decoration: none; cursor: default; pointer-events: none; }
 .duplicate-remove-btn { min-width: 34px; }
 .duplicate-meta { color: #c3cad8; font-size: 12px; }
+.duplicate-global-actions { display:flex; flex-wrap:wrap; gap:8px; margin: 0 0 10px; }
+.duplicate-global-actions button { flex: 1 1 260px; }
+
 
 .emoji-obrys {
   filter: drop-shadow(0 0 0.1px black)
@@ -10081,6 +10084,15 @@ function getTripPointEmoji(p) {
       }));
     }
 
+    function removeDuplicateItemsAndKeepFirst(items) {
+      items.slice(1).forEach((item) => {
+        const pinToDelete = item.pinRef;
+        removedDuplicatePinIds.add(item.uiId);
+        item.removed = true;
+        deletePinLocal(pinToDelete.id);
+      });
+    }
+
     function renderDuplicatePinsList() {
       const container = document.getElementById('duplicatePinsList');
       if (!container) return;
@@ -10198,15 +10210,34 @@ function getTripPointEmoji(p) {
                   if (pinName === name && pinLayer === layer) matchingPins.push(item);
                 });
               });
-              matchingPins.slice(1).forEach((item) => {
-                const pinToDelete = item.pinRef;
-                removedDuplicatePinIds.add(item.uiId);
-                item.removed = true;
-                deletePinLocal(pinToDelete.id);
-              });
+              removeDuplicateItemsAndKeepFirst(matchingPins);
               renderDuplicatePinsList();
               return;
             }
+          if (action === 'remove-all-same-name-location') {
+            duplicateModalGroupsCache.forEach((group) => {
+              const byName = new Map();
+              group.pins.forEach((item) => {
+                if (item.removed) return;
+                const pinName = item.pinRef.nazwa || item.pinRef.name || '(bez nazwy)';
+                if (!byName.has(pinName)) byName.set(pinName, []);
+                byName.get(pinName).push(item);
+              });
+              byName.forEach((items) => {
+                if (items.length > 1) removeDuplicateItemsAndKeepFirst(items);
+              });
+            });
+            renderDuplicatePinsList();
+            return;
+          }
+          if (action === 'remove-all-same-location') {
+            duplicateModalGroupsCache.forEach((group) => {
+              const activeItems = group.pins.filter((item) => !item.removed);
+              if (activeItems.length > 1) removeDuplicateItemsAndKeepFirst(activeItems);
+            });
+            renderDuplicatePinsList();
+            return;
+          }
           const row = target.closest('.duplicate-item');
           if (!row) return;
           const pinId = row.dataset.dupPinId;
@@ -10940,6 +10971,10 @@ function confirmLayerDelete() {
 	      <div class="duplicate-modal-header">
         <h3 style="margin:0;">Duplikaty pinezek (te same współrzędne)</h3>
         <button id="closeDuplicatePinsModal" type="button">Zamknij</button>
+      </div>
+      <div class="duplicate-global-actions">
+        <button type="button" class="duplicate-remove-all-btn" data-action="remove-all-same-name-location">Usuń wszystkie z tą samą nazwą i lokalizacją</button>
+        <button type="button" class="duplicate-remove-all-btn" data-action="remove-all-same-location">Usuń wszystkie z tą samą lokalizacją</button>
       </div>
       <div id="duplicatePinsList"></div>
     </div>


### PR DESCRIPTION
### Motivation
- Provide two bulk cleanup actions in the duplicate-pin modal so users can easily remove redundant pins by (1) same name+location and (2) same location only, while preserving one pin per coordinate. 
- Keep existing temporary-removal UX where removed pins stay visible as gray with the “(usunięto)” suffix so users can review changes before permanent persistence.

### Description
- Added a compact action row UI to the duplicate modal (`.duplicate-global-actions`) with two buttons wired to `data-action` values `remove-all-same-name-location` and `remove-all-same-location` in `index.html`.
- Introduced `removeDuplicateItemsAndKeepFirst(items)` helper and refactored the existing exact-duplicate removal to call this helper so all bulk removals keep the first item and mark the rest removed.
- Implemented event-handler logic to: group and remove duplicates by name+location, remove duplicates by location (regardless of name), and reuse the existing temporary-removal flow (`removedDuplicatePinIds`, `item.removed`, `deletePinLocal`).
- Only `index.html` was modified (CSS, modal markup and JS logic updates). 

### Testing
- Ran content/regexp checks with `rg -n "duplicate-global-actions|remove-all-same-name-location|remove-all-same-location|removeDuplicateItemsAndKeepFirst" index.html` and confirmed the new symbols are present (succeeded). 
- Confirmed working tree status with `git status --short` and committed the change with `git add index.html && git commit -m "Add bulk duplicate pin removal actions in duplicate modal"` (commit succeeded). 
- Performed manual inspection of the modal rendering and click handler paths for the three removal cases (exact, same name+location, same location) after the changes (visual/interactive checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032612d5588330bfad3e8844f5598f)