### PR TITLE
Fix edit popup reopening after close

### DIFF
--- a/index.html
+++ b/index.html
@@ -7123,9 +7123,7 @@ function zaladujPinezkiZFirestore() {
           marker.off('popupclose', marker._editCloseHandler);
           marker._editCloseHandler = null;
         }
-        const editPopup = marker.getPopup();
-        const onEditPopupClose = (e) => {
-          if (e && e.popup && e.popup !== editPopup) return;
+        const onEditPopupClose = () => {
           if (!p._isEditing) return;
 
           marker.off('popupclose', onEditPopupClose);


### PR DESCRIPTION
### Motivation
- Users reported that after opening the pin edit popup, closing it via the `X` button or by clicking outside, and then clicking the same pin, the edit popup reopened instead of the normal view popup, due to an overly strict popup-instance check in the edit-close handler in `edytuj` (in `index.html`).

### Description
- Simplified the edit popup close handler in `edytuj` by removing the popup-instance comparison (`e.popup !== editPopup`) and handling close unconditionally when the pin is still in edit mode, and wired it to `marker._editCloseHandler` in `index.html`.
- The change ensures `restoreViewPopup(marker, p)` runs on `popupclose` for the editing marker so the normal view popup is restored and `p._isEditing` is cleared.

### Testing
- No automated tests are present for this UI/Leaflet popup flow, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c465c23b0833089fde708f472c312)