### PR TITLE
Ukryj przycisk zapisu mapy po udanym zapisie

### DIFF
--- a/index.html
+++ b/index.html
@@ -10167,11 +10167,14 @@ function getTripPointEmoji(p) {
         layersToDelete = [];
         layerEmojiChanges = {};
         layerDefaultVisibilityChanges = {};
+        layerOrderChanged = false;
+        initialLayerOrder = [...orderList];
         pinsToDelete = [];
         window.localTrasy = [];
         localStorage.removeItem('nowePinezki');
         shouldWarnBeforeUnload = false;
         btn.textContent = 'Zapisano ✔';
+        updateSaveButton();
         persistAllLayerCollapseStates();
         persistAllLayerVisibilityStates();
         showToast('Zapisano zmiany mapy.', 5000);


### PR DESCRIPTION
### Motivation
- Po zapisaniu zmian mapy przycisk „Zapisz edycję mapy” powinien znikać i pojawiać się ponownie tylko gdy wystąpią nowe, wymagające zapisu zmiany, ponieważ zmiana kolejności warstw czasami pozostawiała fałszywy stan „niesaved”.

### Description
- Po pomyślnym zakończeniu `zapiszZmiany()` resetuję `layerOrderChanged`, aktualizuję `initialLayerOrder = [...orderList]` i wywołuję `updateSaveButton()`, dzięki czemu lokalny stan zmian zostaje wyczyszczony i przycisk znika od razu.

### Testing
- Uruchomiłem `git diff -- index.html` aby zweryfikować zmiany oraz `git commit` w celu zapisania modyfikacji i oba polecenia wykonały się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05913aa73883308044b1debff309fd)