### PR TITLE
Adjust mobile geosearch suggestions to avoid overlapping toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -1217,6 +1217,7 @@ body.mobile-layout #geosearch-container {
 }
 body.mobile-layout #geosearch-suggestions {
   left: 52px;
+  top: calc(100% + 56px);
 }
 body.mobile-layout #gpsFollowBtn {
   position: fixed;
@@ -1277,6 +1278,7 @@ body.mobile-layout #toggleBasemaps {
   }
   #geosearch-suggestions {
     left: 52px;
+    top: calc(100% + 56px);
   }
   #gpsFollowBtn {
     position: fixed;


### PR DESCRIPTION
### Motivation
- On small screens the geosearch suggestion dropdown could overlap the floating tool buttons, so the dropdown needs to be displayed lower to avoid covering the tools.

### Description
- Add `top: calc(100% + 56px);` to `body.mobile-layout #geosearch-suggestions` and the `@media (max-width: 700px) #geosearch-suggestions` rule in `index.html` to shift the suggestions dropdown below the toolbar.

### Testing
- No automated tests exist for this CSS-only layout change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae5a0921483309e36c49dce741d19)