### PR TITLE
Natychmiastowe ukrywanie małych klastrów podczas animowanego zoomu

### DIFF
--- a/index.html
+++ b/index.html
@@ -578,6 +578,10 @@
     .leaflet-zoom-anim .custom-cluster-icon {
       transition: none !important;
     }
+    .leaflet-marker-icon.marker-cluster-hidden {
+      opacity: 0 !important;
+      pointer-events: none !important;
+    }
     .emoji-inline {
 width: 15px;
     height: 15px;
@@ -3071,6 +3075,27 @@ function slugify(str) {
         return clone;
       }
 
+      function hideTinyClustersImmediately() {
+        const clusterGroup = clusterLayer;
+        const visible = clusterGroup?._featureGroup?.getLayers?.() || [];
+
+        for (const layer of visible) {
+          if (!(layer instanceof L.MarkerCluster)) continue;
+
+          const count = layer.getChildCount();
+
+          if (count < CLUSTER_MIN_MARKERS) {
+            const el = layer._icon;
+            if (el) {
+              el.classList.add('marker-cluster-hidden');
+              el.style.display = 'none';
+              el.style.opacity = '0';
+              el.style.pointerEvents = 'none';
+            }
+          }
+        }
+      }
+
       function renderSmallClustersAsSingleMarkers() {
         if (!map || !clusterLayer || !clusterLayer._featureGroup) return;
         if (!smallClusterOverlayLayer || !map.hasLayer(clusterLayer)) return;
@@ -3093,6 +3118,10 @@ function slugify(str) {
           hiddenSmallClusterIds.add(id);
           smallClusterMarkers.push({ id, cluster });
           setClusterMarkerVisibility(cluster, false);
+          if (cluster._icon) {
+            cluster._icon.classList.add('marker-cluster-hidden');
+            cluster._icon.style.display = 'none';
+          }
 
           childMarkers.forEach(childMarker => {
             const markerClone = buildSingleMarkerClone(childMarker);
@@ -3104,6 +3133,7 @@ function slugify(str) {
       function refreshClusterVisuals() {
         requestAnimationFrame(() => {
           renderSmallClustersAsSingleMarkers();
+          hideTinyClustersImmediately();
           mergeStronglyOverlappingClusters();
         });
       }
@@ -3111,8 +3141,8 @@ function slugify(str) {
       clusterLayer = L.markerClusterGroup({
         disableClusteringAtZoom: CLUSTER_DISABLE_AT_ZOOM,
         maxClusterRadius: () => 105,
-        animate: false,
-        animateAddingMarkers: false,
+        animate: true,
+        animateAddingMarkers: true,
         spiderfyOnMaxZoom: true,
         showCoverageOnHover: true,
         iconCreateFunction: cluster => {
@@ -3133,6 +3163,8 @@ function slugify(str) {
         mergedOverlayLayer.addTo(map);
         smallClusterOverlayLayer.addTo(map);
         map.on('zoomstart zoomend moveend', handleMapViewChange);
+        map.on('zoomstart', hideTinyClustersImmediately);
+        map.on('zoomanim', hideTinyClustersImmediately);
         refreshClusterVisuals();
       });
       clusterLayer.on('remove', () => {
@@ -3141,7 +3173,10 @@ function slugify(str) {
         mergedOverlayLayer.remove();
         smallClusterOverlayLayer.remove();
         map.off('zoomstart zoomend moveend', handleMapViewChange);
+        map.off('zoomstart', hideTinyClustersImmediately);
+        map.off('zoomanim', hideTinyClustersImmediately);
       });
+      clusterLayer.on('animationend', hideTinyClustersImmediately);
       clusterLayer.on('animationend', refreshClusterVisuals);
       clusterLayer.on('spiderfied', refreshClusterVisuals);
       clusterLayer.on('unspiderfied', refreshClusterVisuals);


### PR DESCRIPTION
### Motivation
- Podczas animowanego zoomu drobne klastry (2–4 pinezki) chwilowo się pojawiały zanim istniejące przekształcenia i nakładki je zastępowały.
- Trzeba ukryć te przemijające ikony natychmiast, bez wyłączania animacji klastrów ani animacji zoomu.

### Description
- Włączono animacje MarkerCluster ustawiając `animate: true` i `animateAddingMarkers: true` dla `L.markerClusterGroup`.
- Dodano funkcję `hideTinyClustersImmediately()` która iteruje widoczne warstwy z `clusterLayer._featureGroup.getLayers()` i natychmiast chowa klastry z liczbą dzieci mniejszą niż `CLUSTER_MIN_MARKERS` (dodaje klasę `marker-cluster-hidden` oraz ustawia `display: none`, `opacity: 0`, `pointer-events: none`).
- Wywołano `hideTinyClustersImmediately()` na zdarzeniach `zoomstart`, `zoomanim` oraz `animationend`, oraz wstawiono jej wywołanie przed `mergeStronglyOverlappingClusters()` w `refreshClusterVisuals()`; dodatkowo `renderSmallClustersAsSingleMarkers()` ustawia `cluster._icon.style.display = 'none'` dla natychmiastowego ukrycia.
- Dodano pomocniczy CSS `.leaflet-marker-icon.marker-cluster-hidden { opacity: 0 !important; pointer-events: none !important; }` aby zapewnić nieinteraktywność i pełne ukrycie ikon.

### Testing
- Uruchomiono wyszukiwanie w pliku aby potwierdzić wstawienie nowych symboli: `rg -n "hideTinyClustersImmediately|animate: true|animateAddingMarkers: true|zoomanim|marker-cluster-hidden|cluster._icon.style.display" index.html` i wynik potwierdził zmiany.
- Sprawdzono zawartość pliku i kontekst zmian poleceniem `nl -ba index.html | sed -n '572,590p;3070,3185p'` aby zweryfikować poprawne osadzenie funkcji, wywołań i CSS.
- Weryfikacje plików źródłowych przeszły pomyślnie (komendy inspekcyjne zakończone bez błędów).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ad8fcabc833098f6ff7ab4d8a916)