### PR TITLE
Add Overpass endpoint fallback and cooldown for OSM overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -5088,12 +5088,19 @@ function emojiHtml(str) {
 
       const osmOverlayCache = new Map();
       const OSM_OVERLAY_MIN_ZOOM = 12;
+      const OSM_OVERLAY_COOLDOWN_MS = 30000;
+      const OVERPASS_ENDPOINTS = [
+        'https://overpass-api.de/api/interpreter',
+        'https://overpass.kumi.systems/api/interpreter',
+        'https://overpass.private.coffee/api/interpreter'
+      ];
       let osmOverlayEnabled = true;
       let osmOverlayLoading = false;
       let lastOsmRequestKey = null;
       let osmAbortController = null;
       let osmOverlayLayer = null;
       let osmOverlayStatusEl = null;
+      let osmOverlayCooldownUntil = 0;
 
       function setOsmOverlayStatus(message, type = '') {
         if (!osmOverlayStatusEl) return;
@@ -5522,9 +5529,26 @@ function emojiHtml(str) {
         return [z,b.getSouth().toFixed(2),b.getWest().toFixed(2),b.getNorth().toFixed(2),b.getEast().toFixed(2)].join(',');
       }
       async function fetchOsmOverlay(bbox) {
-        const response = await fetch('https://overpass-api.de/api/interpreter', { method:'POST', body: buildOsmOverlayQuery(bbox), headers:{'Content-Type':'text/plain;charset=UTF-8'}, signal: osmAbortController?.signal });
-        if (!response.ok) throw new Error(`Overpass API error: ${response.status}`);
-        return response.json();
+        const query = buildOsmOverlayQuery(bbox);
+        let lastError = null;
+        for (const endpoint of OVERPASS_ENDPOINTS) {
+          try {
+            const response = await fetch(endpoint, {
+              method: 'POST',
+              body: query,
+              headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+              signal: osmAbortController?.signal
+            });
+            if (!response.ok) throw new Error(`Overpass API error ${response.status} from ${endpoint}`);
+            console.log('[OSM Overlay] Loaded from:', endpoint);
+            return await response.json();
+          } catch (err) {
+            lastError = err;
+            if (err?.name === 'AbortError') throw err;
+            console.warn('[OSM Overlay] Endpoint failed:', endpoint, err);
+          }
+        }
+        throw lastError || new Error('All Overpass endpoints failed');
       }
       function openNewPinPopupWithDefaults(latlng, defaults = {}) {
         window.__osmPrefillNewPin = { latlng, defaults };
@@ -5570,6 +5594,7 @@ function emojiHtml(str) {
       }
       const debouncedLoadOsmOverlay = debounce(async () => {
         if (!osmOverlayEnabled) return;
+        if (Date.now() < osmOverlayCooldownUntil) return;
         if (map.getZoom() < OSM_OVERLAY_MIN_ZOOM) {
           osmOverlayLayer.clearLayers();
           setOsmOverlayStatus('Przybliż aby pokazać miejsca OSM', 'zoom');
@@ -5587,7 +5612,14 @@ function emojiHtml(str) {
         setOsmOverlayStatus('Wczytywanie miejsc OSM dla aktualnego obszaru…', 'loading');
         const b = map.getBounds(); const bbox = `${b.getSouth()},${b.getWest()},${b.getNorth()},${b.getEast()}`;
         try { const data = await fetchOsmOverlay(bbox); if (lastOsmRequestKey !== key) return; osmOverlayCache.set(key, data); renderOsmOverlay(data); setOsmOverlayStatus('Miejsca OSM załadowane dla bieżącego obszaru.', 'success'); }
-        catch (err) { if (err.name !== 'AbortError') console.warn('[OSM Overlay]', err); }
+        catch (err) {
+          if (err.name !== 'AbortError') {
+            osmOverlayLayer.clearLayers();
+            osmOverlayCooldownUntil = Date.now() + OSM_OVERLAY_COOLDOWN_MS;
+            setOsmOverlayStatus('OSM chwilowo niedostępne', 'disabled');
+            console.warn('[OSM Overlay]', err);
+          }
+        }
         finally { osmOverlayLoading = false; }
       }, 900);
 


### PR DESCRIPTION
### Motivation
- Zapobiec przerwom działania nakładki OSM kiedy domyślny endpoint Overpass zwraca błąd lub jest niedostępny, tak aby mapa nie crashowała.
- Dodać listę fallbacków Overpass i mechanizm ograniczający powtarzające się próby (cooldown), żeby nie spamować serwerów po awarii.
- Zachować istniejące zachowanie wydajnościowe (debounce przy `moveend`/`zoomend`) oraz fakt, że OSM jest tylko nakładką bez zapisu do Firestore.

### Description
- Dodano stałą `OVERPASS_ENDPOINTS` zawierającą trzy endpointy oraz `OSM_OVERLAY_COOLDOWN_MS = 30000` i `osmOverlayCooldownUntil` do kontroli cooldownu.
- Zmieniono `fetchOsmOverlay(bbox)` tak, aby wysyłał sekwencyjne `POST`y do endpointów z `OVERPASS_ENDPOINTS` i zwracał wynik przy pierwszym udanym responsie, przy błędach logując `console.warn` i przepuszczając `AbortError` bez fallbacku.
- Po całkowitej niepowodze wszystkich endpointów kod czyści tylko `osmOverlayLayer`, ustawia status `OSM chwilowo niedostępne` i ustawia cooldown, zamiast przerywać inicjalizację mapy.
- Pozostawiono istniejący `debouncedLoadOsmOverlay` (debounce przy `moveend/zoomend`) i zachowanie nakładki jako elementu `overlay-item` bez integracji z listą lub Firestore.

### Testing
- Przeszukano repozytorium referencji związanych z OSM (`rg`) aby potwierdzić miejsca modyfikacji, i komenda zakończyła się pomyślnie.
- Wyświetlono i przejrzano zmieniony fragment pliku za pomocą `sed`/`nl` aby zweryfikować wstawki, i polecenia zakończyły się pomyślnie.
- Zatwierdzono zmiany przez `git commit` i utworzono PR, oba działania zakończyły się pomyślnie; nie uruchomiono oddzielnych testów jednostkowych w tym repozytorium.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032d94caf08330acd50235278fadaa)