### PR TITLE
Debounce and batch marker visibility updates to reduce work and use bulk layer ops

### DIFF
--- a/index.html
+++ b/index.html
@@ -9621,6 +9621,7 @@ function getTripPointEmoji(p) {
     }
 
     let markerViewportUpdateScheduled = false;
+    let markerVisibilityDebounceTimer = null;
 
     function pinIsInViewport(pin, paddedBounds) {
       if (!pin || typeof pin.lat !== 'number' || typeof pin.lng !== 'number') return false;
@@ -9629,46 +9630,68 @@ function getTripPointEmoji(p) {
     }
 
     function scheduleMarkerVisibilityUpdate() {
-      if (markerViewportUpdateScheduled) return;
-      markerViewportUpdateScheduled = true;
-      showLoading();
-      requestAnimationFrame(() => {
+      if (markerVisibilityDebounceTimer) clearTimeout(markerVisibilityDebounceTimer);
+      markerVisibilityDebounceTimer = setTimeout(() => {
+        if (markerViewportUpdateScheduled) return;
+        markerViewportUpdateScheduled = true;
+        showLoading();
         requestAnimationFrame(() => {
-          markerViewportUpdateScheduled = false;
-          try {
-            updateMarkerVisibility();
-          } finally {
-            hideLoading();
-          }
+          requestAnimationFrame(() => {
+            try {
+              updateMarkerVisibility();
+            } finally {
+              markerViewportUpdateScheduled = false;
+              hideLoading();
+              markerVisibilityDebounceTimer = null;
+            }
+          });
         });
-      });
+      }, 120);
     }
 
     function updateMarkerVisibility() {
       const paddedBounds = map ? map.getBounds().pad(0.15) : null;
       const changedLayers = new Set();
+      const layerOps = new Map();
+
       Object.values(warstwy).forEach(w => {
+        const toAdd = [];
+        const toRemove = [];
         w.lista.forEach(p => {
           if (!p.marker) return;
           const visibleByFilters = pinMatchesAllFilters(p, true);
           const visible = visibleByFilters && pinIsInViewport(p, paddedBounds);
           if (visible) {
-            if (!w.layer.hasLayer(p.marker)) {
-              w.layer.addLayer(p.marker);
-              changedLayers.add(w.layer);
-            }
+            if (!w.layer.hasLayer(p.marker)) toAdd.push(p.marker);
           } else {
-            if (w.layer.hasLayer(p.marker)) {
-              w.layer.removeLayer(p.marker);
-              changedLayers.add(w.layer);
-            }
+            if (w.layer.hasLayer(p.marker)) toRemove.push(p.marker);
           }
           updatePlanVisibilityForPin(p);
         });
+        if (toAdd.length || toRemove.length) {
+          layerOps.set(w.layer, { toAdd, toRemove });
+        }
       });
+
+      layerOps.forEach((ops, layer) => {
+        if (!layer) return;
+        if (ops.toRemove.length && typeof layer.removeLayers === 'function') {
+          layer.removeLayers(ops.toRemove);
+          changedLayers.add(layer);
+        } else if (ops.toRemove.length) {
+          ops.toRemove.forEach(marker => layer.removeLayer(marker));
+          changedLayers.add(layer);
+        }
+        if (ops.toAdd.length && typeof layer.addLayers === 'function') {
+          layer.addLayers(ops.toAdd);
+          changedLayers.add(layer);
+        } else if (ops.toAdd.length) {
+          ops.toAdd.forEach(marker => layer.addLayer(marker));
+          changedLayers.add(layer);
+        }
+      });
+
       changedLayers.forEach(layer => {
-        // refreshClusters() potrafi rzucać wyjątek w niektórych stanach MarkerCluster.
-        // Pomijamy odświeżanie klastrów, aby nie przerywać generowania listy warstw.
         if (layer && typeof layer.fire === 'function') {
           layer.fire('animationend');
         }


### PR DESCRIPTION
### Motivation
- Reduce redundant marker visibility work and avoid thrashing when many rapid viewport/filter changes occur by debouncing updates with a short delay.
- Improve performance when toggling many markers by batching add/remove operations per layer and using bulk APIs when available.
- Make the visibility update cycle more robust and ensure state flags and timers are cleared reliably after updates complete.

### Description
- Add a debounce timer `markerVisibilityDebounceTimer` and a 120ms delay inside `scheduleMarkerVisibilityUpdate` to coalesce rapid calls and guard `markerViewportUpdateScheduled` correctly.
- Update the animation frame flow so the actual visibility work runs inside nested `requestAnimationFrame` callbacks and ensure `markerViewportUpdateScheduled` and `markerVisibilityDebounceTimer` are reset in the finally block.
- Rework `updateMarkerVisibility` to collect `toAdd`/`toRemove` lists per layer in a `layerOps` map and apply them in bulk using `addLayers`/`removeLayers` when available, with fallbacks to `addLayer`/`removeLayer`.
- Continue tracking `changedLayers` and fire `'animationend'` on each changed layer after updates to trigger any layer-level refresh behavior.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a043c5dc3f88330acd3735df9d5c674)