### PR TITLE
Zmniejszenie odstępów nazw OSM i pionowe piętrowanie etykiet

### DIFF
--- a/index.html
+++ b/index.html
@@ -5607,36 +5607,30 @@ function emojiHtml(str) {
           }
         });
         if (!markers.length) return;
+
         const placedPoints = [];
-        const minDistancePx = 46;
-        const ringStepPx = 26;
-        const maxRing = 7;
+        const minHorizontalDistancePx = 18;
+        const verticalStepPx = 15;
+        const maxStackLevels = 10;
 
         markers.forEach((marker) => {
           const originalLatLng = marker._osmOriginalLatLng || marker.getLatLng();
           const centerPoint = map.latLngToLayerPoint(originalLatLng);
           let chosenPoint = centerPoint;
-          let foundSpot = false;
-          for (let ring = 0; ring <= maxRing && !foundSpot; ring++) {
-            const radius = ring * ringStepPx;
-            const candidates = ring === 0
-              ? [centerPoint]
-              : Array.from({ length: Math.max(8, ring * 10) }, (_, i) => {
-                  const angle = (2 * Math.PI * i) / Math.max(8, ring * 10);
-                  return L.point(
-                    centerPoint.x + Math.cos(angle) * radius,
-                    centerPoint.y + Math.sin(angle) * radius
-                  );
-                });
-            for (const candidate of candidates) {
-              const collides = placedPoints.some((placed) => candidate.distanceTo(placed) < minDistancePx);
-              if (!collides) {
-                chosenPoint = candidate;
-                foundSpot = true;
-                break;
-              }
+
+          for (let level = 0; level <= maxStackLevels; level++) {
+            const candidate = L.point(centerPoint.x, centerPoint.y + (level * verticalStepPx));
+            const collides = placedPoints.some((placed) => {
+              const dx = Math.abs(candidate.x - placed.x);
+              const dy = Math.abs(candidate.y - placed.y);
+              return dx < minHorizontalDistancePx && dy < verticalStepPx;
+            });
+            if (!collides) {
+              chosenPoint = candidate;
+              break;
             }
           }
+
           placedPoints.push(chosenPoint);
           marker.setLatLng(map.layerPointToLatLng(chosenPoint));
         });


### PR DESCRIPTION
### Motivation
- Użytkownik zgłosił, że etykiety miejsc OSM przy bliskich obiektach są rozstrzelone zbyt daleko od siebie i powinny być wyświetlane jedna pod drugą z minimalnym marginesem.
- Celem było zmniejszyć pozycjonowanie w poziomie i ustawić prosty, przewidywalny układ „piętrowy”, aby nazwy były bliżej siebie i czytelne przy skupiskach punktów.
- Zmiana ma poprawić estetykę i użyteczność nakładki OSM bez wprowadzania nowych zależności.

### Description
- Zmieniono implementację `spreadOsmOverlayMarkers` w `index.html` tak, by zastąpić pierścieniowy algorytm rozpraszania pionowym piętrowaniem (stałe `x`, rosnące `y`).
- Usunięto wcześniejszą logikę ringów i kandydatów oraz dodano nowe parametry: `minHorizontalDistancePx = 18`, `verticalStepPx = 15` i `maxStackLevels = 10` dla bliższych odstępów i kontrolowanego przesunięcia w pionie.
- Markery są teraz pozycjonowane przez konwersję punktów warstwy na współrzędne mapy przy użyciu `map.layerPointToLatLng` i zapisywane w prostszej liście `placedPoints`.

### Testing
- Przeprowadzono inspekcje kodu przy pomocy `rg` w celu zlokalizowania sekcji OSM oraz `sed`/`nl` do podglądu zmienionego bloku funkcji i obie komendy zakończyły się sukcesem.
- Zastosowano łatkę poprzez prosty skrypt Python, który zgłosił `patched` po wprowadzeniu zamiany, co potwierdza poprawne wstrzyknięcie zmian.
- Utworzono PR przy użyciu narzędzia pomocniczego (`make_pr`) i zweryfikowano zmodyfikowany fragment pliku, wszystkie kroki automatyczne zakończyły się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03319842e883308e1dcfac2921db83)