### PR TITLE
Ensure missing markers are created when layers are shown

### DIFF
--- a/index.html
+++ b/index.html
@@ -10200,6 +10200,33 @@ function getTripPointEmoji(p) {
       updatePerformanceDebug('viewport render', performance.now() - viewportStartTs);
     }
 
+    function ensureLayerMarkersCreated(layerName) {
+      const layerData = warstwy[layerName];
+      if (!layerData || !Array.isArray(layerData.lista) || !layerData.layer) return 0;
+      let count = 0;
+      layerData.lista.forEach(pin => {
+        if (pin.marker) return;
+        const iconEmoji = layerData.emoji || pin.emoji;
+        pin.marker = L.marker([pin.lat, pin.lng], { icon: createEmojiIcon(iconEmoji, pin.warstwaId, 32, pin) });
+        pin.marker.on('popupopen', () => {
+          if (!pin.marker._popupBuilt) {
+            const popupDiv = document.createElement("div");
+            popupDiv.className = "popup-container";
+            popupDiv.innerHTML = createPopupHtml(pin);
+            pin.marker.bindPopup(popupDiv);
+            attachPopupHandlers(pin.marker, pin);
+            pin.marker._popupBuilt = true;
+          }
+        });
+        attachMarkerLongPress(pin.marker, pin);
+        attachHighlight(pin.marker, null);
+        layerData.layer.addLayer(pin.marker);
+        count++;
+      });
+      console.log('[ensure-layer-markers]', layerName, 'created:', count, 'total:', layerData.lista.length);
+      return count;
+    }
+
     function setLayerVisible(layerName, visible, options = {}) {
       const layerData = warstwy[layerName];
       if (!layerData || !layerData.layer) return false;
@@ -10216,6 +10243,7 @@ function getTripPointEmoji(p) {
       const hasLayer = map.hasLayer(layer);
 
       if (normalizedVisible) {
+        ensureLayerMarkersCreated(layerName);
         if (normalizedOptions.force && hasLayer) {
           map.removeLayer(layer);
         }
@@ -10361,27 +10389,7 @@ function getTripPointEmoji(p) {
           });
         });
         checkbox.onchange = () => {
-          if (checkbox.checked && window.innerWidth <= 700) {
-            warstwy[nazwa].lista.forEach(pin => {
-              if (!pin.marker) {
-                const iconEmoji = warstwy[nazwa].emoji || pin.emoji;
-                pin.marker = L.marker([pin.lat, pin.lng], { icon: createEmojiIcon(iconEmoji, pin.warstwaId, 32, pin) });
-                pin.marker.on('popupopen', () => {
-                  if (!pin.marker._popupBuilt) {
-                    const popupDiv = document.createElement("div");
-                    popupDiv.className = "popup-container";
-                    popupDiv.innerHTML = createPopupHtml(pin);
-                    pin.marker.bindPopup(popupDiv);
-                    attachPopupHandlers(pin.marker, pin);
-                    pin.marker._popupBuilt = true;
-                  }
-                });
-                attachMarkerLongPress(pin.marker, pin);
-                attachHighlight(pin.marker, null);
-                warstwy[nazwa].layer.addLayer(pin.marker);
-              }
-            });
-          }
+          if (checkbox.checked) ensureLayerMarkersCreated(nazwa);
           setLayerVisible(nazwa, checkbox.checked, {
             persist: !warstwy[nazwa].temporary,
             source: 'layer-checkbox-change'


### PR DESCRIPTION
### Motivation
- Naprawa błędu, w którym markery były tworzone tylko w `checkbox.onchange`, przez co po „Załaduj pinezki” widoczne warstwy nie renderowały markerów aż do ręcznego przełączenia checkboxa. 
- Cel: ujednolicić ścieżkę tworzenia markerów tak, aby zarówno ręczne toggle jak i programowe pokazywanie warstwy tworzyły brakujące markery.

### Description
- Dodano helper `ensureLayerMarkersCreated(layerName)` który iteruje po `warstwy[layerName].lista`, tworzy brakujące `pin.marker` dokładnie tą samą logiką co wcześniej (ikona, lazy popup, `attachPopupHandlers`, `attachMarkerLongPress`, `attachHighlight`, dodanie do klastra) i zwraca liczbę utworzonych markerów oraz loguje debug `console.log('[ensure-layer-markers]', layerName, 'created:', count, 'total:', layerData.lista.length)`.
- Usunięto zduplikowany kod z `checkbox.onchange` i zastąpiono go wywołaniem `if (checkbox.checked) ensureLayerMarkersCreated(nazwa);`.
- Dodano wywołanie `ensureLayerMarkersCreated(layerName)` w `setLayerVisible(layerName, true, ...)` przed `layer.addTo(map)`, dzięki czemu programowe ponowne pokazanie warstwy również tworzy brakujące markery.
- Nie zmieniono wyglądu markerów, popupów, sidebaru, klastrów ani filtrów oraz zachowano istniejący przepływ po `zaladujPinezkiZFirestore()` używający `setLayerVisible(..., { source: 'after-load-pins' })`.

### Testing
- Nie uruchomiono automatycznych testów, ponieważ repozytorium nie zawiera zestawu testów dla tej zmiany.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a070ba74de0833092d6e435034b40f8)