### PR TITLE
Adjust emoji picker spacing and desktop alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -5247,8 +5247,8 @@ function emojiHtml(str) {
       if (!preview || !grid || grid.style.display !== 'grid') return;
       const isMobile = window.matchMedia('(max-width: 700px)').matches;
       if (!isMobile) {
-        grid.style.left = '0';
-        grid.style.right = 'auto';
+        grid.style.left = 'auto';
+        grid.style.right = '0';
         grid.style.top = 'auto';
         grid.style.bottom = '34px';
         return;

--- a/style.css
+++ b/style.css
@@ -56,15 +56,16 @@
     position: absolute;
     top: auto;
     bottom: 34px;
-    left: 0;
+    left: auto;
+    right: 0;
   background: #2b2b2b;
   border: 1px solid #444;
-  padding: 4px;
+  padding: 8px;
   display: none;
   z-index: 2000;
   grid-template-columns: repeat(8, 24px);
-  gap: 4px;
-  width: calc(8 * 24px + 7 * 4px);
+  gap: 8px;
+  width: calc(8 * 24px + 7 * 8px);
 }
 
 .emoji-picker-grid img {


### PR DESCRIPTION
### Motivation
- Improve emoji picker usability by increasing spacing so emoji tiles are not too close together.
- Align desktop picker to open to the left of the trigger so it appears beside the button on desktop instead of extending to the right.

### Description
- Increased the picker container `padding` and grid `gap`, and updated the computed `width` in `style.css` to give each emoji tile more margin (`.emoji-picker-grid`).
- Changed desktop alignment in the picker positioning logic in `index.html` to set `grid.style.left = 'auto'` and `grid.style.right = '0'` so the dropdown is right-aligned to the trigger button.
- Kept mobile behavior unchanged (picker still opens appropriately on small screens).

### Testing
- No automated tests were run for this visual/CSS-focused change. 
- Changes were committed locally and included `style.css` and `index.html` updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aed109e2c8330a7de03ece39b0ad6)