### PR TITLE
Fix popup pin actions during auto-pan

### DIFF
--- a/index.html
+++ b/index.html
@@ -4946,50 +4946,54 @@ function emojiHtml(str) {
         L.DomEvent.disableClickPropagation(container);
         L.DomEvent.disableScrollPropagation(container);
         setupGallery(container.querySelector('.photo-gallery'));
+        const bindPopupAction = (element, action) => {
+          if (!element) return;
+          let triggered = false;
+          const invoke = ev => {
+            ev.preventDefault();
+            ev.stopPropagation();
+            if (typeof ev.stopImmediatePropagation === 'function') ev.stopImmediatePropagation();
+            if (triggered) return;
+            triggered = true;
+            setTimeout(() => { triggered = false; }, 0);
+            action(ev);
+          };
+          element.addEventListener('pointerup', invoke);
+          element.addEventListener('click', invoke);
+        };
+
         const btn = container.querySelector('.popup-edit-pin-btn');
-        if (btn) {
-          btn.addEventListener('click', ev => {
-            ev.stopPropagation();
-            edytuj(p.id, p.lat, p.lng);
-          });
-        }
+        bindPopupAction(btn, () => {
+          edytuj(p.id, p.lat, p.lng);
+        });
+
         const deleteBtn = container.querySelector('.popup-delete-btn');
-        if (deleteBtn) {
-          deleteBtn.addEventListener('click', ev => {
-            ev.stopPropagation();
-            openDeleteModal(p.id);
-          });
-        }
+        bindPopupAction(deleteBtn, () => {
+          openDeleteModal(p.id);
+        });
+
         const rbtn = container.querySelector('.popup-route-add-btn');
-        if (rbtn) {
-          rbtn.addEventListener('click', ev => {
-            ev.stopPropagation();
-            map.closePopup();
-            startRouteDrawing(p);
-          });
-        }
+        bindPopupAction(rbtn, () => {
+          map.closePopup();
+          startRouteDrawing(p);
+        });
+
         const directBtn = container.querySelector('.popup-route-direct-btn');
-        if (directBtn) {
-          directBtn.addEventListener('click', ev => {
-            ev.stopPropagation();
-            map.closePopup();
-            routeToPin(p, directBtn);
-          });
-        }
+        bindPopupAction(directBtn, () => {
+          map.closePopup();
+          routeToPin(p, directBtn);
+        });
+
         const planBtn = container.querySelector('.popup-plan-btn');
-        if (planBtn) {
-          planBtn.addEventListener('click', ev => {
-            ev.stopPropagation();
-            map.closePopup();
-            startPlanUpload(p);
-          });
-        }
+        bindPopupAction(planBtn, () => {
+          map.closePopup();
+          startPlanUpload(p);
+        });
         const tripBtn = container.querySelector('.popup-trip-add-btn');
         if (tripBtn) {
           const tripBtnClean = tripBtn.cloneNode(true);
           tripBtn.replaceWith(tripBtnClean);
-          tripBtnClean.addEventListener('click', async ev => {
-            ev.stopPropagation();
+          bindPopupAction(tripBtnClean, async () => {
             await addPointToTripFromData({ type: 'existing', pinId: p.id, pinFirebaseId: p.firebaseId || null, nameSnapshot: p.nazwa, lat: p.lat, lng: p.lng, emojiSnapshot: p.emoji || '', defaultPointType: 'urbex', defaultVisitMinutes: 60 });
           });
         }


### PR DESCRIPTION
### Motivation
- Popup buttons (especially the edit button) could have their first press swallowed when opening a popup caused the map to auto-pan, making actions unresponsive until the popup was reopened. 
- The change aims to make popup action buttons responsive immediately after open even while the map is moving. 

### Description
- Added a local helper `bindPopupAction` inside `attachPopupHandlers` in `index.html` that binds both `pointerup` and `click`, calls `preventDefault`/`stopPropagation`/`stopImmediatePropagation` and deduplicates invocations to avoid lost or double events. 
- Replaced the previous per-button `click` handlers with `bindPopupAction` for the edit, delete, route-add, route-direct, plan and trip buttons and kept the trip button cloning logic while using the new helper. 
- Updated wiring so that `edytuj` and other actions are invoked reliably even during the manual auto-pan flow implemented for popups. 

### Testing
- No automated tests are configured for this repository, so no automated test runs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfe790e708330b11e9c2b32299c62)