### PR TITLE
Podnieś minimalny zoom dla nakładki miejsc OSM

### DIFF
--- a/index.html
+++ b/index.html
@@ -5090,7 +5090,7 @@ function emojiHtml(str) {
       };
 
       const osmOverlayCache = new Map();
-      const OSM_OVERLAY_MIN_ZOOM = 12;
+      const OSM_OVERLAY_MIN_ZOOM = 14;
       const OSM_OVERLAY_COOLDOWN_MS = 30000;
       const OVERPASS_ENDPOINTS = [
         'https://overpass-api.de/api/interpreter',


### PR DESCRIPTION
### Motivation
- Użytkownik chciał, aby miejsca z OpenStreetMap (nakładka OSM) zaczynały się pojawiać dopiero przy większym przybliżeniu mapy.

### Description
- Zmieniono wartość `OSM_OVERLAY_MIN_ZOOM` w `index.html` z `12` na `14`, przez co nakładka miejsc OSM będzie ładowana i renderowana dopiero przy wyższym poziomie zoomu.

### Testing
- Wykonano wyszukiwanie (`rg`) by zlokalizować stałą, zastosowano skrypt Pythona do aktualizacji pliku, zweryfikowano zmianę poleceniem `nl` oraz zatwierdzono modyfikację przez `git commit`; wszystkie kroki zakończyły się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a039b7893cc8330ba200fe206d89dfd)