### PR TITLE
Popraw mobilny panel „Plan tripu” i ustaw menu burger po prawej

### DIFF
--- a/index.html
+++ b/index.html
@@ -1899,6 +1899,20 @@ img.emoji {
     }
 
     @media (max-width: 700px) {
+      .sidebar-header {
+        align-items: center;
+      }
+
+      #specialMenu {
+        order: 2;
+        margin-bottom: 0;
+        margin-left: auto;
+      }
+
+      #logoNaglowek {
+        order: 1;
+      }
+
       #mobileControlsToggle {
         display: flex;
         margin-bottom: 6px;
@@ -2094,6 +2108,14 @@ img.emoji {
       </div>
       </div>
       <button id="loadPinsBtn">Załaduj pinezki</button>
+      <div id="mainCategoryFilters" class="main-category-filters">
+        <div class="main-category-title">Kategoria główna</div>
+        <div class="main-category-options">
+          <label><input type="checkbox" id="maincat-urbex" checked> URBEX</label>
+          <label><input type="checkbox" id="maincat-turystyczne" checked> TURYSTYCZNE</label>
+        </div>
+      </div>
+      <div id="pinTotalCounter" class="pin-total-counter">Liczba miejsc: 0</div>
       <div id="tripPlannerPanel" class="trip-planner-panel" style="display:none;">
         <h3>Plan tripu</h3>
         <div class="trip-select-row">
@@ -2105,14 +2127,6 @@ img.emoji {
         </div>
         <div id="tripActiveBox"></div>
       </div>
-      <div id="mainCategoryFilters" class="main-category-filters">
-        <div class="main-category-title">Kategoria główna</div>
-        <div class="main-category-options">
-          <label><input type="checkbox" id="maincat-urbex" checked> URBEX</label>
-          <label><input type="checkbox" id="maincat-turystyczne" checked> TURYSTYCZNE</label>
-        </div>
-      </div>
-      <div id="pinTotalCounter" class="pin-total-counter">Liczba miejsc: 0</div>
       <div id="lista-warstw"></div>
       <button id="syncBtn">Synchronizuj (<span id="syncCount">0</span>)</button>
     </div>


### PR DESCRIPTION
### Motivation
- Na mobilnej wersji panel „Plan tripu” bywał niewidoczny lub wyświetlał się poza obszarem listy warstw, więc trzeba go wyświetlać w tym samym miejscu co panel warstw.
- Burger menu powinno na mobilkach być wyrównane po prawej stronie nagłówka, bez wpływu na układ desktopowy.

### Description
- Przeniesiono blok `#tripPlannerPanel` w `index.html`, tak aby renderował się bezpośrednio przed `#lista-warstw` w sidebarze, co poprawia jego widoczność na mobilkach.
- Usunięto zduplikowane wystąpienie sekcji filtra/licznika (zachowano jednolitą kolejność elementów `#mainCategoryFilters`, `#pinTotalCounter` i `#tripPlannerPanel`).
- Dodano reguły CSS w `@media (max-width: 700px)` ustawiające `.sidebar-header { align-items: center; }`, `#specialMenu { order: 2; margin-left: auto; }` oraz `#logoNaglowek { order: 1; }` aby przesunąć menu burgerowe na prawą stronę tylko na mobilkach.
- Zmiany są zawarte w pojedynczym pliku `index.html` (HTML + inline CSS) i nie modyfikują logiki JavaScript.

### Testing
- Zweryfikowano zmiany struktury i stylów przez przegląd diffu (`git diff`), który pokazał relokację i dodane reguły CSS, oraz te kroki zakończyły się pomyślnie.
- Potwierdzono zawartość pliku za pomocą `nl`/`sed` aby sprawdzić nowe miejsce `#tripPlannerPanel` i reguły w `@media (max-width: 700px)`, co zakończyło się pomyślnie.
- Commit zawierający zmiany został utworzony lokalnie bez błędów.
- Nie uruchamiano testów jednostkowych ani end-to-end w ramach tej zmiany.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0435a7825883308252d3ceab16c125)