### PR TITLE
Add diagnostic flag to disable custom cluster visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -2791,6 +2791,7 @@ function slugify(str) {
     const PINTEREST_PINS_COLLECTION = 'pinterest_diane_g';
     const CLUSTER_DISABLE_AT_ZOOM = 14; // skupiaj pinezki aż do średniego przybliżenia mapy
     const CLUSTER_MIN_MARKERS = 5; // poniżej tej liczby pokazuj pojedyncze pinezki zamiast klastra
+    const DISABLE_CUSTOM_CLUSTER_VISUALS = true;
     const BIG_CLUSTER_COUNT = 500;
     const MAX_VISIBLE_CLUSTERS_FOR_OVERLAP_MERGE = 1000;
     const MAX_CLUSTERS_TO_MERGE_FAST = 500;
@@ -3171,9 +3172,15 @@ function slugify(str) {
       });
       console.log('[cluster-performance] animations disabled');
 
-      mergedOverlayLayer = L.layerGroup();
-      smallClusterOverlayLayer = L.layerGroup();
-      const handleMapViewChange = () => refreshClusterVisuals();
+      if (DISABLE_CUSTOM_CLUSTER_VISUALS) {
+        console.log('[cluster-debug] custom cluster overlays disabled for animation test');
+      } else {
+        mergedOverlayLayer = L.layerGroup();
+        smallClusterOverlayLayer = L.layerGroup();
+      }
+      const handleMapViewChange = () => {
+        if (!DISABLE_CUSTOM_CLUSTER_VISUALS) refreshClusterVisuals();
+      };
       const handleClusterZoomStart = () => {
         isZoomingClusters = true;
         clearSmallClusterOverlays();
@@ -3188,16 +3195,18 @@ function slugify(str) {
       };
       const handleClusterZoomEnd = () => {
         isZoomingClusters = false;
-        refreshClusterVisuals();
+        if (!DISABLE_CUSTOM_CLUSTER_VISUALS) refreshClusterVisuals();
       };
       clusterLayer.on('add', () => {
-        mergedOverlayLayer.addTo(map);
-        smallClusterOverlayLayer.addTo(map);
-        map.on('moveend', handleMapViewChange);
+        if (!DISABLE_CUSTOM_CLUSTER_VISUALS) {
+          mergedOverlayLayer.addTo(map);
+          smallClusterOverlayLayer.addTo(map);
+          map.on('moveend', handleMapViewChange);
+        }
         map.on('zoomstart', handleClusterZoomStart);
         map.on('zoomanim', handleClusterZoomAnim);
         map.on('zoomend', handleClusterZoomEnd);
-        refreshClusterVisuals();
+        if (!DISABLE_CUSTOM_CLUSTER_VISUALS) refreshClusterVisuals();
       });
       clusterLayer.on('remove', () => {
         isZoomingClusters = false;
@@ -3209,19 +3218,23 @@ function slugify(str) {
           cancelAnimationFrame(zoomanimHideTinyRaf);
           zoomanimHideTinyRaf = null;
         }
-        clearMergedClusterOverlays();
-        clearSmallClusterOverlays();
-        mergedOverlayLayer.remove();
-        smallClusterOverlayLayer.remove();
-        map.off('moveend', handleMapViewChange);
+        if (!DISABLE_CUSTOM_CLUSTER_VISUALS) {
+          clearMergedClusterOverlays();
+          clearSmallClusterOverlays();
+          mergedOverlayLayer.remove();
+          smallClusterOverlayLayer.remove();
+          map.off('moveend', handleMapViewChange);
+        }
         map.off('zoomstart', handleClusterZoomStart);
         map.off('zoomanim', handleClusterZoomAnim);
         map.off('zoomend', handleClusterZoomEnd);
       });
       clusterLayer.on('animationend', hideTinyClustersImmediately);
-      clusterLayer.on('animationend', refreshClusterVisuals);
-      clusterLayer.on('spiderfied', refreshClusterVisuals);
-      clusterLayer.on('unspiderfied', refreshClusterVisuals);
+      if (!DISABLE_CUSTOM_CLUSTER_VISUALS) {
+        clusterLayer.on('animationend', refreshClusterVisuals);
+        clusterLayer.on('spiderfied', refreshClusterVisuals);
+        clusterLayer.on('unspiderfied', refreshClusterVisuals);
+      }
 
       return clusterLayer;
     }


### PR DESCRIPTION
### Motivation
- The UI still showed cluster jumping despite `animate:false`, so a diagnostic switch is needed to isolate whether custom overlay/refresh logic causes the animation. 

### Description
- Added a test flag `const DISABLE_CUSTOM_CLUSTER_VISUALS = true` to `index.html` to gate the custom cluster visuals. 
- When the flag is enabled the code skips creating `mergedOverlayLayer` and `smallClusterOverlayLayer` and does not add them to the map. 
- The custom refresh path `refreshClusterVisuals()` is prevented from running on `moveend`, `zoomend`, cluster `animationend`, `spiderfied` and `unspiderfied` events when the flag is active, and a debug log `console.log('[cluster-debug] custom cluster overlays disabled for animation test');` is emitted. 
- The base `Leaflet.markercluster` configuration remains unchanged (including `animate: false` and `animateAddingMarkers: false`) so the test isolates custom code from the plugin. 

### Testing
- No automated tests were executed for this diagnostic change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d7345a408330be8565d1c5b074cb)