### PR TITLE
Poprawa płynności renderowania markerów podczas zoomu

### DIFF
--- a/index.html
+++ b/index.html
@@ -3294,6 +3294,9 @@ function slugify(str) {
         maxClusterRadius: () => 105,
         animate: true,
         animateAddingMarkers: true,
+        chunkedLoading: true,
+        chunkDelay: 24,
+        chunkInterval: 64,
         spiderfyOnMaxZoom: true,
         showCoverageOnHover: true,
         iconCreateFunction: cluster => {
@@ -6154,8 +6157,15 @@ function emojiHtml(str) {
     map.on("click", e => { if (currentTool === "pin" && !drawingRoute && window.innerWidth > 800) onMapClick(e); });
     map.on(L.Draw.Event.CREATED, onRouteCreated);
     map.on('draw:drawstop', () => { drawingRoute = false; activeRoutePin = null; });
+    map.on('zoomstart', () => { markerZoomInProgress = true; });
+    map.on('zoomend', () => {
+      markerZoomInProgress = false;
+      if (markerVisibilityUpdateDeferred) {
+        markerVisibilityUpdateDeferred = false;
+      }
+      scheduleMarkerVisibilityUpdate();
+    });
     map.on('moveend', scheduleMarkerVisibilityUpdate);
-    map.on('zoomend', scheduleMarkerVisibilityUpdate);
 
     if (window.innerWidth <= 700) {
       let startLatLng = null;
@@ -10059,6 +10069,8 @@ function getTripPointEmoji(p) {
 
     let markerViewportUpdateScheduled = false;
     let markerVisibilityDebounceTimer = null;
+    let markerVisibilityUpdateDeferred = false;
+    let markerZoomInProgress = false;
     let mapWhenReadyExecuted = false;
     let pinsFirestoreLoaded = false;
 
@@ -10099,23 +10111,25 @@ function getTripPointEmoji(p) {
     }
 
     function scheduleMarkerVisibilityUpdate() {
+      if (markerZoomInProgress) {
+        markerVisibilityUpdateDeferred = true;
+        return;
+      }
       if (markerVisibilityDebounceTimer) clearTimeout(markerVisibilityDebounceTimer);
       markerVisibilityDebounceTimer = setTimeout(() => {
         if (markerViewportUpdateScheduled) return;
         markerViewportUpdateScheduled = true;
-        showLoading();
         requestAnimationFrame(() => {
           requestAnimationFrame(() => {
             try {
               updateMarkerVisibility();
             } finally {
               markerViewportUpdateScheduled = false;
-              hideLoading();
               markerVisibilityDebounceTimer = null;
             }
           });
         });
-      }, 120);
+      }, 80);
     }
 
     function updateMarkerVisibility() {


### PR DESCRIPTION
### Motivation
- Zmniejszyć „szarpanie” i widoczne migotanie markerów podczas powiększania/zmniejszania mapy bez zmiany wyglądu ikon.
- Ograniczyć kosztowne operacje add/remove markerów w czasie animacji zoomu, aby nie blokować UI przy dużej liczbie pinezek.

### Description
- Włączono `chunkedLoading` w `L.markerClusterGroup` i ustawiono parametry `chunkDelay` i `chunkInterval`, aby dodawanie grup markerów było porcjowane i mniej blokujące UI (`index.html`).
- Dodano flagi `markerZoomInProgress` i `markerVisibilityUpdateDeferred` oraz podpięto nasłuch do `zoomstart`/`zoomend`, aby odraczać aktualizacje widoczności markerów podczas aktywnego zoomu (`index.html`).
- Skrócono debounce wywołania z `120ms` do `80ms` i usunięto wywołania `showLoading()`/`hideLoading()` z `scheduleMarkerVisibilityUpdate`, aby zmniejszyć mikroprzycięcia i migotanie interfejsu (`index.html`).

### Testing
- Zastosowano i potwierdzono poprawki w pliku `index.html` przy użyciu automatycznych operacji patch/commit (`apply_patch` → success, `git add` + `git commit` wykonano pomyślnie`).
- Przejrzano wygenerowany diff i konkretne fragmenty pliku za pomocą `git diff`, `sed -n` i `nl -ba` aby zweryfikować wprowadzone zmiany; wszystkie komendy zakończyły się sukcesem.
- Nie wykryto regresji kompilacyjnej ani błędów podczas uruchomionych poleceń kontrolnych (brak automatycznych testów jednostkowych w repo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07112a6c308330bd4af83751d6bfd2)