### PR TITLE
Poprawa płynności wczytywania pinezek przy oddalaniu mapy

### DIFF
--- a/index.html
+++ b/index.html
@@ -9621,6 +9621,8 @@ function getTripPointEmoji(p) {
     }
 
     let markerViewportUpdateScheduled = false;
+    let markerVisibilityDebounceTimer = null;
+    let markerVisibilityJobToken = 0;
 
     function pinIsInViewport(pin, paddedBounds) {
       if (!pin || typeof pin.lat !== 'number' || typeof pin.lng !== 'number') return false;
@@ -9629,54 +9631,83 @@ function getTripPointEmoji(p) {
     }
 
     function scheduleMarkerVisibilityUpdate() {
-      if (markerViewportUpdateScheduled) return;
-      markerViewportUpdateScheduled = true;
-      showLoading();
-      requestAnimationFrame(() => {
+      if (markerVisibilityDebounceTimer) clearTimeout(markerVisibilityDebounceTimer);
+      markerVisibilityDebounceTimer = setTimeout(() => {
+        if (markerViewportUpdateScheduled) return;
+        markerViewportUpdateScheduled = true;
+        showLoading();
         requestAnimationFrame(() => {
-          markerViewportUpdateScheduled = false;
-          try {
-            updateMarkerVisibility();
-          } finally {
-            hideLoading();
-          }
+          requestAnimationFrame(() => {
+            const jobToken = ++markerVisibilityJobToken;
+            updateMarkerVisibility(jobToken).finally(() => {
+              if (jobToken === markerVisibilityJobToken) {
+                markerViewportUpdateScheduled = false;
+                hideLoading();
+              }
+            });
+          });
         });
-      });
+      }, 120);
     }
 
-    function updateMarkerVisibility() {
+    function updateMarkerVisibility(jobToken = 0) {
       const paddedBounds = map ? map.getBounds().pad(0.15) : null;
       const changedLayers = new Set();
+      const items = [];
       Object.values(warstwy).forEach(w => {
         w.lista.forEach(p => {
-          if (!p.marker) return;
-          const visibleByFilters = pinMatchesAllFilters(p, true);
-          const visible = visibleByFilters && pinIsInViewport(p, paddedBounds);
-          if (visible) {
-            if (!w.layer.hasLayer(p.marker)) {
-              w.layer.addLayer(p.marker);
-              changedLayers.add(w.layer);
-            }
-          } else {
-            if (w.layer.hasLayer(p.marker)) {
-              w.layer.removeLayer(p.marker);
-              changedLayers.add(w.layer);
-            }
-          }
-          updatePlanVisibilityForPin(p);
+          items.push({ w, p });
         });
       });
-      changedLayers.forEach(layer => {
-        // refreshClusters() potrafi rzucać wyjątek w niektórych stanach MarkerCluster.
-        // Pomijamy odświeżanie klastrów, aby nie przerywać generowania listy warstw.
-        if (layer && typeof layer.fire === 'function') {
-          layer.fire('animationend');
-        }
+
+      return new Promise(resolve => {
+        const BATCH_SIZE = 250;
+        let index = 0;
+        const processBatch = () => {
+          if (jobToken && jobToken !== markerVisibilityJobToken) return resolve();
+          const end = Math.min(index + BATCH_SIZE, items.length);
+          for (; index < end; index++) {
+            const { w, p } = items[index];
+            if (!p.marker) continue;
+            const visibleByFilters = pinMatchesAllFilters(p, true);
+            const visible = visibleByFilters && pinIsInViewport(p, paddedBounds);
+            if (visible) {
+              if (!w.layer.hasLayer(p.marker)) {
+                w.layer.addLayer(p.marker);
+                changedLayers.add(w.layer);
+              }
+            } else {
+              if (w.layer.hasLayer(p.marker)) {
+                w.layer.removeLayer(p.marker);
+                changedLayers.add(w.layer);
+              }
+            }
+            updatePlanVisibilityForPin(p);
+          }
+
+          if (index < items.length) {
+            requestAnimationFrame(processBatch);
+            return;
+          }
+
+          changedLayers.forEach(layer => {
+            // refreshClusters() potrafi rzucać wyjątek w niektórych stanach MarkerCluster.
+            // Pomijamy odświeżanie klastrów, aby nie przerywać generowania listy warstw.
+            if (layer && typeof layer.fire === 'function') {
+              layer.fire('animationend');
+            }
+          });
+          resolve();
+        };
+        processBatch();
       });
     }
 
     function generujListeWarstw() {
-      updateMarkerVisibility();
+      const jobToken = ++markerVisibilityJobToken;
+      updateMarkerVisibility(jobToken).finally(() => {
+        if (jobToken === markerVisibilityJobToken) markerViewportUpdateScheduled = false;
+      });
       layerDomRefs = {};
       const lista = document.getElementById("lista-warstw");
       const pinTotalCounter = document.getElementById("pinTotalCounter");


### PR DESCRIPTION
### Motivation
- Przy dużej liczbie pinezek szybkie oddalanie/poruszanie mapą powodowało zawieszanie UI z powodu synchronicznych operacji dodawania/usuwania markerów na głównym wątku.
- Celem zmiany jest rozłożenie kosztu aktualizacji widoczności pinezek w czasie i zapobieganie nakładaniu się przestarzałych zadań aktualizacyjnych.

### Description
- Dodano debounce (120 ms) w `scheduleMarkerVisibilityUpdate` aby uniknąć uruchamiania ciężkiej aktualizacji przy każdym szybkim zdarzeniu `moveend/zoomend`.
- Wprowadzono token zadania (`markerVisibilityJobToken`) do anulowania/stłumienia przestarzałych przebiegów aktualizacji, tak aby tylko najnowsze zadanie kontynuowało pracę.
- Przebudowano `updateMarkerVisibility` na wersję asynchroniczną zwracającą `Promise`, która przetwarza markery wsadowo (batch po 250 elementów) i używa `requestAnimationFrame` do rozłożenia pracy na kolejne klatki, zachowując dotychczasową logikę filtrów i viewportu.
- `generujListeWarstw()` wywołuje teraz wersję aktualizacji z tokenem, co zapobiega nakładaniu się starszych zadań po szybkich interakcjach z UI.

### Testing
- Nie uruchamiano zautomatyzowanego zestawu testów dla tej zmiany.
- Zmiana została przeglądnięta lokalnie w pliku `index.html` oraz uruchomiona jako poprawka gotowa do testów ręcznych w przeglądarce (smoke-check przed wdrożeniem).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a043c5dc3f88330acd3735df9d5c674)