### PR TITLE
Ujednolicenie progu klastrowania: klastry od 5 pinezek niezależnie od zoomu

### DIFF
--- a/index.html
+++ b/index.html
@@ -2773,8 +2773,7 @@ function slugify(str) {
     const PINTEREST_LAYER_NAME = 'pinterest_diane_g';
     const PINTEREST_PINS_COLLECTION = 'pinterest_diane_g';
     const CLUSTER_DISABLE_AT_ZOOM = 14; // skupiaj pinezki aż do średniego przybliżenia mapy
-    const CLUSTER_MIN_MARKERS = 5; // poniżej tej liczby, od dużego przybliżenia pokazuj pojedyncze pinezki zamiast klastra
-    const SMALL_CLUSTER_BREAK_ZOOM = 11;
+    const CLUSTER_MIN_MARKERS = 5; // poniżej tej liczby pokazuj pojedyncze pinezki zamiast klastra
     const BIG_CLUSTER_COUNT = 500;
     const MAX_VISIBLE_CLUSTERS_FOR_OVERLAP_MERGE = 1000;
     const CLUSTER_OVERLAP_MERGE_PADDING = 22;
@@ -3008,7 +3007,7 @@ function slugify(str) {
             cluster.getAllChildMarkers().forEach(marker => markerSet.add(marker));
           });
 
-          if (totalChildren < 2) continue;
+          if (totalChildren < CLUSTER_MIN_MARKERS) continue;
           const centerPoint = L.point(weightedX / totalChildren, weightedY / totalChildren);
           const centerLatLng = map.layerPointToLatLng(centerPoint);
           const size = getClusterIconSize(totalChildren);
@@ -3072,7 +3071,6 @@ function slugify(str) {
         const clusters = getVisibleTopClusters();
         for (const cluster of clusters) {
           const count = cluster.getChildCount();
-          if (map.getZoom() < SMALL_CLUSTER_BREAK_ZOOM) continue;
           if (count >= CLUSTER_MIN_MARKERS) continue;
           if (typeof cluster.getAllChildMarkers !== 'function') continue;
           const childMarkers = cluster.getAllChildMarkers();


### PR DESCRIPTION
### Motivation
- Obecne zachowanie tworzy klastry z 2–4 pinezek przy niskim przybliżeniu z powodu warunku zależnego od zoomu, co prowadzi do niepożądanych sztucznych klastrów.
- Należało ujednolicić próg klastrowania tak, aby klaster powstawał dopiero od `CLUSTER_MIN_MARKERS = 5`, niezależnie od zoomu.

### Description
- Usunięto użycie stałej `SMALL_CLUSTER_BREAK_ZOOM` i warunek `map.getZoom() < SMALL_CLUSTER_BREAK_ZOOM` z funkcji `renderSmallClustersAsSingleMarkers()` tak, by decyzja opierała się wyłącznie na liczbie pinezek.
- W `renderSmallClustersAsSingleMarkers()` zostało zachowane sprawdzenie `const count = cluster.getChildCount(); if (count >= CLUSTER_MIN_MARKERS) continue;` aby małe klastry (2–4) zawsze były rozbijane na pojedyncze markery.
- W `mergeStronglyOverlappingClusters()` zmieniono warunek z `if (totalChildren < 2) continue;` na `if (totalChildren < CLUSTER_MIN_MARKERS) continue;` aby zapobiec scalaniu, które mogłoby utworzyć klastry poniżej progu 5.
- Nie zmieniano warstw, filtrów, popupów, funkcji edycji pinezek ani innego zachowania mapy poza logiką klastrowania.

### Testing
- Uruchomiono wyszukiwania w pliku z `rg -n "CLUSTER_MIN_MARKERS|SMALL_CLUSTER_BREAK_ZOOM|renderSmallClustersAsSingleMarkers|mergeStronglyOverlappingClusters|totalChildren <" index.html` i `rg -n "SMALL_CLUSTER_BREAK_ZOOM|totalChildren <|count >= CLUSTER_MIN_MARKERS|CLUSTER_MIN_MARKERS" index.html` aby zweryfikować zamiany, oba polecenia zakończyły się pomyślnie.
- Wyświetlono fragment pliku poleceniem `nl -ba index.html | sed -n '2768,3082p'` aby potwierdzić nowe warunki i usunięcie stałej, co zakończyło się pomyślnie.
- Zmiany zostały zatwierdzone lokalnie przy użyciu `git commit`, które zakończyło się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0443a748d48330b5053b172cd14a1f)