### PR TITLE
Renderowanie markerów tylko w obrębie widoku mapy

### DIFF
--- a/index.html
+++ b/index.html
@@ -10107,7 +10107,10 @@ function getTripPointEmoji(p) {
 
     function pinIsInViewport(pin, paddedBounds) {
       if (!pin || typeof pin.lat !== 'number' || typeof pin.lng !== 'number') return false;
-      return true;
+      if (!map || typeof map.getBounds !== 'function') return true;
+      const viewportBounds = paddedBounds || map.getBounds();
+      if (!viewportBounds || typeof viewportBounds.contains !== 'function') return true;
+      return viewportBounds.contains([pin.lat, pin.lng]);
     }
 
     function scheduleMarkerVisibilityUpdate() {
@@ -10134,6 +10137,7 @@ function getTripPointEmoji(p) {
 
     function updateMarkerVisibility() {
       const viewportStartTs = performance.now();
+      const currentBounds = map?.getBounds?.() || null;
       const changedLayers = new Set();
       const layerOps = new Map();
       let totalAdded = 0;
@@ -10155,7 +10159,7 @@ function getTripPointEmoji(p) {
           beforeFilters++;
           const visibleByFilters = pinMatchesAllFilters(p, true) && p.visible !== false;
           if (visibleByFilters) afterFilters++;
-          const inViewport = visibleByFilters && pinIsInViewport(p, null);
+          const inViewport = visibleByFilters && pinIsInViewport(p, currentBounds);
           if (inViewport) inBounds++;
           const visible = layerVisible && layerChecked && inViewport;
           if (visible) {


### PR DESCRIPTION
### Motivation
- Zmniejszyć obciążenie renderera i poprawić zachowanie na urządzeniach mobilnych przez nie-renderowanie markerów znajdujących się poza aktualnym widokiem mapy.
- Zachować pełną listę pinezek w panelu bocznym niezależnie od tego, czy ich marker jest aktualnie dodany do warstwy mapy.

### Description
- Zmieniono funkcję `pinIsInViewport` tak, aby używała `map.getBounds().contains([lat, lng])` zamiast zawsze zwracać `true`.
- W `updateMarkerVisibility` obliczane są granice widoku mapy (`currentBounds`) raz na cykl i przekazywane do sprawdzeń dla każdego pina.
- Marker jest dodawany/usuwany z warstwy tylko gdy pin przejdzie walidację filtrów i znajdzie się wewnątrz granic widoku mapy, natomiast generowanie i wyświetlanie listy pinezek w panelu pozostaje bez zmian.

### Testing
- Uruchomiono `git status --short` aby potwierdzić zmodyfikowane pliki, polecenie zakończyło się pomyślnie.
- Wykonano `git add index.html && git commit -m "Render markers only within current map viewport"` i commit został utworzony pomyślnie.
- Wygenerowano opis PR przy pomocy narzędzia `make_pr`, które zwróciło tytuł i treść PR; zmiany są zaaplikowane w `index.html` i przygotowane do review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0713362b208330a2d5ce82d5f92a43)