### PR TITLE
Fix pin edit button on first popup open

### DIFF
--- a/index.html
+++ b/index.html
@@ -6318,6 +6318,7 @@ function zaladujPinezkiZFirestore() {
     const iconEmoji = warstwy[warstwaNazwa].emoji || p.emoji;
     const marker = L.marker([lat, lng], { icon: createEmojiIcon(iconEmoji, p.warstwaId, 32, p) });
     marker.bindPopup('<div class="popup-container">Ładowanie…</div>');
+    attachPopupHandlers(marker, p);
     marker.on('popupopen', (evt) => {
       const popupStartTs = performance.now();
       if (!marker._popupBuilt) {
@@ -6325,7 +6326,6 @@ function zaladujPinezkiZFirestore() {
         popupDiv.className = "popup-container";
         popupDiv.innerHTML = createPopupHtml(p);
         evt.popup.setContent(popupDiv);
-        attachPopupHandlers(marker, p);
         marker._popupBuilt = true;
       }
       updatePerformanceDebug('popup lazy render time', performance.now() - popupStartTs);


### PR DESCRIPTION
### Motivation
- Fix inconsistent behavior where the popup edit button did not respond on the very first popup open because click handlers were registered too late.

### Description
- Call `attachPopupHandlers(marker, p)` immediately after `bindPopup(...)` and remove the redundant late attachment inside the lazy popup-content build branch in `index.html` so handlers are present for the initial `popupopen`.

### Testing
- Ran `git diff -- index.html` to verify the change and committed the patch with `git commit -m "Fix pin edit button on first popup open"`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad8949b008330ba5e9af0939e614b)