### PR TITLE
Ustawienie emoji pickera obok przycisku zdjęcia i poprawa położenia Anuluj na mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -6864,10 +6864,16 @@ function zaladujPinezkiZFirestore() {
       closeBtn.type = 'button';
       closeBtn.id = 'mobileCustomFormCancel';
       closeBtn.textContent = 'Anuluj';
-      closeBtn.style.alignSelf = 'flex-end';
-      closeBtn.style.marginBottom = '8px';
+      closeBtn.style.marginLeft = '8px';
       closeBtn.addEventListener('click', cleanup);
-      modalContent.appendChild(closeBtn);
+      const saveBtnInForm = formContainer.querySelector('button[onclick^="zapiszLokalnie("]');
+      if (saveBtnInForm && saveBtnInForm.parentNode) {
+        saveBtnInForm.insertAdjacentElement('afterend', closeBtn);
+      } else {
+        closeBtn.style.alignSelf = 'flex-end';
+        closeBtn.style.marginBottom = '8px';
+        modalContent.appendChild(closeBtn);
+      }
       modalContent.appendChild(formContainer);
       modal.dataset.customFormOpen = '1';
       modal.style.display = 'flex';
@@ -6886,7 +6892,10 @@ function zaladujPinezkiZFirestore() {
       container.className = "popup-container edit-popup";
       container.innerHTML = `
         <div class="photo-gallery" data-slug="${p.slug}"></div>
-        <button class="popup-add-photo" data-slug="${p.slug}">📷</button>
+        <div class="popup-media-row">
+          <button class="popup-add-photo" data-slug="${p.slug}">📷</button>
+          <div id="emojiPicker-${id}" class="emoji-picker"></div>
+        </div>
         <input id="enazwa" value="${p.nazwa}" style="width: 100%"><br>
         <textarea id="eopis" style="width: 100%; height: 50px"></textarea><br>
         <input id="eodKogo" value="${p.odKogo || ''}" placeholder="Od kogo" style="width: 100%"><br>
@@ -6912,7 +6921,6 @@ function zaladujPinezkiZFirestore() {
         <button id="movePinBtn-${id}">📍 Zmień położenie</button>
         <button onclick="zapiszLokalnie('${id}')">💾 Zapisz</button>
         <button id="deleteBtn-${id}">🗑️</button>
-        <div id="emojiPicker-${id}" class="emoji-picker"></div>
       `;
       L.DomEvent.disableClickPropagation(container);
       const eOpisInput = container.querySelector('#eopis');
@@ -7241,7 +7249,10 @@ function zaladujPinezkiZFirestore() {
       L.DomEvent.disableClickPropagation(container);
       container.innerHTML = `
         <div class="photo-gallery" data-slug="${tempPin.slug}"></div>
-        <button class="popup-add-photo" data-slug="${tempPin.slug}">📷</button>
+        <div class="popup-media-row">
+          <button class="popup-add-photo" data-slug="${tempPin.slug}">📷</button>
+          <div id="emojiPickerNew" class="emoji-picker"></div>
+        </div>
         <input id="nazwaNew" placeholder="Nazwa" style="width: 100%"><br>
         <textarea id="opisNew" placeholder="Opis" style="width: 100%; height: 100px"></textarea><br>
         <input id="odKogoNew" placeholder="Od kogo" style="width: 100%"><br>
@@ -7265,8 +7276,7 @@ function zaladujPinezkiZFirestore() {
         </div>
         ${buildStatusGrid('', 'New')}
         <button id="saveNew">💾 Zapisz</button>
-        <button id="cancelNew">Anuluj</button>
-        <div id="emojiPickerNew" class="emoji-picker"></div>`;
+        <button id="cancelNew">Anuluj</button>`;
 
       setupGallery(container.querySelector('.photo-gallery'));
       setupAddPhotoButton(container.querySelector('.popup-add-photo'), tempPin.slug, container.querySelector('.photo-gallery'));

--- a/style.css
+++ b/style.css
@@ -127,6 +127,18 @@
   padding: 0;
 }
 
+.popup-media-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.popup-media-row .emoji-picker {
+  margin-left: auto;
+}
+
 .dropdown-arrow {
   position: absolute;
   right: 4px;


### PR DESCRIPTION
### Motivation
- Poprawić rozmieszczenie UI w popupie edycji i tworzenia pinezki tak, aby `emoji picker` był blisko i po prawej stronie przycisku `popup-add-photo`.
- Umieścić przycisk `mobileCustomFormCancel` (Anuluj) po prawej stronie obok przycisku zapisu lokalnego, gdy formularz zawiera `button` z `onclick="zapiszLokalnie(...)"`.

### Description
- Zmieniono logikę w `openFormInMobileModal`: tworzony jest `button#mobileCustomFormCancel` i wstawiany bezpośrednio po przycisku zapisu znalezionym przez selektor `button[onclick^="zapiszLokalnie(")`; jeśli taki przycisk nie istnieje, zachowany jest poprzedni fallback (ustawienie `alignSelf`/`marginBottom` i dołączenie do `modalContent`).
- W popupie edycji (`edytuj`) przeniesiono `div#emojiPicker-${id}` do nowego kontenera `.popup-media-row` obok `button.popup-add-photo` aby picker był po prawej stronie przycisku zdjęcia.
- W popupie tworzenia nowej pinezki przeniesiono `div#emojiPickerNew` do `.popup-media-row` obok `button.popup-add-photo` (analogicznie do edycji).
- Dodano CSS `.popup-media-row` i regułę `.popup-media-row .emoji-picker` w `style.css`, które ustawiają poziomy układ i dociskają pickera na prawą stronę.
- Zmienione pliki: `index.html`, `style.css`.

### Testing
- Wykonano automatyczne operacje Git: `git status --short`, `git add index.html style.css`, `git commit -m "Adjust pin popup layout for emoji picker and mobile cancel button"` i utworzono PR przez narzędzie `make_pr`; wszystkie polecenia zakończyły się sukcesem.
- Nie uruchamiano dodatkowych testów jednostkowych ani automatycznych testów UI w tym PR; zmiana dotyczy układu HTML/CSS i modyfikacji DOM w skryptach.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0adbbb8154833088a18fa2b0a03f0d)