### PR TITLE
Napraw miganie małych klastrów podczas zoomowania

### DIFF
--- a/index.html
+++ b/index.html
@@ -575,6 +575,9 @@
       color: #fff;
       line-height: 1;
     }
+    .leaflet-zoom-anim .custom-cluster-icon {
+      transition: none !important;
+    }
     .emoji-inline {
 width: 15px;
     height: 15px;
@@ -3108,8 +3111,8 @@ function slugify(str) {
       clusterLayer = L.markerClusterGroup({
         disableClusteringAtZoom: CLUSTER_DISABLE_AT_ZOOM,
         maxClusterRadius: () => 105,
-        animate: true,
-        animateAddingMarkers: true,
+        animate: false,
+        animateAddingMarkers: false,
         spiderfyOnMaxZoom: true,
         showCoverageOnHover: true,
         iconCreateFunction: cluster => {
@@ -3129,7 +3132,7 @@ function slugify(str) {
       clusterLayer.on('add', () => {
         mergedOverlayLayer.addTo(map);
         smallClusterOverlayLayer.addTo(map);
-        map.on('zoomend moveend', handleMapViewChange);
+        map.on('zoomstart zoomend moveend', handleMapViewChange);
         refreshClusterVisuals();
       });
       clusterLayer.on('remove', () => {
@@ -3137,7 +3140,7 @@ function slugify(str) {
         clearSmallClusterOverlays();
         mergedOverlayLayer.remove();
         smallClusterOverlayLayer.remove();
-        map.off('zoomend moveend', handleMapViewChange);
+        map.off('zoomstart zoomend moveend', handleMapViewChange);
       });
       clusterLayer.on('animationend', refreshClusterVisuals);
       clusterLayer.on('spiderfied', refreshClusterVisuals);


### PR DESCRIPTION
### Motivation
- Zapobiec chwilowemu wyświetlaniu 2/3/4-elementowych klastrów podczas animowanego zoomu, tak aby reguła ukrywania małych klastrów (minimum 5) była konsekwentna także w trakcie zmiany widoku.

### Description
- Wyłączono animacje MarkerCluster w `createPinLayer()` przez ustawienie `animate: false` i `animateAddingMarkers: false` w wywołaniu `L.markerClusterGroup`.
- Rozszerzono odświeżanie wizualne klastrów, podpinając `handleMapViewChange` także pod `zoomstart` obok `zoomend` i `moveend`, oraz odpowiednio odpinając przy usuwaniu warstwy (`map.on('zoomstart zoomend moveend', ...)` / `map.off('zoomstart zoomend moveend', ...)`).
- Dodano CSS ograniczający przejścia podczas animacji zoomu: `.leaflet-zoom-anim .custom-cluster-icon { transition: none !important; }`.
- Nie zmieniono logiki minimalnej liczby markerów w klastrze (`CLUSTER_MIN_MARKERS` pozostało bez zmian).

### Testing
- Uruchomiono `git -C /workspace/ExploMapa diff -- index.html` aby sprawdzić zmiany i polecenie zakończyło się pomyślnie.
- Wykonano `git -C /workspace/ExploMapa add index.html && git -C /workspace/ExploMapa commit -m "Fix small cluster flicker during zoom"` i commit został utworzony pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05aa207cac8330b2cda4922f0e3710)