### PR TITLE
Always show pin add/edit form in mobile modal (avoid Leaflet popup on mobile)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6817,6 +6817,48 @@ function zaladujPinezkiZFirestore() {
       enforceLayerMatch();
     }
 
+    function isMobilePinFormPreferred() {
+      const narrow = window.matchMedia('(max-width: 800px)').matches;
+      const coarse = window.matchMedia('(pointer: coarse)').matches;
+      const touch = ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
+      return narrow || coarse || touch;
+    }
+
+    let activeMobileFormCleanup = null;
+    function closeMobileFormModalIfNeeded() {
+      if (typeof activeMobileFormCleanup === 'function') {
+        const cleanup = activeMobileFormCleanup;
+        activeMobileFormCleanup = null;
+        cleanup();
+      }
+    }
+
+    function openFormInMobileModal(formContainer, onClose) {
+      const modal = document.getElementById('mobilePinModal');
+      const modalContent = document.getElementById('mobilePinModalContent');
+      if (!modal || !modalContent) return false;
+      const originalContent = Array.from(modalContent.childNodes);
+      const cleanup = () => {
+        if (modal.dataset.customFormOpen !== '1') return;
+        modal.style.display = 'none';
+        modalContent.innerHTML = '';
+        originalContent.forEach(node => modalContent.appendChild(node));
+        modal.dataset.customFormOpen = '0';
+        modal.removeEventListener('click', backdropHandler);
+        if (typeof onClose === 'function') onClose();
+      };
+      const backdropHandler = (ev) => {
+        if (ev.target === modal) cleanup();
+      };
+      modalContent.innerHTML = '';
+      modalContent.appendChild(formContainer);
+      modal.dataset.customFormOpen = '1';
+      modal.style.display = 'flex';
+      modal.addEventListener('click', backdropHandler);
+      activeMobileFormCleanup = cleanup;
+      return cleanup;
+    }
+
     function edytuj(id, lat, lng) {
      /* console.log('Wywołano edytuj dla id:', id, 'lat:', lat, 'lng:', lng); // <-- dodane */
       const p = wszystkiePinezki.find(pp => pp.id === id);
@@ -6957,6 +6999,13 @@ function zaladujPinezkiZFirestore() {
       const marker = p.marker || findMarkerByLatLng(lat, lng);
       if (marker) {
         p.marker = marker;
+        if (isMobilePinFormPreferred()) {
+          map.closePopup();
+          openFormInMobileModal(container, () => {
+            delete p._editDraft;
+          });
+          return;
+        }
         if (marker._editCloseHandler) {
           marker.off('popupclose', marker._editCloseHandler);
         }
@@ -7096,6 +7145,7 @@ function zaladujPinezkiZFirestore() {
       generujListeWarstw();
       updateSaveButton();
       map.closePopup();
+      closeMobileFormModalIfNeeded();
     }
 
 
@@ -7227,7 +7277,14 @@ function zaladujPinezkiZFirestore() {
         window.__osmPrefillNewPin = null;
       }
 
-      const popup = marker.bindPopup(container).openPopup();
+      if (isMobilePinFormPreferred()) {
+        openFormInMobileModal(container, () => {
+          if (!saved && map.hasLayer(marker)) map.removeLayer(marker);
+          updateSaveButton();
+        });
+      } else {
+        marker.bindPopup(container).openPopup();
+      }
       attachHighlight(marker, null);
 
       const chkNewInactive = container.querySelector('#nieaktywneNew');
@@ -7353,11 +7410,13 @@ function zaladujPinezkiZFirestore() {
         generujListeWarstw();
         updateSaveButton();
         map.closePopup();
+        closeMobileFormModalIfNeeded();
       });
 
       container.querySelector("#cancelNew").addEventListener("click", (e) => {
         e.stopPropagation();
         map.closePopup();
+        closeMobileFormModalIfNeeded();
       });
     }
     async function onMapClick(e) {
@@ -11830,7 +11889,7 @@ function confirmLayerDelete() {
   <div id="gpsLoadingMessage">Wczytuję lokalizację GPS...</div>
   <div id="osmOverlayStatus" class="osm-status-loading">Wczytywanie miejsc OSM dla aktualnego obszaru…</div>
   <div id="mobilePinModal" class="mobile-modal">
-    <div class="mobile-modal-content">
+    <div id="mobilePinModalContent" class="mobile-modal-content">
       <div class="photo-gallery mobile-pin-photo-gallery" id="mobilePinPhotoGallery"></div>
       <button id="mobilePinAddPhotoBtn" class="popup-add-photo mobile-pin-add-photo-btn" type="button">📷</button>
       <input type="text" id="mobilePinName" placeholder="Nazwa pinezki" style="width: 100%">


### PR DESCRIPTION
### Motivation
- On mobile some pin add/edit flows opened the standard Leaflet popup (`leaflet-popup-content-wrapper`) instead of the dedicated mobile modal (`mobile-modal-content`), which breaks mobile UX. 
- The goal is to ensure mobile/touch/small-width devices always render the add/edit pin form inside the existing mobile modal and to avoid duplicating the form logic. 
- Desktop behavior with Leaflet popups must remain unchanged.

### Description
- Added `isMobilePinFormPreferred()` to detect mobile context using viewport width, `pointer: coarse` and touch capability. 
- Implemented modal lifecycle helpers `openFormInMobileModal()` and `closeMobileFormModalIfNeeded()` (with `activeMobileFormCleanup`) to inject the existing form container into `#mobilePinModalContent` and restore original modal content on close. 
- Routed existing edit flow (`edytuj`) and new-pin flow (`openNewPinPopup`, including search "dodaj pinezkę") to use the mobile modal when `isMobilePinFormPreferred()` returns true, avoiding opening `leaflet-popup-content-wrapper` on mobile. 
- Added `id="mobilePinModalContent"` to the existing `.mobile-modal-content` element and ensured save/cancel handlers invoke cleanup so all existing fields and handlers are reused without duplicating form logic.

### Testing
- Ran repository searches (`rg`) to locate popup/modal code paths and verify modifications applied to `edytuj` and `openNewPinPopup`, and these commands completed successfully. 
- Inspected the working diff with `git diff` to verify the exact changes and then committed the changes with `git commit`, and both commands succeeded. 
- Created the PR metadata via the project `make_pr` helper and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a023480788330802c2f4362f78580)