### PR TITLE
Naprawa otwierania popupów pinezek — placeholder dla lazy markerów

### DIFF
--- a/index.html
+++ b/index.html
@@ -6310,13 +6310,14 @@ function zaladujPinezkiZFirestore() {
     p.lng = lng;
     const iconEmoji = warstwy[warstwaNazwa].emoji || p.emoji;
     const marker = L.marker([lat, lng], { icon: createEmojiIcon(iconEmoji, p.warstwaId, 32, p) });
+    marker.bindPopup('<div class="popup-container">Ładowanie…</div>');
     marker.on('popupopen', (evt) => {
       const popupStartTs = performance.now();
       if (!marker._popupBuilt) {
         const popupDiv = document.createElement("div");
         popupDiv.className = "popup-container";
         popupDiv.innerHTML = createPopupHtml(p);
-        marker.bindPopup(popupDiv);
+        evt.popup.setContent(popupDiv);
         attachPopupHandlers(marker, p);
         marker._popupBuilt = true;
       }


### PR DESCRIPTION
### Motivation
- Naprawić regresję, w której kliknięcie pinezki nie otwierało popupu, bo markery były tworzone bez przypisanego popupu i treść była dopiero wiązana w `popupopen`.

### Description
- W `index.html` w `createMarkerForPin` dodano natychmiastowe przypisanie placeholdera `marker.bindPopup('<div class="popup-container">Ładowanie…</div>')`, a późniejsze „lazy” uzupełnienie popupu realizowane jest przez `evt.popup.setContent(...)` zamiast ponownego `bindPopup(...)`.

### Testing
- Zastosowano automatyczne kroki w repo: plik został poprawiony (`patched`), zweryfikowano zmiany przez `git diff`, a następnie wykonano `git commit` oraz utworzono pull request; wszystkie kroki zakończyły się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ff7292d08330b2d299ea6ac0b661)