### PR TITLE
Fix desktop edit popup autopan race on Leaflet

### DIFF
--- a/index.html
+++ b/index.html
@@ -5442,7 +5442,28 @@ function emojiHtml(str) {
         pendingToken: 0,
         duringAutoPan: false
       };
-      let suppressPopupCloseUntil = 0;
+      function restoreViewPopup(marker, p) {
+        if (!marker || !p) return;
+        p._isEditing = false;
+        delete p._editDraft;
+        const popupDiv = document.createElement('div');
+        popupDiv.className = 'popup-container';
+        popupDiv.innerHTML = createPopupHtml(p);
+        const popup = marker.getPopup();
+        if (popup) {
+          popup.setContent(popupDiv);
+          popup.options.maxWidth = 300;
+          popup.options.minWidth = undefined;
+          popup.options.autoPan = true;
+          popup.options.autoPanPadding = [30, 30];
+          popup.options.keepInView = false;
+          popup.update();
+        } else {
+          marker.bindPopup(popupDiv);
+        }
+        attachPopupHandlers(marker, p);
+        attachMarkerLongPress(marker, p);
+      }
 
       const osmOverlayCache = new Map();
       const OSM_OVERLAY_MIN_ZOOM = 14;
@@ -7089,9 +7110,11 @@ function zaladujPinezkiZFirestore() {
       const marker = p.marker || findMarkerByLatLng(lat, lng);
       if (marker) {
         p.marker = marker;
+        p._isEditing = true;
         if (isMobilePinFormPreferred()) {
           map.closePopup();
           openFormInMobileModal(container, () => {
+            p._isEditing = false;
             delete p._editDraft;
           });
           return;
@@ -7099,27 +7122,35 @@ function zaladujPinezkiZFirestore() {
         if (marker._editCloseHandler) {
           marker.off('popupclose', marker._editCloseHandler);
         }
-        const onClose = () => {
-          if (Date.now() < suppressPopupCloseUntil) return;
+        const editPopup = marker.getPopup();
+        const onClose = (e) => {
+          if (e && e.popup && e.popup !== editPopup) return;
+          if (!p._isEditing) return;
+          p._isEditing = false;
           delete p._editDraft;
-          const popupDiv = document.createElement('div');
-          popupDiv.className = 'popup-container';
-          popupDiv.innerHTML = createPopupHtml(p);
-          marker.bindPopup(popupDiv);
-          attachPopupHandlers(marker, p);
-          attachMarkerLongPress(marker, p);
           marker.off('popupclose', onClose);
           marker._editCloseHandler = null;
         };
         marker._editCloseHandler = onClose;
-        suppressPopupCloseUntil = Date.now() + 400;
-        marker.bindPopup(container, {
-          maxWidth: 400,
-          minWidth: 400,
-          autoPan: true,
-          autoPanPadding: [30, 30],
-          keepInView: false
-        }).openPopup();
+        const popup = marker.getPopup();
+        if (popup) {
+          popup.setContent(container);
+          popup.options.maxWidth = 400;
+          popup.options.minWidth = 400;
+          popup.options.autoPan = true;
+          popup.options.autoPanPadding = L.point(30, 30);
+          popup.options.keepInView = false;
+        } else {
+          marker.bindPopup(container, {
+            maxWidth: 400,
+            minWidth: 400,
+            autoPan: true,
+            autoPanPadding: L.point(30, 30),
+            keepInView: false
+          });
+        }
+        marker.openPopup();
+        if (marker.getPopup()) marker.getPopup().update();
         marker.on('popupclose', onClose);
       }
     }
@@ -7242,8 +7273,15 @@ function zaladujPinezkiZFirestore() {
       }
       generujListeWarstw();
       updateSaveButton();
-      map.closePopup();
-      closeMobileFormModalIfNeeded();
+      const mobileModalOpen = document.getElementById('mobilePinModal')?.dataset?.customFormOpen === '1';
+      if (mobileModalOpen) {
+        closeMobileFormModalIfNeeded();
+      } else if (p && p.marker) {
+        restoreViewPopup(p.marker, p);
+        p.marker.openPopup();
+      } else {
+        map.closePopup();
+      }
     }
 
 


### PR DESCRIPTION
### Motivation
- The edit popup on desktop was immediately replaced or closed when opening a large edit form that triggered Leaflet `autoPan`, because `popupclose` handlers rebounded the view popup during the edit transition and a previous `suppressPopupCloseUntil` timeout-based mitigation did not solve the race. 

### Description
- Added a `restoreViewPopup(marker, p)` helper that explicitly exits edit mode and restores the normal view popup content using `popup.setContent(...)` and reattaching handlers. 
- Reworked `edytuj(...)` desktop flow to reuse the existing popup (`marker.getPopup()` + `popup.setContent(container)` + `marker.openPopup()` + `popup.update()`) instead of rebinding a new popup instance. 
- Limited the edit `popupclose` handler to cleanup only the current edit popup by checking the event `e.popup` against the edit popup and verifying `p._isEditing`, and removed automatic rebinding of the view popup from that handler. 
- Replaced the timeout-based suppression logic with the explicit restore flow and ensured `zapiszLokalnie(...)` restores the view popup on desktop while keeping the mobile modal behavior unchanged. 

### Testing
- Searched and inspected modified sources with `rg` and `sed` to verify changes to `edytuj(...)`, `popupclose`, `suppressPopupCloseUntil` removal, and the new `restoreViewPopup` helper, and observed expected diffs. (commands executed: `rg -n ...`, `sed -n ...`, `nl -ba ...`). 
- Committed the change successfully (`git add` + `git commit`) and verified the working tree shows the intended single-file modification. 
- No unit tests exist for this UI flow; the above automated inspections and commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0f24b05c83308f2d4e71b1975147)