### PR TITLE
Add special-menu toggle for performance debug overlay (default OFF)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2078,6 +2078,7 @@ img.emoji {
             <button id="emojiToolBtn">Emoji Tool</button>
             <button id="exportKML">Zapisz do .KML</button>
             <button id="findDuplicatePinsBtn">Znajdź duplikaty pinezek</button>
+            <button id="performanceDebugToggleBtn" type="button" aria-pressed="false">Debug wydajności: OFF</button>
           </div>
         </div>
         <h2 id="logoNaglowek">ExploMapy</h2>
@@ -2814,6 +2815,7 @@ function slugify(str) {
     const CLUSTER_OVERLAP_MERGE_PADDING = 22;
     const DISABLE_OVERLAP_MERGE = true;
     const ENABLE_PERFORMANCE_DEBUG = true;
+    let performanceDebugEnabled = false;
     const performanceDebugStats = {};
     const performanceDebugCounters = {
       totalPins: 0,
@@ -2832,11 +2834,21 @@ function slugify(str) {
       if (!ENABLE_PERFORMANCE_DEBUG || performanceDebugOverlay) return;
       performanceDebugOverlay = document.createElement('div');
       performanceDebugOverlay.id = 'performance-debug-overlay';
+      performanceDebugOverlay.style.display = 'none';
       document.body.appendChild(performanceDebugOverlay);
     }
 
+    function setPerformanceDebugOverlayEnabled(nextEnabled) {
+      if (!ENABLE_PERFORMANCE_DEBUG) return;
+      performanceDebugEnabled = Boolean(nextEnabled);
+      ensurePerformanceDebugOverlay();
+      if (!performanceDebugOverlay) return;
+      performanceDebugOverlay.style.display = performanceDebugEnabled ? 'block' : 'none';
+      if (performanceDebugEnabled) renderPerformanceDebugOverlay();
+    }
+
     function updatePerformanceDebug(label, time) {
-      if (!ENABLE_PERFORMANCE_DEBUG || !Number.isFinite(time)) return;
+      if (!ENABLE_PERFORMANCE_DEBUG || !performanceDebugEnabled || !Number.isFinite(time)) return;
       if (!performanceDebugStats[label]) performanceDebugStats[label] = { last: 0, sum: 0, count: 0, avg: 0 };
       const stat = performanceDebugStats[label];
       stat.last = time;
@@ -2849,7 +2861,7 @@ function slugify(str) {
     function updatePerformanceCounters(nextCounters = {}) {
       if (!ENABLE_PERFORMANCE_DEBUG) return;
       Object.assign(performanceDebugCounters, nextCounters);
-      renderPerformanceDebugOverlay();
+      if (performanceDebugEnabled) renderPerformanceDebugOverlay();
     }
 
     function renderPerformanceDebugOverlay() {
@@ -10892,6 +10904,19 @@ function getTripPointEmoji(p) {
           specialMenuContent.classList.remove('open');
           specialMenuToggle.setAttribute('aria-expanded', 'false');
         }
+      });
+    }
+
+    const performanceDebugToggleBtn = document.getElementById('performanceDebugToggleBtn');
+    if (performanceDebugToggleBtn) {
+      const syncPerformanceDebugToggleUi = () => {
+        performanceDebugToggleBtn.textContent = `Debug wydajności: ${performanceDebugEnabled ? 'ON' : 'OFF'}`;
+        performanceDebugToggleBtn.setAttribute('aria-pressed', String(performanceDebugEnabled));
+      };
+      syncPerformanceDebugToggleUi();
+      performanceDebugToggleBtn.addEventListener('click', () => {
+        setPerformanceDebugOverlayEnabled(!performanceDebugEnabled);
+        syncPerformanceDebugToggleUi();
       });
     }
 


### PR DESCRIPTION
### Motivation
- Umożliwić włączanie/wyłączanie nakładki wydajności (`#performance-debug-overlay`) z poziomu menu burgerowego jako opcję specjalną zamiast zawsze jej pokazywać. 
- Domyślnie trzymać nakładkę wyłączoną, aby nie przeszkadzała zwykłym użytkownikom i oszczędzać koszty renderowania.

### Description
- Dodano przycisk w sekcji `#specialMenuContent` o id `performanceDebugToggleBtn` z etykietą `Debug wydajności: OFF` w `index.html`.
- Wprowadzono zmienną `performanceDebugEnabled = false` oraz pozostawiono `ENABLE_PERFORMANCE_DEBUG` jako globalny flag; nakładka jest domyślnie ukrywana (lazily-created z `style.display = 'none'`).
- Dodano funkcję `setPerformanceDebugOverlayEnabled(nextEnabled)` do włączania/wyłączania widoczności nakładki oraz spreparowano `ensurePerformanceDebugOverlay()` żeby stworzyć element tylko raz; renderowanie wywoływane jest tylko gdy tryb debug jest włączony.
- Zmieniono `updatePerformanceDebug` i `updatePerformanceCounters`, aby nie aktualizowały widoku gdy `performanceDebugEnabled` jest `false`, oraz podłączono logikę przycisku do synchronizacji tekstu i atrybutu `aria-pressed` (ON/OFF).

### Testing
- Uruchomiono `git diff -- index.html | sed -n '1,220p'` w celu weryfikacji diffu i wynik był pozytywny (sukces).
- Wykonano `git add index.html && git commit -m "Add burger-menu toggle for performance debug overlay"` i commit przeszedł pomyślnie.
- Stworzono PR za pomocą narzędzia `make_pr` z opisem zmian i operacja zakończyła się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a070def092483309d2c680b1c91da50)