### PR TITLE
Disable Leaflet.markercluster animations to improve zoom performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -3149,11 +3149,15 @@ function slugify(str) {
       }
 
       clusterLayer = L.markerClusterGroup({
+
         disableClusteringAtZoom: CLUSTER_DISABLE_AT_ZOOM,
         maxClusterRadius: () => 105,
-        animate: true,
-        animateAddingMarkers: true,
+        animate: false,
+        animateAddingMarkers: false,
         spiderfyOnMaxZoom: true,
+        chunkedLoading: true,
+        chunkInterval: 100,
+        chunkDelay: 25,
         showCoverageOnHover: true,
         iconCreateFunction: cluster => {
           const count = cluster.getChildCount();
@@ -3165,6 +3169,7 @@ function slugify(str) {
           });
         }
       });
+      console.log('[cluster-performance] animations disabled');
 
       mergedOverlayLayer = L.layerGroup();
       smallClusterOverlayLayer = L.layerGroup();


### PR DESCRIPTION
### Motivation
- Zooming large marker layers was lagging because cluster animations and marker processing caused heavy DOM work and stutters. 
- The goal is to reduce animation overhead and use chunked processing to make zoom more responsive without changing clustering logic.

### Description
- In `createPinLayer()` I updated the `L.markerClusterGroup({...})` config to set `animate: false` and `animateAddingMarkers: false` to disable cluster animations. 
- I enabled chunked processing with `chunkedLoading: true` and tuned it using `chunkInterval: 100` and `chunkDelay: 25`. 
- Left `spiderfyOnMaxZoom` unchanged and added a debug line `console.log('[cluster-performance] animations disabled');` after the cluster config.

### Testing
- Ran `git diff -- index.html` to verify the config changes were present and it succeeded. 
- Committed the change with `git commit -m "Disable markercluster animations for smoother zoom"` and the commit succeeded. 
- Inspected the updated section of `index.html` with `nl -ba index.html | sed -n '3146,3180p'` to confirm the inserted lines were in the expected location and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ccdb9c9c8330afbd4f26942bd98c)