### PR TITLE
Fix stale edit popup reopening on marker click

### DIFF
--- a/index.html
+++ b/index.html
@@ -5060,6 +5060,11 @@ function emojiHtml(str) {
       };
 
       const handler = e => {
+        const popupElement = marker.getPopup && marker.getPopup() ? marker.getPopup().getElement() : null;
+        if (popupElement && popupElement.querySelector('.edit-popup') && !p._isEditing) {
+          restoreViewPopup(marker, p);
+          return;
+        }
         bindCurrentPopupButtons();
         setTimeout(bindCurrentPopupButtons, 0);
         map.once('moveend', bindCurrentPopupButtons);


### PR DESCRIPTION
### Motivation
- Fix a bug where after closing the edit popup (via X or clicking outside) clicking the same marker reopened the edit UI instead of the normal popup.

### Description
- Add a guard inside the popup-open handler in `attachPopupHandlers` that checks the popup DOM for `.edit-popup` and calls `restoreViewPopup(marker, p)` when the DOM shows edit UI but `p._isEditing` is false, preventing stale edit UI from being reattached (file: `index.html`).

### Testing
- Ran `git status --short`, `git diff -- index.html` and `git commit -m "Fix stale edit popup reopening on marker click"` to verify the change was applied and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c5237e1ac83309ae9adb2ac3cffed)