### PR TITLE
Dodaj przycisk "+ Do tripa" w popupie miejsc OSM

### DIFF
--- a/index.html
+++ b/index.html
@@ -5581,13 +5581,21 @@ function emojiHtml(str) {
           const marker = L.marker([lat, lng], { icon: getOsmIcon(names), keyboard: false });
           const popupItems = items.map((item) => `<div><strong>${escapeHtml(item.name)}</strong><br><span>${escapeHtml(item.typeLabel)}</span></div>`).join('<hr style="border:none;border-top:1px solid rgba(255,255,255,0.22);margin:6px 0;">');
           const googleMapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${lat},${lng}`)}`;
-          const popupHtml = `<div class="osm-popup">${popupItems}<small>Źródło: OpenStreetMap</small><br><a href="${googleMapsUrl}" target="_blank" rel="noopener noreferrer">Otwórz w Google Maps</a><br><button class="osm-import-pin">Dodaj jako pinezkę</button></div>`;
+          const popupHtml = `<div class="osm-popup">${popupItems}<small>Źródło: OpenStreetMap</small><br><a href="${googleMapsUrl}" target="_blank" rel="noopener noreferrer">Otwórz w Google Maps</a><div style="height:8px"></div><button class="osm-trip-add-btn">+ Do tripa</button><br><button class="osm-import-pin">Dodaj jako pinezkę</button></div>`;
           marker.bindPopup(popupHtml);
           marker.on('popupopen', (evt) => {
-            const btn = evt.popup.getElement()?.querySelector('.osm-import-pin');
+            const popupEl = evt.popup.getElement();
+            const btn = popupEl?.querySelector('.osm-import-pin');
+            const tripBtn = popupEl?.querySelector('.osm-trip-add-btn');
+            const first = items[0];
+            if (tripBtn) {
+              tripBtn.addEventListener('click', async () => {
+                await addPointToTripFromData({ id: `cp_${Date.now()}`, type: 'custom', name: first.name, lat: first.lat, lng: first.lng, emoji: '📍', tripOnly: true, defaultPointType: 'inny', defaultVisitMinutes: 45 });
+                map.closePopup();
+              }, { once: true });
+            }
             if (!btn) return;
             btn.addEventListener('click', () => {
-              const first = items[0];
               openNewPinPopupWithDefaults(L.latLng(first.lat, first.lng), { nazwa: first.name, opis: `Źródło: OpenStreetMap\nTyp: ${first.typeLabel}`, warstwa: 'OSM import' });
               map.closePopup();
             }, { once: true });


### PR DESCRIPTION
### Motivation
- Użytkownik chce w popupie miejsc z nakładki OSM dodać przycisk „+ Do tripa”, który doda punkt tylko do planu tripa (nie tworząc głównej pinezki). 
- Ma być też odstęp między linkiem `Otwórz w Google Maps` a sekcją przycisków zgodnie z UX.

### Description
- Zaktualizowano `index.html` w funkcji renderującej popupy OSM, dodając w HTML przycisk `<button class="osm-trip-add-btn">+ Do tripa</button>` oraz `div` z wysokością `8px` dla odstępu pomiędzy linkiem a akcjami.
- Dodano obsługę `popupopen`, która znajduje element `osm-trip-add-btn` i wiąże z nim handler wywołujący istniejącą funkcję `addPointToTripFromData(...)`, tworząc punkt typu `custom` z `tripOnly: true` (czyli punkt widoczny tylko w planie tripa).
- Zachowano dotychczasowy przycisk `Dodaj jako pinezkę` i jego handler bez zmian, oraz uporządkowano pobieranie referencji do elementów popupu tak oba przyciski działają niezależnie.

### Testing
- Nie uruchomiono automatycznych testów dla tej zmiany.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0396999e0483308eead9cb01651c33)