### PR TITLE
Restore standard marker popup after closing edit popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -7124,11 +7124,8 @@ function zaladujPinezkiZFirestore() {
           marker._editCloseHandler = null;
         }
         const onEditPopupClose = () => {
-          if (!p._isEditing) return;
-
           marker.off('popupclose', onEditPopupClose);
           marker._editCloseHandler = null;
-
           restoreViewPopup(marker, p);
         };
 


### PR DESCRIPTION
### Motivation
- Fix a regression where closing the pin edit popup (using `X` or clicking outside) could leave the marker bound to edit-mode content so reopening the same marker opened the edit popup instead of the normal popup.

### Description
- In `index.html` simplified the edit-popup close handler by removing the conditional early return in `onEditPopupClose` so it always unbinds the handler and calls `restoreViewPopup(marker, p)`, guaranteeing the marker is restored to its standard popup.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4c833b04833087074b862914da13)