### PR TITLE
Naprawa: nieklikalne przyciski w popupach — usuń skalowanie CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -5463,15 +5463,10 @@ function emojiHtml(str) {
         const maxWidth = Math.max(1, maxRight - maxLeft);
         const maxHeight = Math.max(1, maxBottom - minTop);
 
+        // Utrzymuj pełną skalę popupu — CSS zoom potrafi rozjechać hitboxy przycisków
+        // (np. edycja/usuwanie) na części przeglądarek i poziomów mapy.
         popupEl.style.zoom = '';
-        let popupRect = popupEl.getBoundingClientRect();
-        const widthScale = maxWidth / Math.max(1, popupRect.width);
-        const heightScale = maxHeight / Math.max(1, popupRect.height);
-        const popupScale = Math.max(0.55, Math.min(1, widthScale, heightScale));
-        if (popupScale < 1) {
-          popupEl.style.zoom = String(popupScale);
-          popupRect = popupEl.getBoundingClientRect();
-        }
+        const popupRect = popupEl.getBoundingClientRect();
 
         let dx = 0;
         let dy = 0;


### PR DESCRIPTION
### Motivation
- Poprawić problem, w którym przyciski `popup-edit-btn` / `popup-edit-pin-btn` nie reagowały na kliknięcia na niektórych pinezkach, co wynikało ze skalowania popupu przez CSS `zoom` i rozjeżdżania hitboxów przycisków.

### Description
- Usunięto skalowanie popupu przez ustawianie `style.zoom` w funkcji `panMapAfterPopupOpen` w `index.html` i dodano komentarz wyjaśniający, że `zoom` może rozjechać hitboxy; logika autopanu pozostała bez zmian.

### Testing
- Nie uruchomiono testów automatycznych dla tej zmiany.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1024dc7083309d546861771a21c9)