### PR TITLE
Fix active trip day card to scroll internally

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,7 +858,7 @@ body.trip-planner-mode .trip-mode-toggle { display:flex !important; }
 .trip-segment-row,.trip-point-meta { color:var(--ui-text-muted); font-size:11px; }
 .trip-color-input { width:32px; height:24px; padding:0; border:0; background:none; }
 .trip-day-visible-toggle { display:inline-flex; align-items:center; gap:4px; font-size:11px; opacity:.9; }
-.trip-active-day { box-shadow:0 0 0 1px var(--ui-accent) inset; }
+.trip-active-day { box-shadow:0 0 0 1px var(--ui-accent) inset; max-height:45vh; overflow-y:auto; overscroll-behavior:contain; -webkit-overflow-scrolling:touch; }
 .trip-muted-day { opacity:.7; }
 body.trip-planner-mode #sidebarTopControls,
 body.trip-planner-mode #pinTotalCounter,


### PR DESCRIPTION
### Motivation
- The active trip day card should scroll internally when its content overflows so the whole page does not scroll instead of the card.

### Description
- Updated the `.trip-active-day` CSS in `index.html` to add `max-height: 45vh`, `overflow-y: auto`, `overscroll-behavior: contain`, and `-webkit-overflow-scrolling: touch` while keeping the existing inset `box-shadow` highlight.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a057b806f108330a27cf7e60e8ad2fb)