### PR TITLE
Zapobiegaj natychmiastowemu zamknięciu popupu edycji po auto-pan

### DIFF
--- a/index.html
+++ b/index.html
@@ -5442,6 +5442,7 @@ function emojiHtml(str) {
         pendingToken: 0,
         duringAutoPan: false
       };
+      let suppressPopupCloseUntil = 0;
 
       const osmOverlayCache = new Map();
       const OSM_OVERLAY_MIN_ZOOM = 14;
@@ -7099,6 +7100,7 @@ function zaladujPinezkiZFirestore() {
           marker.off('popupclose', marker._editCloseHandler);
         }
         const onClose = () => {
+          if (Date.now() < suppressPopupCloseUntil) return;
           delete p._editDraft;
           const popupDiv = document.createElement('div');
           popupDiv.className = 'popup-container';
@@ -7110,7 +7112,14 @@ function zaladujPinezkiZFirestore() {
           marker._editCloseHandler = null;
         };
         marker._editCloseHandler = onClose;
-        marker.bindPopup(container, {maxWidth: 400, minWidth: 400}).openPopup();
+        suppressPopupCloseUntil = Date.now() + 400;
+        marker.bindPopup(container, {
+          maxWidth: 400,
+          minWidth: 400,
+          autoPan: true,
+          autoPanPadding: [30, 30],
+          keepInView: false
+        }).openPopup();
         marker.on('popupclose', onClose);
       }
     }


### PR DESCRIPTION
### Motivation
- Na desktopie otwarcie popupu edycji przy krawędzi mapy powodowało, że Leaflet auto-pan lub inne zdarzenia zamykały świeżo otwarty popup, przerywając tryb edycji. 
- Celem jest zabezpieczenie momentu przejścia do trybu edycji tak, by krótkotrwały ruch mapy nie wywoływał natychmiastowego `popupclose` i nie cofał edycji.

### Description
- Dodano globalną zmienną `let suppressPopupCloseUntil = 0;` używaną do krótkiego tłumienia obsługi zamknięcia popupu. 
- W handlerze zamknięcia popupu edycji (`onClose`) dodano warunek `if (Date.now() < suppressPopupCloseUntil) return;` aby ignorować bliskie zdarzenia `popupclose` po wejściu w tryb edycji. 
- Przed otwarciem popupu edycji ustawiane jest `suppressPopupCloseUntil = Date.now() + 400;` i popup jest teraz bindowany z opcjami `{ autoPan: true, autoPanPadding: [30, 30], keepInView: false, maxWidth: 400, minWidth: 400 }` tak jak wymagano. 
- Pozostawiono dotychczasowe zachowanie przypinania/wiązania akcji przycisku edycji (wywołanie `edytuj()` na `click`/`touchend`, a blokowanie propagacji na `pointerdown`/`mousedown`/`touchstart`).

### Testing
- Nie uruchomiono zautomatyzowanych testów; zmiana została zweryfikowana przez przegląd kodu i inspekcję ścieżek otwierania/zamykania popupu oraz przez wyszukiwanie powiązanych fragmentów w repozytorium.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0ccdf0fc833082f56e167151afee)