### PR TITLE
Fix mobile pin modal: constrain height, enable internal scrolling and sticky action footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -11846,7 +11846,7 @@ function confirmLayerDelete() {
         <label><input type="checkbox" id="mobilePinVisited"> Zwiedzone <img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Green_check.svg" width="16" height="16" class="checkmark-obrys"></label>
         <label><input type="checkbox" id="mobilePinHighlighted"> Wyróżnione ⭐</label>
       </div>
-      <div style="display:flex;gap:10px;justify-content:center;">
+      <div class="mobile-pin-actions">
         <button id="mobilePinOk">Zapisz</button>
         <button id="mobilePinCancel">Anuluj</button>
       </div>

--- a/style.css
+++ b/style.css
@@ -289,6 +289,9 @@
   max-width: 500px;
   position: relative;
   z-index: 2147483601;
+  max-height: calc(100dvh - 24px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 .mobile-modal-content button {
   padding: 8px 12px;
@@ -299,6 +302,49 @@
 .mobile-modal-content button,
 .mobile-modal-content label {
   font-size: 24px;
+}
+
+.mobile-pin-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  position: sticky;
+  bottom: 0;
+  background: #2b2b2b;
+  padding: 10px 0 calc(12px + env(safe-area-inset-bottom));
+  margin-top: 6px;
+}
+
+@media (max-width: 800px) {
+  #mobilePinModal .mobile-modal-content {
+    width: min(92vw, 500px);
+    gap: 8px;
+    padding: 12px;
+  }
+
+  #mobilePinModal .mobile-modal-content input,
+  #mobilePinModal .mobile-modal-content select,
+  #mobilePinModal .mobile-modal-content textarea,
+  #mobilePinModal .mobile-modal-content button,
+  #mobilePinModal .mobile-modal-content label {
+    font-size: 16px;
+  }
+
+  #mobilePinModal .mobile-modal-content input,
+  #mobilePinModal .mobile-modal-content select,
+  #mobilePinModal .mobile-modal-content textarea {
+    min-height: 38px;
+    padding: 8px 10px;
+  }
+
+  #mobilePinModal .mobile-modal-content textarea {
+    min-height: 84px;
+    height: 84px !important;
+  }
+
+  #mobilePinModal .status-grid {
+    gap: 6px;
+  }
 }
 
 .gps-marker {


### PR DESCRIPTION
### Motivation
- Mobile pin-creation popup was taller than the viewport and its bottom action buttons could be cut off on phones with navigation bars or safe-area insets.
- The goal is to make the mobile form fit the screen, allow internal scrolling, and keep `Zapisz`/`Anuluj` always accessible without changing desktop layout or removing any form fields.

### Description
- Limit the mobile modal height with `max-height: calc(100dvh - 24px)` and enable internal scrolling via `overflow-y: auto` and `overscroll-behavior: contain` in `.mobile-modal-content` in `style.css`.
- Add a sticky action footer `.mobile-pin-actions` with `position: sticky; bottom: 0;` and safe-area-aware padding `padding-bottom: calc(12px + env(safe-area-inset-bottom))` so save/cancel are always available above system UI.
- Add a mobile media query (`@media (max-width: 800px)`) that reduces spacing, font-size and input/textarea heights to make the form more compact on phones while preserving desktop styles.
- Replace the inline action-row wrapper in `index.html` with the semantic `<div class="mobile-pin-actions">` so the sticky footer styling is applied cleanly and no form fields or logic were removed.

### Testing
- Located modal/fields using `rg` and updated `index.html`/`style.css`, then inspected diffs with `git diff` to confirm intended changes; these checks succeeded.
- Committed changes with `git commit` which completed successfully and created the PR content via the automated `make_pr` step; all commands returned success.
- No automated unit tests exist for this UI change; changes are limited to mobile CSS and markup with no modifications to form logic or fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f717bc548330b247efe07af98429)