### PR TITLE
Fix popup edit button not responding on first click

### DIFF
--- a/index.html
+++ b/index.html
@@ -4939,6 +4939,10 @@ function emojiHtml(str) {
       const handler = e => {
         const container = e.popup.getElement();
         if (!container) return;
+        // Zapobiega przechwyceniu pierwszego kliknięcia przez mapę (zwłaszcza na mobile),
+        // przez co przyciski w popupie reagują od razu po otwarciu.
+        L.DomEvent.disableClickPropagation(container);
+        L.DomEvent.disableScrollPropagation(container);
         setupGallery(container.querySelector('.photo-gallery'));
         const btn = container.querySelector('.popup-edit-pin-btn');
         if (btn) {


### PR DESCRIPTION
### Motivation
- Fix the issue where popup action buttons (notably the `popup-edit-btn popup-edit-pin-btn`) did not respond to the first click/tap because the map sometimes intercepted the initial interaction, especially on touch devices.

### Description
- In `index.html` inside `attachPopupHandlers`, call `L.DomEvent.disableClickPropagation(container)` and `L.DomEvent.disableScrollPropagation(container)` when a popup opens so clicks and scrolls inside the popup are not swallowed by the map, ensuring buttons respond immediately.

### Testing
- No automated tests were executed for this change; the fix is a minimal DOM-event handling update and was committed after a local smoke check of the diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a12de8324833091d60082fdd07d5a)