### PR TITLE
Poprawka UI (mobile): z-index przycisku ZAPISZ PIN i statusu OSM + spinner

### DIFF
--- a/index.html
+++ b/index.html
@@ -1978,6 +1978,19 @@ img.emoji {
       border: 1px solid rgba(255,255,255,0.22);
       pointer-events: none;
       max-width: min(80vw, 360px);
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    #osmOverlayStatus::before {
+      content: '';
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      border: 2px solid rgba(255, 255, 255, 0.32);
+      border-top-color: #9bc4ff;
+      animation: spin 0.9s linear infinite;
+      flex: 0 0 auto;
     }
     #osmOverlayStatus.osm-status-success { border-color: rgba(67, 197, 110, 0.7); }
     #osmOverlayStatus.osm-status-loading { border-color: rgba(88, 161, 255, 0.8); }
@@ -1986,6 +1999,15 @@ img.emoji {
     body.dark-mode .osm-overlay-label {
       color: #a6f6ffc9;
     }
+
+    @media (max-width: 800px) {
+      #osmOverlayStatus {
+        right: 10px;
+        bottom: 88px;
+        max-width: min(78vw, 300px);
+      }
+    }
+
     #overlay-item-osm.active {
       box-shadow: inset 0 0 0 1px var(--ui-accent, #007bff);
       border-radius: 6px;

--- a/style.css
+++ b/style.css
@@ -251,7 +251,7 @@
 }
 
 @media (max-width: 800px) {
-  #savePinBtn { display: block; }
+  #savePinBtn { display: block; z-index: 250; }
 }
 
 #centerMarker {


### PR DESCRIPTION
### Motivation
- Na mobile przycisk `ZAPISZ PIN` zasłaniał panel boczny warstw i wymagał korekty stacking orderu oraz przesunięcia statusu ładowania miejsc OSM, żeby nie nachodził na przycisk.
- Dodatkowo chciano mieć jasny, mały wskaźnik ładowania obok tekstu statusu OSM zarówno na desktop jak i mobile.

### Description
- Zmieniono `style.css`, w media query `@media (max-width: 800px)` ustawiając `#savePinBtn` na `z-index: 250` aby nie przykrywał panelu bocznego.
- Zaktualizowano `index.html` CSS dla `#osmOverlayStatus` aby używał `display: inline-flex; align-items: center; gap: 8px;` i dodać pseudo-element `#osmOverlayStatus::before` pełniący rolę animowanego, małego spinnera.
- Dodano mobilne dostosowanie pozycji statusu OSM w media query (`right: 10px; bottom: 88px; max-width: min(78vw, 300px);`) aby nie nachodził na przycisk zapisu.
- Modyfikacje dotyczą wyłącznie prezentacji (CSS) i nie zmieniają logiki JavaScript.

### Testing
- Brak testów automatycznych dla zmian prezentacyjnych CSS w tym PR.
- Zmiany zostały sprawdzone lokalnie poprzez inspekcję plików i porównanie różnic CSS/HTML.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a041ac9589c83308224303d7e63919b)