### PR TITLE
Fix edit pin popup closing during map auto-pan

### DIFF
--- a/index.html
+++ b/index.html
@@ -10239,7 +10239,8 @@ function getTripPointEmoji(p) {
           if (visibleByFilters) afterFilters++;
           const inViewport = visibleByFilters && pinIsInViewport(p, currentBounds);
           if (inViewport) inBounds++;
-          const visible = layerVisible && layerChecked && inViewport;
+          const markerHasOpenPopup = typeof p.marker.isPopupOpen === 'function' && p.marker.isPopupOpen();
+          const visible = layerVisible && layerChecked && (inViewport || markerHasOpenPopup);
           if (visible) {
             if (!w.layer.hasLayer(p.marker)) toAdd.push(p.marker);
           } else {


### PR DESCRIPTION
### Motivation
- Naprawa problemu, w którym popup edycji pinezki zamykał się gdy mapa była automatycznie przesuwana, ponieważ mechanizm „lazy visibility” usuwał marker jeśli chwilowo wyszedł poza widoczne granice podczas auto-pan.

### Description
- W `updateMarkerVisibility()` zmieniono warunek widoczności markera tak, że marker jest traktowany jako widoczny gdy jest w widoku **lub** ma otwarty popup (sprawdzane bezpiecznie przez `typeof p.marker.isPopupOpen === 'function'`), zmiana dokonana w `index.html`.

### Testing
- Uruchomiono podstawowe kroki walidacji repozytorium: `git -C /workspace/ExploMapa status --short`, `git -C /workspace/ExploMapa add index.html` oraz `git -C /workspace/ExploMapa commit -m "Fix edit popup closing during map auto-pan"`, i zweryfikowano zawartość pliku poleceniem `nl -ba /workspace/ExploMapa/index.html | sed -n '10228,10255p'`, wszystkie komendy zakończyły się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad3b32fc8833086906b0257a41628)