### PR TITLE
Add toggle to disable overlap cluster merge for performance testing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2796,6 +2796,7 @@ function slugify(str) {
     const MAX_VISIBLE_CLUSTERS_FOR_OVERLAP_MERGE = 1000;
     const MAX_CLUSTERS_TO_MERGE_FAST = 500;
     const CLUSTER_OVERLAP_MERGE_PADDING = 22;
+    const DISABLE_OVERLAP_MERGE = true;
 
     const shouldRestoreLayerState = localStorage.getItem(LAYER_STATE_PRESERVE_FLAG_KEY) === '1';
     // When the page is opened normally we want layer visibility/collapse to reset.
@@ -3018,6 +3019,15 @@ function slugify(str) {
       }
 
       function mergeStronglyOverlappingClusters() {
+        if (DISABLE_OVERLAP_MERGE) {
+          console.log('[cluster-debug] overlap merge disabled');
+          for (const id of hiddenClusterIds) {
+            const cluster = mergedClusterMarkers.find(item => item.id === id)?.cluster;
+            if (cluster) setClusterMarkerVisibility(cluster, true);
+          }
+          clearMergedClusterOverlays();
+          return;
+        }
         if (!map || !clusterLayer || !clusterLayer._featureGroup) return;
         if (!mergedOverlayLayer || !map.hasLayer(clusterLayer)) return;
         if (map.getZoom() >= CLUSTER_DISABLE_AT_ZOOM) return;


### PR DESCRIPTION
### Motivation
- Umożliwić porównawczy test wydajności mapy bez customowego scalania nachodzących klastrów, aby sprawdzić czy to ono jest głównym źródłem lagów.

### Description
- Dodano flagę `const DISABLE_OVERLAP_MERGE = true;` obok istniejących stałych klastrowania.
- W `mergeStronglyOverlappingClusters()` dodano wczesny `return` kiedy flaga jest aktywna, oraz `console.log('[cluster-debug] overlap merge disabled')`, przywracanie widoczności wcześniej ukrytych klastrów i czyszczenie `mergedOverlayLayer` bez tworzenia nowych DOM-ów ani renderowania custom merged clusterów.
- Kod overlap-merge pozostał nienaruszony poniżej warunku flagi i można go przywrócić przez ustawienie flagi na `false`; nie zmieniono `CLUSTER_MIN_MARKERS`, zachowania `Leaflet.markercluster`, popupów, filtrów, warstw, viewport renderingu ani trybu trip.

### Testing
- Wykonano `rg -n "DISABLE_OVERLAP_MERGE|overlap merge disabled|function mergeStronglyOverlappingClusters"` i potwierdzono obecność nowych fragmentów (sukces).
- Zastosowano skrypt `python` do automatycznej modyfikacji pliku i potwierdzono jego wykonanie (sukces).
- Zweryfikowano zmiany w pliku z `nl -ba index.html | sed -n '2790,3045p'` i potwierdzono wstawione linie (sukces).
- Uruchomiono `rg -n "mergeStronglyOverlappingClusters|mergedOverlayLayer|custom.*cluster|overlap merge|CLUSTER_MIN_MARKERS|markercluster"` aby upewnić się, że pozostały kod klastrów pozostał obecny (sukces).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e5cebd3883308b27d1d145f4fb2e)