### PR TITLE
Fix popup edit behavior for pins opened from list and desktop clicks

### DIFF
--- a/index.html
+++ b/index.html
@@ -4936,24 +4936,63 @@ function emojiHtml(str) {
       `;
     }
 
+    function rebindPinPopupAfterOpen(marker, p) {
+      if (!marker || !p) return;
+      attachPopupHandlers(marker, p);
+
+      setTimeout(() => {
+        if (marker.getPopup && marker.getPopup()) {
+          marker.openPopup();
+        }
+      }, 0);
+
+      if (map) {
+        map.once('moveend', () => {
+          attachPopupHandlers(marker, p);
+          setTimeout(() => {
+            const popup = marker.getPopup && marker.getPopup();
+            if (popup && popup.getElement()) {
+              marker.fire('popupopen', { popup });
+            }
+          }, 0);
+        });
+      }
+
+      setTimeout(() => {
+        const popup = marker.getPopup && marker.getPopup();
+        if (popup && popup.getElement()) {
+          marker.fire('popupopen', { popup });
+        }
+      }, 150);
+    }
+
     function attachPopupHandlers(marker, p) {
     /*  console.log('Wywołano attachPopupHandlers dla pinezki:', p); // <-- dodane */
       const bindPopupAction = (element, action) => {
         if (!element || element.dataset.popupActionBound === '1') return;
         element.dataset.popupActionBound = '1';
-        let triggered = false;
-        const invoke = ev => {
+
+        const blockEvent = ev => {
           ev.preventDefault();
           ev.stopPropagation();
           if (typeof ev.stopImmediatePropagation === 'function') ev.stopImmediatePropagation();
-          if (triggered) return;
-          triggered = true;
-          setTimeout(() => { triggered = false; }, 0);
+        };
+
+        const runAction = ev => {
+          blockEvent(ev);
+          if (element.dataset.popupActionRunning === '1') return;
+          element.dataset.popupActionRunning = '1';
+          setTimeout(() => {
+            element.dataset.popupActionRunning = '0';
+          }, 250);
           action(ev);
         };
-        ['pointerdown', 'touchstart', 'mousedown', 'click'].forEach(type => {
-          element.addEventListener(type, invoke, { passive: false });
-        });
+
+        element.addEventListener('pointerdown', blockEvent, { passive: false });
+        element.addEventListener('mousedown', blockEvent, { passive: false });
+        element.addEventListener('touchstart', blockEvent, { passive: false });
+        element.addEventListener('click', runAction);
+        element.addEventListener('touchend', runAction, { passive: false });
       };
 
       const bindCurrentPopupButtons = () => {
@@ -7791,10 +7830,16 @@ function zaladujPinezkiZFirestore() {
       const openPopupForPin = () => {
         updateMarkerVisibility();
         if (!p.marker || !layerData || typeof layerData.layer.zoomToShowLayer !== 'function') {
-          if (p.marker) p.marker.openPopup();
+          if (p.marker) {
+            p.marker.openPopup();
+            rebindPinPopupAfterOpen(p.marker, p);
+          }
           return;
         }
-        layerData.layer.zoomToShowLayer(p.marker, () => p.marker.openPopup());
+        layerData.layer.zoomToShowLayer(p.marker, () => {
+          p.marker.openPopup();
+          rebindPinPopupAfterOpen(p.marker, p);
+        });
       };
       let popupOpened = false;
       const openPopupOnce = () => {


### PR DESCRIPTION
### Motivation
- Mobile: opening a pin from the sidebar list opened the marker popup but skipped/rebroke popup handler binding so the edit button did not respond until popup was reopened. 
- Desktop: edit action could be triggered too early (on `pointerdown`/`mousedown`) causing Leaflet/document click to immediately close or switch the popup after the edit popup opened.

### Description
- Added a helper `rebindPinPopupAfterOpen(marker, p)` that calls `attachPopupHandlers(marker, p)`, forces `openPopup()`, and re-emits `popupopen` immediately and after `map` `moveend` to ensure list-opened popups get the same bindings as map-clicked popups.
- Updated `openPinFromList` to call `rebindPinPopupAfterOpen(...)` after each `marker.openPopup()` call including the `zoomToShowLayer` callback path.
- Refactored `bindPopupAction()` inside `attachPopupHandlers()` to separate blocking propagation (`pointerdown`/`mousedown`/`touchstart`) from running actions (`click`/`touchend`), and added a `data-popup-action-running` guard to debounce action invocations.

### Testing
- Located and inspected relevant code paths with `rg`/`sed` to confirm targets (`generujListeWarstw`, `attachPopupHandlers`, `openPinFromList`), which completed successfully.
- Verified the source diff with `git diff` and committed the changes with `git commit`, which succeeded.
- Printed file regions with `nl`/`sed` to confirm the inserted `rebindPinPopupAfterOpen` and modified `bindPopupAction`/`openPinFromList` logic, which matched the intended edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0a161a9883309a5d78cd07527ac2)