### PR TITLE
Fix mobile quick-save flow and marker popup binding

### DIFF
--- a/index.html
+++ b/index.html
@@ -10299,12 +10299,13 @@ function getTripPointEmoji(p) {
         if (pin.marker) return;
         const iconEmoji = layerData.emoji || pin.emoji;
         pin.marker = L.marker([pin.lat, pin.lng], { icon: createEmojiIcon(iconEmoji, pin.warstwaId, 32, pin) });
-        pin.marker.on('popupopen', () => {
+        pin.marker.bindPopup('<div class="popup-container">Ładowanie…</div>');
+        pin.marker.on('popupopen', (evt) => {
           if (!pin.marker._popupBuilt) {
             const popupDiv = document.createElement("div");
             popupDiv.className = "popup-container";
             popupDiv.innerHTML = createPopupHtml(pin);
-            pin.marker.bindPopup(popupDiv);
+            evt.popup.setContent(popupDiv);
             attachPopupHandlers(pin.marker, pin);
             pin.marker._popupBuilt = true;
           }
@@ -11545,7 +11546,7 @@ function confirmLayerDelete() {
         kategoria: '',
         kategoriaGlowna: MAIN_CATEGORY_URBEX,
         kraj: '',
-        emoji: '',
+        emoji: 'emoji39',
         trudnosc: 0,
         lat: currentLocation[0],
         lng: currentLocation[1],
@@ -11563,14 +11564,14 @@ function confirmLayerDelete() {
         kategoria: '',
         kategoriaGlowna: MAIN_CATEGORY_URBEX,
         kraj: '',
-        emoji: '',
+        emoji: 'emoji39',
         trudnosc: 0,
         lat: currentLocation[0],
         lng: currentLocation[1],
         dataDodania: Date.now(),
         slug: slugify(name)
       };
-    const marker = L.marker(currentLocation, {icon: createEmojiIcon('', movingLayerId)}).addTo(warstwy['Tryb w ruchu'].layer);
+    const marker = L.marker(currentLocation, {icon: createEmojiIcon('emoji39', movingLayerId)}).addTo(warstwy['Tryb w ruchu'].layer);
     const popupDiv = document.createElement('div');
     popupDiv.className = 'popup-container';
     popupDiv.innerHTML = createPopupHtml(data);
@@ -11714,6 +11715,10 @@ function confirmLayerDelete() {
 
     function openGpsModal() {
       nameInput.value = '';
+      storePhotos(mobileDraftPhotosSlug, []);
+      if (mobilePhotoGallery) renderGallery(mobilePhotoGallery);
+      if (mobilePhotoGallery) mobilePhotoGallery.style.display = 'none';
+      if (mobileAddPhotoBtn) mobileAddPhotoBtn.style.display = 'none';
       descInput.style.display = 'none';
       layerInput.style.display = 'none';
       mainCatInput.style.display = 'none';
@@ -11753,6 +11758,8 @@ function confirmLayerDelete() {
       highlightedInput.checked = false;
       storePhotos(mobileDraftPhotosSlug, []);
       if (mobilePhotoGallery) renderGallery(mobilePhotoGallery);
+      if (mobilePhotoGallery) mobilePhotoGallery.style.display = '';
+      if (mobileAddPhotoBtn) mobileAddPhotoBtn.style.display = '';
       descInput.style.display = '';
       layerInput.style.display = '';
       mainCatInput.style.display = '';


### PR DESCRIPTION
### Motivation
- Mobile quick-save (when `pinTool` is not active) should present only a minimal UI (name + confirm/cancel) and immediately persist the pin to the moving layer with a default emoji.
- Some markers had no popup bound initially which caused clicks/taps to not open the `leaflet-popup-content-wrapper`, so popups must be reliably available on first interaction.

### Description
- Set default emoji to `emoji39` for GPS quick-saved pins in both the Firestore payload and the local pin object, and use it when creating the marker icon (`Tryb w ruchu`).
- In the mobile GPS quick-save modal hide the photo gallery and camera button and clear its draft photos so the UI shows only the minimal name/confirm flow.
- Ensure markers created in `ensureLayerMarkersCreated` are bound with a lightweight placeholder popup (`<div class="popup-container">Ładowanie…</div>`) and replace the content lazily in the `popupopen` handler using `evt.popup.setContent(...)` so the popup always opens on first click/tap.
- Minor UI visibility toggles to restore photo controls for the full center/save modal and to hide them for the quick GPS modal.

### Testing
- Ran `git status --short` to confirm working tree state and it completed successfully.
- Used `git diff -- index.html` to inspect the patch and it showed the intended changes successfully.
- Committed changes with `git commit -m "Fix mobile quick-save modal and marker popup opening"` which completed successfully and a PR was created via the automated `make_pr` helper.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a07a3a4ec8330b6305ebbc270c510)