### PR TITLE
Simplify tiny-cluster handling to run only after zoom ends

### DIFF
--- a/index.html
+++ b/index.html
@@ -2915,9 +2915,7 @@ function slugify(str) {
       const mergedClusterMarkers = [];
       const hiddenSmallClusterIds = new Set();
       const smallClusterMarkers = [];
-      let isZoomingClusters = false;
       let refreshClusterRaf = null;
-      let zoomanimHideTinyRaf = null;
 
       function setClusterMarkerVisibility(cluster, visible) {
         if (!cluster || !cluster._icon) return;
@@ -3081,29 +3079,7 @@ function slugify(str) {
         return clone;
       }
 
-      function hideTinyClustersImmediately() {
-        const clusterGroup = clusterLayer;
-        const visible = clusterGroup?._featureGroup?.getLayers?.() || [];
-
-        for (const layer of visible) {
-          if (!(layer instanceof L.MarkerCluster)) continue;
-
-          const count = layer.getChildCount();
-
-          if (count < CLUSTER_MIN_MARKERS) {
-            const el = layer._icon;
-            if (el) {
-              el.classList.add('marker-cluster-hidden');
-              el.style.display = 'none';
-              el.style.opacity = '0';
-              el.style.pointerEvents = 'none';
-            }
-          }
-        }
-      }
-
       function renderSmallClustersAsSingleMarkers() {
-        if (isZoomingClusters) return;
         if (!map || !clusterLayer || !clusterLayer._featureGroup) return;
         if (!smallClusterOverlayLayer || !map.hasLayer(clusterLayer)) return;
 
@@ -3141,8 +3117,6 @@ function slugify(str) {
         if (refreshClusterRaf) cancelAnimationFrame(refreshClusterRaf);
         refreshClusterRaf = requestAnimationFrame(() => {
           refreshClusterRaf = null;
-          if (isZoomingClusters) return;
-          hideTinyClustersImmediately();
           renderSmallClustersAsSingleMarkers();
           mergeStronglyOverlappingClusters();
         });
@@ -3169,51 +3143,33 @@ function slugify(str) {
       mergedOverlayLayer = L.layerGroup();
       smallClusterOverlayLayer = L.layerGroup();
       const handleMapViewChange = () => refreshClusterVisuals();
-      const handleClusterZoomStart = () => {
-        isZoomingClusters = true;
-        clearSmallClusterOverlays();
-        hideTinyClustersImmediately();
-      };
       const handleClusterZoomAnim = () => {
-        if (zoomanimHideTinyRaf) return;
-        zoomanimHideTinyRaf = requestAnimationFrame(() => {
-          zoomanimHideTinyRaf = null;
-          hideTinyClustersImmediately();
-        });
+        console.log('[clusters] zoom animation skipped, refreshing after zoomend');
       };
       const handleClusterZoomEnd = () => {
-        isZoomingClusters = false;
         refreshClusterVisuals();
       };
       clusterLayer.on('add', () => {
         mergedOverlayLayer.addTo(map);
         smallClusterOverlayLayer.addTo(map);
         map.on('moveend', handleMapViewChange);
-        map.on('zoomstart', handleClusterZoomStart);
         map.on('zoomanim', handleClusterZoomAnim);
         map.on('zoomend', handleClusterZoomEnd);
         refreshClusterVisuals();
       });
       clusterLayer.on('remove', () => {
-        isZoomingClusters = false;
         if (refreshClusterRaf) {
           cancelAnimationFrame(refreshClusterRaf);
           refreshClusterRaf = null;
-        }
-        if (zoomanimHideTinyRaf) {
-          cancelAnimationFrame(zoomanimHideTinyRaf);
-          zoomanimHideTinyRaf = null;
         }
         clearMergedClusterOverlays();
         clearSmallClusterOverlays();
         mergedOverlayLayer.remove();
         smallClusterOverlayLayer.remove();
         map.off('moveend', handleMapViewChange);
-        map.off('zoomstart', handleClusterZoomStart);
         map.off('zoomanim', handleClusterZoomAnim);
         map.off('zoomend', handleClusterZoomEnd);
       });
-      clusterLayer.on('animationend', hideTinyClustersImmediately);
       clusterLayer.on('animationend', refreshClusterVisuals);
       clusterLayer.on('spiderfied', refreshClusterVisuals);
       clusterLayer.on('unspiderfied', refreshClusterVisuals);


### PR DESCRIPTION
### Motivation
- Reduce DOM churn and jank during map zoom animations by avoiding heavy cluster-reshaping work while `zoomanim`/`zoomstart` is running. 
- Preserve the UX rule that clusters are split into individual markers only below `CLUSTER_MIN_MARKERS = 5`, but perform that split only after zoom completes. 
- Let `Leaflet.markercluster` animate normally during zoom so zoom in/out is smoother on large layers. 

### Description
- Removed animation-time tiny-cluster workaround code including `hideTinyClustersImmediately()`, the RAF throttling path, `isZoomingClusters` and `zoomanimHideTinyRaf`, and related `zoomstart` handlers. 
- Stopped hiding small clusters or creating single-marker overlays during `zoomanim` and `zoomstart`, and removed class toggles/workarounds used only during zoom animation. 
- Kept `renderSmallClustersAsSingleMarkers()` and `mergeStronglyOverlappingClusters()` and ensured `refreshClusterVisuals()` calls them; `refreshClusterVisuals()` is invoked after `zoomend`/`moveend`. 
- Added debug log in the zoom animation handler: `console.log('[clusters] zoom animation skipped, refreshing after zoomend');` and simplified `zoomanim`/`zoomend` bindings so refresh runs post-animation. 

### Testing
- Ran pattern search `rg -n "hideTinyClustersImmediately|scheduleHideTinyClustersImmediately|zoomanimHideTinyRaf|zoomstart|cluster-zooming|isZoomingClusters"` against `index.html` and received no matches confirming removal of the old animation-time logic. (success) 
- Inspected the modified `index.html` region with `sed`/`nl` to verify `refreshClusterVisuals()` still calls `renderSmallClustersAsSingleMarkers()` and `mergeStronglyOverlappingClusters()` and that the `zoomanim` debug log is present. (success) 
- Verified the code diff to ensure only the animation-time work was removed and no other subsystems (popups, filters, layers, trip mode, editing, viewport rendering, Firestore, search) were changed. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06cb1fd058833084a61b374159e3ab)