### PR TITLE
Fix Leaflet marker edit popup state on close

### DIFF
--- a/index.html
+++ b/index.html
@@ -7129,6 +7129,8 @@ function zaladujPinezkiZFirestore() {
           marker._editCloseHandler = null;
         }
         const onEditPopupClose = () => {
+          p._isEditing = false;
+          if (p._editDraft) delete p._editDraft;
           marker.off('popupclose', onEditPopupClose);
           marker._editCloseHandler = null;
           restoreViewPopup(marker, p);


### PR DESCRIPTION
### Motivation
- Naprawić problem, w którym zamknięcie popupa edycji (przycisk X / klik poza / zamiana popupa) nie resetowało stanu edycji, co powodowało ponowne otwarcie formularza edycji zamiast widoku podglądu przy kolejnym kliknięciu pinezki.

### Description
- W `edytuj(id, lat, lng)` zaktualizowano handler `popupclose` tak, aby ustawiać `p._isEditing = false`, usuwać draft przez `delete p._editDraft`, odpiąć handler (`marker.off('popupclose', ...)` i `marker._editCloseHandler = null`) oraz wywołać `restoreViewPopup(marker, p)` przed zakończeniem.

### Testing
- Wykonano commit zmiany w `index.html` oraz sprawdzono zawartość pliku przez `nl -ba ... | sed -n ...` i operacje zakończyły się pomyślnie; PR metadata utworzono przez `make_pr` i zakończyło się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c5bb5a8a483309404dfdd1d8a5071)