### PR TITLE
Zachowaj widoczne markery kolejności punktów przy ukrytej trasie

### DIFF
--- a/index.html
+++ b/index.html
@@ -8630,9 +8630,8 @@ function getTripPointEmoji(p) {
       if (!trip || !Array.isArray(trip.days)) return;
       ensureActiveTripDay(trip);
       (trip.days || []).forEach(day => {
-        if (day.visible === false) return;
         const pointsSorted = [...(day.points || [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-        (day.routeSegments || []).forEach((seg, segIdx) => {
+        if (day.visible !== false) (day.routeSegments || []).forEach((seg, segIdx) => {
           let coords = (seg.geometry || []).map(c => {
             if (Array.isArray(c)) return [Number(c[0]), Number(c[1])];
             if (c && typeof c === 'object' && Number.isFinite(Number(c.lat)) && Number.isFinite(Number(c.lng))) return [Number(c.lat), Number(c.lng)];


### PR DESCRIPTION
### Motivation
- Zapewnić, że po wyłączeniu widoczności trasy dnia (`day.visible`) numerowane markery punktów (`trip-order-marker-icon`) pozostają widoczne na mapie.

### Description
- W `renderTripMapLayers()` w `index.html` usunięto wczesne `return` dla `day.visible === false` i zmieniono logikę tak, że rysowanie segmentów trasy (`L.polyline`) jest wykonywane tylko gdy `day.visible !== false`, natomiast markery budowane przez `buildTripPointNumberIcon` są zawsze renderowane dla punktów dnia.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a057cc231848330a30c1c86df16ab53)