### PR TITLE
Optimize single-marker zoom animation to improve map FPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -582,6 +582,15 @@
       opacity: 0 !important;
       pointer-events: none !important;
     }
+
+    body.single-marker-no-zoom-animation .emoji-marker,
+    body.single-marker-no-zoom-animation .leaflet-marker-icon:not(.marker-cluster),
+    body.single-marker-no-zoom-animation .leaflet-pane .leaflet-marker-icon:not(.marker-cluster),
+    #map.single-marker-no-zoom-animation .emoji-marker,
+    #map.single-marker-no-zoom-animation .leaflet-marker-icon:not(.marker-cluster) {
+      transition: none !important;
+      animation: none !important;
+    }
     .emoji-inline {
 width: 15px;
     height: 15px;
@@ -5399,6 +5408,30 @@ function emojiHtml(str) {
       }
 
       map = L.map('map', { crs: L.CRS.EPSG3857 }).setView([52.1, 20.9], 7);
+      let singleMarkerZoomClassTimer = null;
+      const SINGLE_MARKER_ZOOM_CLASS = 'single-marker-no-zoom-animation';
+      const setSingleMarkerZoomClass = enabled => {
+        document.body.classList.toggle(SINGLE_MARKER_ZOOM_CLASS, enabled);
+        const mapEl = map && map.getContainer ? map.getContainer() : document.getElementById('map');
+        if (mapEl) mapEl.classList.toggle(SINGLE_MARKER_ZOOM_CLASS, enabled);
+      };
+      const handleSingleMarkerZoomStart = () => {
+        if (singleMarkerZoomClassTimer) {
+          clearTimeout(singleMarkerZoomClassTimer);
+          singleMarkerZoomClassTimer = null;
+        }
+        setSingleMarkerZoomClass(true);
+        console.log('[cluster-performance] single marker zoom animations disabled');
+      };
+      const handleSingleMarkerZoomEnd = () => {
+        if (singleMarkerZoomClassTimer) clearTimeout(singleMarkerZoomClassTimer);
+        singleMarkerZoomClassTimer = setTimeout(() => {
+          setSingleMarkerZoomClass(false);
+          singleMarkerZoomClassTimer = null;
+        }, 80);
+      };
+      map.on('zoomstart', handleSingleMarkerZoomStart);
+      map.on('zoomend', handleSingleMarkerZoomEnd);
       const savedMapViewRaw = localStorage.getItem(MAP_VIEW_PRESERVE_KEY);
       if (savedMapViewRaw) {
         localStorage.removeItem(MAP_VIEW_PRESERVE_KEY);


### PR DESCRIPTION
### Motivation
- Reduce repaint/lag when many single emoji markers are shown while preserving smooth cluster zoom animations.
- Provide a performance compromise where clusters still animate during zoom while single markers snap to their final positions after zoom.

### Description
- Add CSS rules in `index.html` that set `transition: none !important;` and `animation: none !important;` for `.emoji-marker` and `.leaflet-marker-icon:not(.marker-cluster)` when the `single-marker-no-zoom-animation` class is present on the `body` or `#map` element.
- Add map initialization code to define `SINGLE_MARKER_ZOOM_CLASS`, toggle that class on `zoomstart`/`zoomend` (with an `80ms` delayed removal), and log `console.log('[cluster-performance] single marker zoom animations disabled')` when disabling single-marker zoom animations.
- Ensure cluster-related selectors (e.g. `.marker-cluster`, `.custom-cluster-icon`) and clustering logic are left unchanged so cluster animations continue to function normally.

### Testing
- Verified the diff with `git diff -- index.html` and inspected changes which only touch `index.html`, and the check succeeded.
- Committed the change with `git commit -m "Optimize single marker zoom behavior without affecting clusters"` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e45650a0833092e5b3c4694ed8a8)