### PR TITLE
Rozbijanie małych klastrów przy dużym zoomie (CLUSTER_MIN_MARKERS=5, SMALL_CLUSTER_BREAK_ZOOM=11)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2773,7 +2773,8 @@ function slugify(str) {
     const PINTEREST_LAYER_NAME = 'pinterest_diane_g';
     const PINTEREST_PINS_COLLECTION = 'pinterest_diane_g';
     const CLUSTER_DISABLE_AT_ZOOM = 14; // skupiaj pinezki aż do średniego przybliżenia mapy
-    const CLUSTER_MIN_MARKERS = 2; // prawie zawsze pokazuj grupę zamiast pojedynczych pinezek
+    const CLUSTER_MIN_MARKERS = 5; // poniżej tej liczby, od dużego przybliżenia pokazuj pojedyncze pinezki zamiast klastra
+    const SMALL_CLUSTER_BREAK_ZOOM = 11;
     const BIG_CLUSTER_COUNT = 500;
     const MAX_VISIBLE_CLUSTERS_FOR_OVERLAP_MERGE = 1000;
     const CLUSTER_OVERLAP_MERGE_PADDING = 22;
@@ -3071,6 +3072,7 @@ function slugify(str) {
         const clusters = getVisibleTopClusters();
         for (const cluster of clusters) {
           const count = cluster.getChildCount();
+          if (map.getZoom() < SMALL_CLUSTER_BREAK_ZOOM) continue;
           if (count >= CLUSTER_MIN_MARKERS) continue;
           if (typeof cluster.getAllChildMarkers !== 'function') continue;
           const childMarkers = cluster.getAllChildMarkers();


### PR DESCRIPTION
### Motivation
- Poprawić zachowanie klastrowania tak, aby przy dużym powiększeniu małe grupy (<5 pinezek) były rozbijane na pojedyncze markery, podczas gdy większe grupy i logika łączenia dużych/nachodzących klastrów pozostają bez zmian.

### Description
- Zmieniono `const CLUSTER_MIN_MARKERS` z `2` na `5` i zaktualizowano komentarz przy niej, aby odzwierciedlał nowe zachowanie w dużym przybliżeniu.
- Dodano `const SMALL_CLUSTER_BREAK_ZOOM = 11` jako próg zoomu, od którego rozbijane są małe klastry.
- W `renderSmallClustersAsSingleMarkers()` najpierw sprawdzany jest zoom: `if (map.getZoom() < SMALL_CLUSTER_BREAK_ZOOM) continue;` a dopiero potem próg rozmiaru klastra (`if (count >= CLUSTER_MIN_MARKERS) continue;`).

### Testing
- Wykonano przeszukanie kodu z `rg` w celu zlokalizowania zmian oraz zapisano i zmodyfikowano plik `index.html` (modyfikacja zapisana). 
- Uruchomiono `git -C /workspace/ExploMapa status --short` oraz `git -C /workspace/ExploMapa add index.html && git -C /workspace/ExploMapa commit -m "Adjust small-cluster breakup behavior at high zoom"`, oba polecenia zakończyły się powodzeniem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04422416b483308829e45852f0dc41)