### PR TITLE
Rozsuwanie etykiet miejsc OSM, aby uniknąć nakładania się

### DIFF
--- a/index.html
+++ b/index.html
@@ -5593,6 +5593,53 @@ function emojiHtml(str) {
           });
           marker.addTo(osmOverlayLayer);
         });
+        spreadOsmOverlayMarkers();
+      }
+
+      function spreadOsmOverlayMarkers() {
+        if (!osmOverlayLayer || !map) return;
+        const markers = [];
+        osmOverlayLayer.eachLayer((layer) => {
+          if (layer instanceof L.Marker) {
+            const original = layer._osmOriginalLatLng || layer.getLatLng();
+            layer._osmOriginalLatLng = original;
+            markers.push(layer);
+          }
+        });
+        if (!markers.length) return;
+        const placedPoints = [];
+        const minDistancePx = 46;
+        const ringStepPx = 26;
+        const maxRing = 7;
+
+        markers.forEach((marker) => {
+          const originalLatLng = marker._osmOriginalLatLng || marker.getLatLng();
+          const centerPoint = map.latLngToLayerPoint(originalLatLng);
+          let chosenPoint = centerPoint;
+          let foundSpot = false;
+          for (let ring = 0; ring <= maxRing && !foundSpot; ring++) {
+            const radius = ring * ringStepPx;
+            const candidates = ring === 0
+              ? [centerPoint]
+              : Array.from({ length: Math.max(8, ring * 10) }, (_, i) => {
+                  const angle = (2 * Math.PI * i) / Math.max(8, ring * 10);
+                  return L.point(
+                    centerPoint.x + Math.cos(angle) * radius,
+                    centerPoint.y + Math.sin(angle) * radius
+                  );
+                });
+            for (const candidate of candidates) {
+              const collides = placedPoints.some((placed) => candidate.distanceTo(placed) < minDistancePx);
+              if (!collides) {
+                chosenPoint = candidate;
+                foundSpot = true;
+                break;
+              }
+            }
+          }
+          placedPoints.push(chosenPoint);
+          marker.setLatLng(map.layerPointToLatLng(chosenPoint));
+        });
       }
       const debouncedLoadOsmOverlay = debounce(async () => {
         if (!osmOverlayEnabled) return;


### PR DESCRIPTION
### Motivation
- Miejsca z OSM często występują bardzo blisko siebie i ich etykiety się nakładają, co utrudnia odczytanie nazw. 
- Celem zmiany jest automatyczne rozstawienie markerów/etykiet po wyrenderowaniu warstwy OSM, aby wszystkie nazwy były czytelne. 

### Description
- Dodano funkcję `spreadOsmOverlayMarkers()` implementującą prosty algorytm rozstawiania w przestrzeni ekranu (szukanie wolnego miejsca po pierścieniach) i ustawiającą nowe pozycje markerów. 
- Funkcja jest wywoływana po utworzeniu i dodaniu markerów w `renderOsmOverlay`, dzięki czemu etykiety są natychmiast rozdzielane po załadowaniu danych. 
- Oryginalne współrzędne każdego markera są przechowywane w polu `._osmOriginalLatLng`, aby przesunięcia były zawsze liczone względem rzeczywistej pozycji. 
- Parametry algorytmu (np. `minDistancePx`, `ringStepPx`, `maxRing`) są zadeklarowane wewnątrz funkcji i można je dostosować w razie potrzeby. 

### Testing
- Uruchomiono składniową próbę `node --check index.html`, która zwróciła błąd ponieważ `node --check` nie obsługuje plików `.html` (niepowodzenie testu z powodu nieodpowiedniego narzędzia). 
- Nie uruchomiono dodatkowych automatycznych testów jednostkowych ani integracyjnych na zmodyfikowanym kodzie w tym PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032f303a28833097952f8e9d5a64ac)