### PR TITLE
Fix mobile trip planner mode activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -11497,7 +11497,14 @@ function confirmLayerDelete() {
       document.getElementById('modeTripBtn')?.classList.toggle('active', mode === 'trip');
       document.body.classList.toggle('trip-planner-mode', mode === 'trip');
       const tripPanel = document.getElementById('tripPlannerPanel');
-      if (tripPanel) tripPanel.style.display = mode === 'trip' ? 'block' : 'none';
+      if (tripPanel) {
+        tripPanel.style.display = mode === 'trip' ? 'block' : 'none';
+      }
+      const sidebar = document.getElementById('sidebar');
+      if (mode === 'trip' && document.body.classList.contains('mobile-layout') && sidebar) {
+        sidebar.classList.add('show');
+        requestAnimationFrame(() => tripPanel?.scrollIntoView({ behavior: 'smooth', block: 'start' }));
+      }
       document.getElementById('toggleLayers').textContent = mode === 'trip' ? '☰ Plan tripu' : '☰ Warstwy';
       renderTripMapLayers();
       applyTripPlannerPinVisibility();


### PR DESCRIPTION
### Motivation
- On mobile the "Plan tripu" panel could remain out of view when switching modes because the sidebar was closed or the panel wasn't scrolled into view, so users did not see the planner UI even though mode changed.

### Description
- Updated `setTripMode` in `index.html` to ensure the trip panel is visible on mobile by adding `sidebar.classList.add('show')` and calling `requestAnimationFrame(() => tripPanel?.scrollIntoView({ behavior: 'smooth', block: 'start' }))`, and wrapped the `tripPanel.style.display` assignment in a block.

### Testing
- Verified the diff with `git diff -- index.html | sed -n '1,120p'`, which showed the intended modifications and succeeded.
- Committed the change with `git add index.html && git commit -m "Fix mobile trip planner mode activation"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a041485fccc8330b6884c702ef2b6f6)