### PR TITLE
Fix mobile emoji picker alignment in pin popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -5245,10 +5245,17 @@ function emojiHtml(str) {
       if (!preview || !grid || grid.style.display !== 'grid') return;
       const isMobile = window.matchMedia('(max-width: 700px)').matches;
       if (!isMobile) {
+        grid.style.left = '0';
+        grid.style.right = 'auto';
         grid.style.top = 'auto';
         grid.style.bottom = '34px';
         return;
       }
+
+      // Na mobile popup jest zwykle przy prawej krawędzi, więc otwieramy picker w lewo.
+      grid.style.left = 'auto';
+      grid.style.right = '0';
+
       const rect = preview.getBoundingClientRect();
       const openDown = rect.bottom + 260 < window.innerHeight;
       if (openDown) {


### PR DESCRIPTION
### Motivation
- Na mobilnej wersji picker emoji w popupie edycji/dodawania pinezki otwierał się w prawo i uciekał poza ekran, przez co był niewidoczny.
- Celem jest wymusić otwieranie pickera w lewo na małych ekranach tak, żeby cały grid był widoczny, przy zachowaniu dotychczasowego zachowania w pionie i na desktopie.

### Description
- Zaktualizowano funkcję `positionEmojiGrid` w `index.html` tak, że na desktopie pozostawiono poziome kotwiczenie po lewej (`grid.style.left = '0'; grid.style.right = 'auto';`).
- Dla mobilnego breakpointu (`max-width: 700px`) ustawiono kotwiczenie pickera po prawej stronie triggera (`grid.style.left = 'auto'; grid.style.right = '0';`), przy czym logika otwierania w górę/dół (`top`/`bottom`) pozostała bez zmian.

### Testing
- Brak zautomatyzowanych testów w tym statycznym frontendowym repozytorium. }

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae378c334833085bb90a3ec7a82f1)