### PR TITLE
Tune Leaflet cluster overlay refresh timing for smoother zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2794,7 +2794,9 @@ function slugify(str) {
     const DISABLE_CUSTOM_CLUSTER_VISUALS = true;
     const BIG_CLUSTER_COUNT = 500;
     const MAX_VISIBLE_CLUSTERS_FOR_OVERLAP_MERGE = 1000;
-    const MAX_CLUSTERS_TO_MERGE_FAST = 500;
+    const CLUSTER_POST_ZOOM_REFRESH_DELAY = 140;
+    const CLUSTER_OVERLAP_MERGE_DELAY = 260;
+    const MAX_CLUSTERS_TO_MERGE_FAST = 150;
     const CLUSTER_OVERLAP_MERGE_PADDING = 22;
 
     const shouldRestoreLayerState = localStorage.getItem(LAYER_STATE_PRESERVE_FLAG_KEY) === '1';
@@ -2919,6 +2921,8 @@ function slugify(str) {
       let isZoomingClusters = false;
       let refreshClusterRaf = null;
       let zoomanimHideTinyRaf = null;
+      let zoomRefreshTimeout = null;
+      let overlapMergeTimeout = null;
 
       function setClusterMarkerVisibility(cluster, visible) {
         if (!cluster || !cluster._icon) return;
@@ -2936,6 +2940,17 @@ function slugify(str) {
         hiddenSmallClusterIds.clear();
         smallClusterMarkers.splice(0, smallClusterMarkers.length);
         if (smallClusterOverlayLayer) smallClusterOverlayLayer.clearLayers();
+      }
+
+      function clearClusterTimers() {
+        if (zoomRefreshTimeout) {
+          clearTimeout(zoomRefreshTimeout);
+          zoomRefreshTimeout = null;
+        }
+        if (overlapMergeTimeout) {
+          clearTimeout(overlapMergeTimeout);
+          overlapMergeTimeout = null;
+        }
       }
 
       function getVisibleTopClusters() {
@@ -3145,8 +3160,17 @@ function slugify(str) {
           if (isZoomingClusters) return;
           hideTinyClustersImmediately();
           renderSmallClustersAsSingleMarkers();
-          mergeStronglyOverlappingClusters();
         });
+      }
+
+      function scheduleOverlapMerge(delay = CLUSTER_OVERLAP_MERGE_DELAY) {
+        if (DISABLE_CUSTOM_CLUSTER_VISUALS) return;
+        if (overlapMergeTimeout) clearTimeout(overlapMergeTimeout);
+        overlapMergeTimeout = setTimeout(() => {
+          overlapMergeTimeout = null;
+          if (isZoomingClusters) return;
+          mergeStronglyOverlappingClusters();
+        }, delay);
       }
 
       clusterLayer = L.markerClusterGroup({
@@ -3179,7 +3203,9 @@ function slugify(str) {
         smallClusterOverlayLayer = L.layerGroup();
       }
       const handleMapViewChange = () => {
-        if (!DISABLE_CUSTOM_CLUSTER_VISUALS) refreshClusterVisuals();
+        if (DISABLE_CUSTOM_CLUSTER_VISUALS) return;
+        refreshClusterVisuals();
+        scheduleOverlapMerge(CLUSTER_OVERLAP_MERGE_DELAY);
       };
       const handleClusterZoomStart = () => {
         isZoomingClusters = true;
@@ -3195,7 +3221,14 @@ function slugify(str) {
       };
       const handleClusterZoomEnd = () => {
         isZoomingClusters = false;
-        if (!DISABLE_CUSTOM_CLUSTER_VISUALS) refreshClusterVisuals();
+        if (DISABLE_CUSTOM_CLUSTER_VISUALS) return;
+        if (zoomRefreshTimeout) clearTimeout(zoomRefreshTimeout);
+        zoomRefreshTimeout = setTimeout(() => {
+          zoomRefreshTimeout = null;
+          if (isZoomingClusters) return;
+          refreshClusterVisuals();
+        }, CLUSTER_POST_ZOOM_REFRESH_DELAY);
+        scheduleOverlapMerge(CLUSTER_OVERLAP_MERGE_DELAY);
       };
       clusterLayer.on('add', () => {
         if (!DISABLE_CUSTOM_CLUSTER_VISUALS) {
@@ -3214,6 +3247,7 @@ function slugify(str) {
           cancelAnimationFrame(refreshClusterRaf);
           refreshClusterRaf = null;
         }
+        clearClusterTimers();
         if (zoomanimHideTinyRaf) {
           cancelAnimationFrame(zoomanimHideTinyRaf);
           zoomanimHideTinyRaf = null;
@@ -5361,7 +5395,12 @@ function emojiHtml(str) {
         popupAutoPanState.duringAutoPan = false;
       }
 
-      map = L.map('map', { crs: L.CRS.EPSG3857 }).setView([52.1, 20.9], 7);
+      map = L.map('map', {
+        crs: L.CRS.EPSG3857,
+        zoomAnimation: true,
+        fadeAnimation: true,
+        markerZoomAnimation: true
+      }).setView([52.1, 20.9], 7);
       const savedMapViewRaw = localStorage.getItem(MAP_VIEW_PRESERVE_KEY);
       if (savedMapViewRaw) {
         localStorage.removeItem(MAP_VIEW_PRESERVE_KEY);


### PR DESCRIPTION
### Motivation
- Przywrócenie wizualnie płynnego zoomu Leafleta przy jednoczesnym ograniczeniu lagów wynikających z przebudowy customowych overlayów klastrów. 
- Przeniesienie cięższych operacji (small-cluster render i merge overlapów) poza krytyczną ścieżkę animacji zoomu, akceptując krótkie opóźnienie w poprawkach małych klastrów i scalaniu overlapów. 

### Description
- Włączono mapowe animacje Leafleta przez ustawienie `zoomAnimation: true`, `fadeAnimation: true` i `markerZoomAnimation: true` podczas inicjalizacji `L.map`. 
- Pozostawiono wyłączone animacje w `L.markerClusterGroup` przez `animate: false` i `animateAddingMarkers: false`. 
- Dodano i ustalono nowe stałe konfiguracyjne: `CLUSTER_POST_ZOOM_REFRESH_DELAY = 140`, `CLUSTER_OVERLAP_MERGE_DELAY = 260` oraz `MAX_CLUSTERS_TO_MERGE_FAST = 150`. 
- Usunięto bezpośrednie wywołanie `mergeStronglyOverlappingClusters()` z głównej ścieżki `refreshClusterVisuals()` i wprowadzono `scheduleOverlapMerge()` uruchamiane z opóźnieniem po `moveend` albo `zoomend`. 
- Wprowadzono opóźnione odświeżanie drobnych klastrów po `zoomend` (przez timeout `CLUSTER_POST_ZOOM_REFRESH_DELAY`) oraz mechanizm timeoutów `zoomRefreshTimeout` / `overlapMergeTimeout` i funkcję `clearClusterTimers()` do ich czyszczenia przy usuwaniu warstwy. 
- Zachowano próg wyłączenia ciężkiego scalania dla dużej liczby widocznych klastrów (`clusters.length > MAX_CLUSTERS_TO_MERGE_FAST`). 

### Testing
- Zweryfikowano obecność i lokalizację zmian przez wyszukiwania kodu z `rg` dla kluczowych symboli (`zoomAnimation`, `CLUSTER_POST_ZOOM_REFRESH_DELAY`, `scheduleOverlapMerge`, itp.), które zwróciły zaktualizowane fragmenty pliku. 
- Przejrzano zmodyfikowane fragmenty pliku przy pomocy `nl`/`sed` w celu potwierdzenia wstawek i przesunięć logiki związanej z klastrami. 
- Narzędzie do przygotowania PR (`make_pr`) uruchomiono i wygenerowało treść PR, a wszystkie opisane kontrole automatyczne zakończyły się pozytywnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d9136b4883308b467ba9c0d0c34e)