### PR TITLE
Add mobile modal Cancel button and make marker-clone clicks open reliably

### DIFF
--- a/index.html
+++ b/index.html
@@ -3199,6 +3199,14 @@ function slugify(str) {
         // If clone has its own popup, it gets destroyed on cluster refresh
         // after auto-pan/moveend and closes unexpectedly.
         clone.on('click', () => {
+          const visibleParent = clusterLayer && typeof clusterLayer.getVisibleParent === 'function'
+            ? clusterLayer.getVisibleParent(marker)
+            : null;
+          if (visibleParent === marker) {
+            marker.fire('click');
+            marker.openPopup();
+            return;
+          }
           if (clusterLayer && typeof clusterLayer.zoomToShowLayer === 'function') {
             clusterLayer.zoomToShowLayer(marker, () => {
               marker.fire('click');
@@ -6838,6 +6846,7 @@ function zaladujPinezkiZFirestore() {
       const modalContent = document.getElementById('mobilePinModalContent');
       if (!modal || !modalContent) return false;
       const originalContent = Array.from(modalContent.childNodes);
+      let closeBtn = null;
       const cleanup = () => {
         if (modal.dataset.customFormOpen !== '1') return;
         modal.style.display = 'none';
@@ -6845,12 +6854,21 @@ function zaladujPinezkiZFirestore() {
         originalContent.forEach(node => modalContent.appendChild(node));
         modal.dataset.customFormOpen = '0';
         modal.removeEventListener('click', backdropHandler);
+        if (closeBtn) closeBtn.removeEventListener('click', cleanup);
         if (typeof onClose === 'function') onClose();
       };
       const backdropHandler = (ev) => {
         if (ev.target === modal) cleanup();
       };
       modalContent.innerHTML = '';
+      closeBtn = document.createElement('button');
+      closeBtn.type = 'button';
+      closeBtn.id = 'mobileCustomFormCancel';
+      closeBtn.textContent = 'Anuluj';
+      closeBtn.style.alignSelf = 'flex-end';
+      closeBtn.style.marginBottom = '8px';
+      closeBtn.addEventListener('click', cleanup);
+      modalContent.appendChild(closeBtn);
       modalContent.appendChild(formContainer);
       modal.dataset.customFormOpen = '1';
       modal.style.display = 'flex';


### PR DESCRIPTION
### Motivation
- Mobile edit/new-pin forms opened inside the app modal had no explicit cancel control, forcing users to tap the backdrop to close them. 
- Markers cloned for rendering pins from very small clusters could require an extra zoom before their popup opened, making pins seem unclickable at some zoom levels.

### Description
- Added a created `mobileCustomFormCancel` button inside `openFormInMobileModal` that is appended to the mobile modal content and wired to the modal cleanup logic so the form can always be closed via an explicit “Anuluj” button (changes in `index.html`).
- Ensured the modal cleanup removes the button event listener when closing the custom mobile form (added `closeBtn` tracking and listener removal in `openFormInMobileModal`).
- Improved `buildSingleMarkerClone` click handler to first query `clusterLayer.getVisibleParent(marker)` and, if the marker is already the visible parent, immediately fire the marker click and open its popup, while keeping the existing `zoomToShowLayer` fallback for clustered cases (changes in `index.html`).

### Testing
- Ran repository checks including `git diff -- index.html` and `git status --short` to verify the intended changes are present, both succeeded. 
- Committed the updated `index.html` and created the PR programmatically, which completed successfully. 
- No automated unit tests were present or executed for this change in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a09df8dc88330be730719c64233e2)