### PR TITLE
Add desktop-equivalent photo upload to mobile pin creation modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -4310,7 +4310,7 @@ function emojiHtml(str) {
       next();
     }
 
-    function setupAddPhotoButton(btn, slug, gallery) {
+    function setupAddPhotoButton(btn, slug, gallery, options = {}) {
       if (!btn) return;
       btn.addEventListener('click', e => {
         e.stopPropagation();
@@ -4318,6 +4318,7 @@ function emojiHtml(str) {
         input.type = 'file';
         input.accept = 'image/*';
         input.multiple = true;
+        if (options.capture) input.setAttribute('capture', options.capture);
         input.addEventListener('change', () => {
           addPhotosToSlug(slug, Array.from(input.files || []), gallery);
         });
@@ -11564,9 +11565,9 @@ function confirmLayerDelete() {
     applyInactiveStyle(data);
     data.marker = marker;
     data.slug = slugify(data.nazwa);
-    if (!photosMap[data.slug]) {
-      storePhotos(data.slug, []);
-    }
+    const initialPhotos = Array.isArray(form.photos) ? form.photos.slice() : [];
+    const existingPhotos = getStoredPhotos(data.slug);
+    storePhotos(data.slug, existingPhotos.concat(initialPhotos));
     registerPinCountry(data);
     enqueueCountryFetch(data);
     const popupDiv = document.createElement('div');
@@ -11623,8 +11624,16 @@ function confirmLayerDelete() {
       const trudInput = document.getElementById('mobilePinTrudnosc');
       const trudLabel = document.getElementById('mobilePinTrudnoscLabel');
       const trudWrapper = document.getElementById('mobileTrudnoscWrapper');
+      const mobilePhotoGallery = document.getElementById('mobilePinPhotoGallery');
+      const mobileAddPhotoBtn = document.getElementById('mobilePinAddPhotoBtn');
       if (!btn || !modal || !ok || !cancel || !nameInput || !trudInput || !trudLabel || !trudWrapper) return;
       setupTrudnoscInput(trudInput, trudLabel);
+      const mobileDraftPhotosSlug = '__mobile_pin_draft__';
+      if (mobilePhotoGallery) {
+        mobilePhotoGallery.dataset.slug = mobileDraftPhotosSlug;
+        setupGallery(mobilePhotoGallery);
+      }
+      setupAddPhotoButton(mobileAddPhotoBtn, mobileDraftPhotosSlug, mobilePhotoGallery, { capture: 'environment' });
 
       let mobileEmojiPickerInitialized = false;
       function refreshMobileEmojiPicker() {
@@ -11682,6 +11691,8 @@ function confirmLayerDelete() {
       destroyedInput.checked = false;
       visitedInput.checked = false;
       highlightedInput.checked = false;
+      storePhotos(mobileDraftPhotosSlug, []);
+      if (mobilePhotoGallery) renderGallery(mobilePhotoGallery);
       descInput.style.display = '';
       layerInput.style.display = '';
       mainCatInput.style.display = '';
@@ -11751,8 +11762,11 @@ function confirmLayerDelete() {
           zwiedzone: visitedInput.checked,
           wyroznione: highlightedInput.checked,
           odKogo: fromInput.value,
-          trudnosc: trudInput.value
+          trudnosc: trudInput.value,
+          photos: getStoredPhotos(mobileDraftPhotosSlug)
         });
+        storePhotos(mobileDraftPhotosSlug, []);
+        if (mobilePhotoGallery) renderGallery(mobilePhotoGallery);
       } else {
         await saveMovingPin(name);
       }
@@ -11816,6 +11830,8 @@ function confirmLayerDelete() {
   <div id="osmOverlayStatus" class="osm-status-loading">Wczytywanie miejsc OSM dla aktualnego obszaru…</div>
   <div id="mobilePinModal" class="mobile-modal">
     <div class="mobile-modal-content">
+      <div class="photo-gallery mobile-pin-photo-gallery" id="mobilePinPhotoGallery"></div>
+      <button id="mobilePinAddPhotoBtn" class="popup-add-photo mobile-pin-add-photo-btn" type="button">📷</button>
       <input type="text" id="mobilePinName" placeholder="Nazwa pinezki" style="width: 100%">
       <textarea id="mobilePinDesc" placeholder="Opis" style="width: 100%; height: 100px"></textarea>
       <input type="text" id="mobilePinFrom" placeholder="Od kogo" style="width: 100%">

--- a/style.css
+++ b/style.css
@@ -315,6 +315,18 @@
   margin-top: 6px;
 }
 
+#mobilePinModal .mobile-pin-photo-gallery {
+  width: 100%;
+  min-height: 56px;
+  max-height: 180px;
+  overflow-y: auto;
+  border-radius: 8px;
+}
+
+#mobilePinModal .mobile-pin-add-photo-btn {
+  align-self: flex-start;
+}
+
 @media (max-width: 800px) {
   #mobilePinModal .mobile-modal-content {
     width: min(92vw, 500px);


### PR DESCRIPTION
### Motivation

- Mobilny popup tworzenia pinezki nie miał funkcji dodawania zdjęć tak jak formularz desktopowy, co uniemożliwia załączanie zdjęć przy tworzeniu pinezki na telefonie.

### Description

- Dodano do markup mobilnego popupu (`#mobilePinModal`) galerię miniatur oraz przycisk dodawania zdjęć (`#mobilePinPhotoGallery`, `#mobilePinAddPhotoBtn`) używając tego samego HTML/CSS patternu co na desktopzie.
- Rozszerzono istniejącą funkcję uploadu `setupAddPhotoButton` o opcjonalny parametr `options.capture` i uruchomiono ją dla mobilnego popupu z `capture: 'environment'` aby pozwolić na wybór z galerii i robienie zdjęć aparatem na telefonie.
- Mobilny panel korzysta z istniejących mechanizmów: `setupGallery`, `addPhotosToSlug`, `storePhotos` (bez tworzenia oddzielnego systemu uploadu), a draft zdjęć trzymany jest tymczasowo pod slugiem `__mobile_pin_draft__` i przekazywany do `saveCenterPin` przez pole `photos` aby zachować ten sam pipeline zapisu do Firestore/Storage co desktop.
- Dodano responsywne style w `style.css` dla `.mobile-pin-photo-gallery` (maksymalna wysokość, przewijanie) oraz drobne ustawienia przycisku, aby gallery nie łamała layoutu popupu i pozostał scrollowalny na małych ekranach.

### Testing

- Uruchomiono wyszukiwanie kodu (`rg`) aby potwierdzić punkty integracji z istniejącymi funkcjami uploadu i galerii (`setupAddPhotoButton`, `setupGallery`, `addPhotosToSlug`) — wynik zgodny z oczekiwaniem.
- Podejrzano zmienione fragmenty plików za pomocą `sed`/`nl` i sprawdzono różnicę przy użyciu `git diff` aby potwierdzić wprowadzone zmiany HTML/JS/CSS — weryfikacja zakończona pomyślnie.
- Wykonano podstawowe repo-checks (status/diff) i utworzono PR metadane; wszystkie automatyczne kroki kontroli plików przebiegły pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09fce39dd883308f1aa8f5594676e5)