### PR TITLE
Prevent layers from expanding when reordered

### DIFF
--- a/index.html
+++ b/index.html
@@ -7147,7 +7147,7 @@ function zaladujPinezkiZFirestore() {
           lista.insertBefore(draggedLayer, div);
           saveLayerOrder({ markChange: false });
           autosaveLayerOrderToFirestore(loadLayerOrder());
-          generujListeWarstw();
+          updateLayerNumbers();
         }
       });
 
@@ -7175,7 +7175,7 @@ function zaladujPinezkiZFirestore() {
         document.removeEventListener('pointercancel', endPointerDrag);
         saveLayerOrder({ markChange: false });
         autosaveLayerOrderToFirestore(loadLayerOrder());
-        generujListeWarstw();
+        updateLayerNumbers();
       };
       handle.addEventListener('pointerdown', (event) => {
         if (event.button !== 0 && event.pointerType !== 'touch') return;


### PR DESCRIPTION
### Motivation
- Reordering layers caused a full regeneration of the layer list which reset UI state and unintentionally expanded collapsed layers, so reorders should preserve per-layer collapse state.

### Description
- Replaced calls to `generujListeWarstw()` with `updateLayerNumbers()` inside `setupDrag` in `index.html` for both the HTML5 `drop` flow and the pointer-based drag end flow.
- The change continues to call `saveLayerOrder()` and `autosaveLayerOrderToFirestore(loadLayerOrder())` so stored order and Firestore autosave remain unchanged while avoiding full list reconstruction.

### Testing
- Verified the source diff with `git diff -- index.html | sed -n '1,120p'` and confirmed the two replacements were applied successfully. 
- Confirmed the committed change via `git commit` output and ensured the working tree is clean with `git status --short`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a81cc8008330bceebee49912ecbe)