### PR TITLE
Ujednolicenie rozmiarów przycisków i domyślny stan przycisku warstw

### DIFF
--- a/index.html
+++ b/index.html
@@ -829,6 +829,7 @@ body, #sidebar, #basemap-switcher {
 }
 .trip-mode-toggle { display:flex; gap:6px; margin:8px 0; }
 .trip-mode-toggle button { flex:1; background:#1d2028; color:#ddd; border:1px solid var(--ui-border); border-radius:var(--ui-radius-sm); padding:6px; }
+.trip-mode-toggle #modePinsBtn,.trip-mode-toggle #modeTripBtn { flex:1 1 0; min-width:0; white-space:nowrap; }
 .trip-mode-toggle button.active { background:var(--ui-accent); color:#fff; border-color:var(--ui-accent); }
 body.trip-planner-mode #tripPlannerPanel { display:block !important; }
 body.trip-planner-mode .trip-mode-toggle { display:flex !important; }
@@ -1630,9 +1631,11 @@ img.emoji {
       margin-top: 0;
       flex: 1 1 0;
       width: auto;
-      min-height: 26px;
-      font-size: 12px;
-      line-height: 1.2;
+      min-height: 24px;
+      font-size: 11px;
+      line-height: 1.1;
+      padding: 3px 4px;
+      white-space: nowrap;
     }
 
     #addLayerBtn {
@@ -3425,6 +3428,7 @@ function slugify(str) {
     const toggleVisibilityBtn = document.getElementById('toggleVisibility');
     let allLayersCollapsed = true;
     let allLayersVisible = true;
+    let layerVisibilityToggleInitialized = false;
     const hideNewLayerControls = () => {
       if (!newLayerControls) return;
       newLayerControls.style.display = 'none';
@@ -9988,7 +9992,12 @@ function getTripPointEmoji(p) {
       }
 
       applySearchFilter();
-      allLayersVisible = Object.values(warstwy).every(w => w.visible);
+      if (!layerVisibilityToggleInitialized) {
+        allLayersVisible = true;
+        layerVisibilityToggleInitialized = true;
+      } else {
+        allLayersVisible = Object.values(warstwy).every(w => w.visible);
+      }
       if (toggleVisibilityBtn) {
         toggleVisibilityBtn.textContent = allLayersVisible ? 'Ukryj wszystkie warstwy' : 'Pokaż wszystkie warstwy';
       }


### PR DESCRIPTION
### Motivation
- Przyciski trybu (`modePinsBtn` i `modeTripBtn`) powinny mieć jednakową szerokość, aby etykiety nie zawijały się i wyglądały spójnie.
- Przycisk widoczności warstw powinien domyślnie proponować akcję ukrycia (najpierw umożliwić ukrycie, a dopiero potem przełączać na „Pokaż”).
- Przyciski `Rozwiń wszystkie warstwy` i `Ukryj/Pokaż wszystkie warstwy` wymagają mniejszych wymiarów, aby tekst mieścił się w jednej linii.

### Description
- Dodano CSS `.trip-mode-toggle #modePinsBtn, .trip-mode-toggle #modeTripBtn` z `flex:1 1 0`, `min-width:0` i `white-space:nowrap` aby wyrównać i zapobiec zawijaniu etykiet na przyciskach trybu.
- Zmodyfikowano styl `.layer-actions-row #collapseAllLayers, .layer-actions-row #toggleVisibility` aby zmniejszyć `min-height`, `font-size` i `padding`, oraz dodać `white-space: nowrap` by zmieścić tekst w jednym wierszu.
- Dodano flagę `layerVisibilityToggleInitialized` oraz logikę w funkcji generującej listę warstw, która ustawia `allLayersVisible = true` tylko przy pierwszym renderze, dzięki czemu przy pierwszym wejściu etykieta przycisku widoczności pokazuje `Ukryj wszystkie warstwy`.
- Wszystkie zmiany zostały wprowadzone w `index.html` (CSS + fragmenty JS odpowiedzialne za listę i stan widoczności warstw).

### Testing
- Wyszukano i zweryfikowano wystąpienia zmienianych identyfikatorów i fragmentów kodu przy pomocy `rg`, co potwierdziło lokalizację reguł i fragmentów JS — sukces.
- Zastosowano i uruchomiono skrypt Pythona do wstawienia poprawek w pliku `index.html`, który zakończył się pomyślnie — sukces.
- Potwierdzono wynik zmian i liniową lokalizację reguł przez przeglądanie pliku przy pomocy `sed`/`nl`, a zmienione fragmenty odpowiadają oczekiwanym efektom — sukces.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0437ea1370833098c358612f59987b)