### PR TITLE
Improve mobile resilience for 'Plan tripu' mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -830,6 +830,8 @@ body, #sidebar, #basemap-switcher {
 .trip-mode-toggle { display:flex; gap:6px; margin:8px 0; }
 .trip-mode-toggle button { flex:1; background:#1d2028; color:#ddd; border:1px solid var(--ui-border); border-radius:var(--ui-radius-sm); padding:6px; }
 .trip-mode-toggle button.active { background:var(--ui-accent); color:#fff; border-color:var(--ui-accent); }
+body.trip-planner-mode #tripPlannerPanel { display:block !important; }
+body.trip-planner-mode .trip-mode-toggle { display:flex !important; }
 .trip-planner-panel { background:#17191f; border:1px solid var(--ui-border); border-radius:var(--ui-radius-sm); padding:8px; margin-bottom:8px; }
 .trip-select-row { display:flex; gap:6px; margin-bottom:8px; }
 .trip-planner-toggle-row { margin-top:8px; padding-top:8px; border-top:1px solid var(--ui-border); }
@@ -11491,6 +11493,53 @@ function confirmLayerDelete() {
   }
 
     function reset(){ els.start.disabled=false; els.stop.disabled=true; abortFlag=false; }
+    let tripModeTapLock = 0;
+
+    async function activateTripModeFromEvent(e) {
+      if (e) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      const now = Date.now();
+      if (now - tripModeTapLock < 350) return;
+      tripModeTapLock = now;
+
+      console.log('Plan tripu clicked', e?.type);
+
+      setTripMode('trip');
+
+      const tripPanel = document.getElementById('tripPlannerPanel');
+      if (tripPanel) {
+        tripPanel.style.display = 'block';
+      }
+
+      const user = firebase.auth().currentUser;
+      if (!user) {
+        showToast('Najpierw zaloguj się');
+        return;
+      }
+
+      await loadTrips();
+      renderTripPlannerPanel();
+      renderTripMapLayers();
+      applyTripPlannerPinVisibility();
+
+      if (document.body.classList.contains('mobile-layout')) {
+        const sidebar = document.getElementById('sidebar');
+        sidebar?.classList.add('show');
+        setTimeout(() => tripPanel?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 100);
+      }
+    }
+
+    function activatePinsModeFromEvent(e) {
+      if (e) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      console.log('Pinezki clicked', e?.type);
+      setTripMode('pins');
+    }
+
     function setTripMode(mode) {
       tripPlannerMode = mode;
       document.getElementById('modePinsBtn')?.classList.toggle('active', mode === 'pins');
@@ -11503,19 +11552,26 @@ function confirmLayerDelete() {
       const sidebar = document.getElementById('sidebar');
       if (mode === 'trip' && document.body.classList.contains('mobile-layout') && sidebar) {
         sidebar.classList.add('show');
-        requestAnimationFrame(() => tripPanel?.scrollIntoView({ behavior: 'smooth', block: 'start' }));
       }
       document.getElementById('toggleLayers').textContent = mode === 'trip' ? '☰ Plan tripu' : '☰ Warstwy';
       renderTripMapLayers();
       applyTripPlannerPinVisibility();
     }
-    document.getElementById('modePinsBtn')?.addEventListener('click', () => setTripMode('pins'));
-    document.getElementById('modeTripBtn')?.addEventListener('click', async () => {
-      setTripMode('trip');
-      const user = firebase.auth().currentUser;
-      if (!user) { showToast('Najpierw zaloguj się'); return; }
-      await loadTrips();
-    });
+
+    const modePinsBtn = document.getElementById('modePinsBtn');
+    const modeTripBtn = document.getElementById('modeTripBtn');
+
+    if (modePinsBtn) {
+      modePinsBtn.addEventListener('click', activatePinsModeFromEvent);
+      modePinsBtn.addEventListener('touchend', activatePinsModeFromEvent, { passive: false });
+      modePinsBtn.addEventListener('pointerup', activatePinsModeFromEvent);
+    }
+
+    if (modeTripBtn) {
+      modeTripBtn.addEventListener('click', activateTripModeFromEvent);
+      modeTripBtn.addEventListener('touchend', activateTripModeFromEvent, { passive: false });
+      modeTripBtn.addEventListener('pointerup', activateTripModeFromEvent);
+    }
     document.getElementById('tripSelect')?.addEventListener('change', e => { activeTripId = e.target.value || null; activeTripDayId = null; renderTripPlannerPanel(); renderTripMapLayers(); applyTripPlannerPinVisibility(); });
     document.getElementById('tripPinsVisibilityToggle')?.addEventListener('click', () => { hideMainPinsInTripMode = !hideMainPinsInTripMode; applyTripPlannerPinVisibility(); });
     document.getElementById('tripNewBtn')?.addEventListener('click', async () => {


### PR DESCRIPTION
### Motivation
- Fix mobile where `Plan tripu` did not reliably open the trip planner because only a click-only handler was used and touch/pointer sequences conflicted or were ignored.
- Prevent duplicate activations from combined `touchend`/`pointerup`/`click` events and ensure the sidebar/panel opens reliably on mobile.
- Avoid forcing an immediate `scrollIntoView` during mode switch on mobile to prevent layout/jump issues before trip data is loaded.

### Description
- Added shared handlers `activateTripModeFromEvent` and `activatePinsModeFromEvent` that call `preventDefault`/`stopPropagation`, log the event type, set mode, show the panel, validate auth, call `loadTrips()` and run the render/visibility updates.
- Introduced a `tripModeTapLock` debounce (350 ms) to ignore duplicate taps and replaced the old click-only listeners with `click`, `touchend` (with `{ passive: false }`) and `pointerup` listeners for `#modePinsBtn` and `#modeTripBtn`.
- Removed the immediate `requestAnimationFrame(() => tripPanel?.scrollIntoView(...))` from `setTripMode` and moved the mobile scroll to a delayed `setTimeout(..., 100)` executed after trips are loaded and UI rendered.
- Added CSS fallbacks `body.trip-planner-mode #tripPlannerPanel { display:block !important; }` and `body.trip-planner-mode .trip-mode-toggle { display:flex !important; }` to ensure the planner panel and toggle stay visible when `trip-planner-mode` is active.

### Testing
- Ran a repository search for `modeTripBtn|modePinsBtn|setTripMode|tripPlannerPanel|trip-mode-toggle|scrollIntoView` and confirmed the new handlers and CSS were added.
- Inspected the `index.html` diff to verify the new functions, listener replacements, debounce, and removal of the immediate `scrollIntoView` call; the verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0418353cd08330822007d5269f19ba)