### PR TITLE
Harden service worker precache to tolerate missing assets

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -8,12 +8,25 @@ const APP_SHELL = [
   '/firestore-setup.js',
   '/offline-uploads.js'
 ];
+
 self.addEventListener('install', event => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(APP_SHELL))
-  );
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE_NAME);
+
+    await Promise.all(
+      APP_SHELL.map(async asset => {
+        try {
+          await cache.add(asset);
+        } catch (error) {
+          console.warn(`[SW] Failed to cache asset: ${asset}`, error);
+        }
+      })
+    );
+  })());
+
   self.skipWaiting();
 });
+
 self.addEventListener('activate', event => {
   event.waitUntil(
     caches.keys().then(keys => Promise.all(
@@ -22,6 +35,7 @@ self.addEventListener('activate', event => {
   );
   self.clients.claim();
 });
+
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
   const url = new URL(event.request.url);


### PR DESCRIPTION
### Motivation
- Prevent the Service Worker `install` from failing when one precache asset is missing or returns a non-OK response.
- Avoid `cache.addAll(...)` rejection which aborts installation for the whole precache list.

### Description
- Replaced `cache.addAll(APP_SHELL)` in `sw.js` with per-asset caching using `APP_SHELL.map(...)` and `await cache.add(asset)` inside a `Promise.all` to run them concurrently.
- Wrapped each `cache.add(asset)` in a `try/catch` and added `console.warn` that logs the asset path and the error when caching fails.
- Left the `APP_SHELL` list, `fetch` handler, runtime caching, and all map/Firebase/UI logic unchanged.

### Testing
- Verified presence of precache files with a scripted check for `index.html`, `style.css`, `manifest.webmanifest`, `firestore-setup.js`, and `offline-uploads.js`, and it succeeded.
- Ran a syntax check with `node --check sw.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06f765d7c08330b2bd162682afe658)