### PR TITLE
Poprawka: reset stanu edycji i globalny listener zamknięcia popupu

### DIFF
--- a/index.html
+++ b/index.html
@@ -5449,8 +5449,12 @@ function emojiHtml(str) {
       };
       function restoreViewPopup(marker, p) {
         if (!marker || !p) return;
+
+        // BEZWZGLĘDNY RESET STANU EDYCJI (Naprawa błędu otwierania starej edycji)
         p._isEditing = false;
-        delete p._editDraft;
+        if (p._editDraft) delete p._editDraft;
+        if (marker._editCloseHandler) marker._editCloseHandler = null;
+
         const popupDiv = document.createElement('div');
         popupDiv.className = 'popup-container';
         popupDiv.innerHTML = createPopupHtml(p);
@@ -7128,15 +7132,22 @@ function zaladujPinezkiZFirestore() {
           marker.off('popupclose', marker._editCloseHandler);
           marker._editCloseHandler = null;
         }
+        // --- POPRAWIONY HANDLER ZAMKNIĘCIA POPUPU EDYCJI ---
         const onEditPopupClose = () => {
-          p._isEditing = false;
-          if (p._editDraft) delete p._editDraft;
+          map.off('popupclose', onEditPopupCloseGlobal);
           marker.off('popupclose', onEditPopupClose);
           marker._editCloseHandler = null;
           restoreViewPopup(marker, p);
         };
 
+        const onEditPopupCloseGlobal = (e) => {
+          if (e.popup === marker.getPopup()) {
+            onEditPopupClose();
+          }
+        };
+
         marker._editCloseHandler = onEditPopupClose;
+
         const popup = marker.getPopup();
         if (popup) {
           popup.setContent(container);
@@ -7146,17 +7157,15 @@ function zaladujPinezkiZFirestore() {
           popup.options.autoPanPadding = L.point(30, 30);
           popup.options.keepInView = false;
         } else {
-          marker.bindPopup(container, {
-            maxWidth: 400,
-            minWidth: 400,
-            autoPan: true,
-            autoPanPadding: L.point(30, 30),
-            keepInView: false
-          });
+          marker.bindPopup(container, { maxWidth: 400, minWidth: 400, autoPan: true, autoPanPadding: L.point(30, 30), keepInView: false });
         }
+
+        // Bezpieczne podwójne nasłuchiwanie - na markerze i globalnie na mapie
+        marker.on('popupclose', onEditPopupClose);
+        map.on('popupclose', onEditPopupCloseGlobal);
+
         marker.openPopup();
         if (marker.getPopup()) marker.getPopup().update();
-        marker.on('popupclose', onEditPopupClose);
       }
     }
 


### PR DESCRIPTION
### Motivation
- MarkerClusterGroup może wirtualizować markery, przez co zdarzenia `popupclose` na poziomie markera bywają zawodné i po zamknięciu formularza edycji stan edycji pozostaje, co powoduje ponowne otwieranie formularza zamiast widoku.
- Celem jest bezwzględne wyczyszczenie stanu edycji i zagwarantowanie, że handler zamknięcia popupa zawsze wykona sprzątanie, nawet gdy marker jest wirtualizowany.

### Description
- W `restoreViewPopup(marker, p)` dodałem bezwzględny reset stanu edycji na samym początku funkcji: `p._isEditing = false`, warunkowe usunięcie `p._editDraft` oraz wyzerowanie `marker._editCloseHandler` przed przywróceniem zawartości popupu.
- W `edytuj(id, lat, lng)` zastąpiłem poprzedni handler zamknięcia popupa bezpiecznym mechanizmem z dwoma listenerami: lokalnym `marker.on('popupclose', onEditPopupClose)` i globalnym `map.on('popupclose', onEditPopupCloseGlobal)` z filtrem `e.popup === marker.getPopup()` oraz zapewniłem usunięcie obu listenerów podczas zamknięcia.
- Ujednoliciłem konfigurację popupu edycji (max/min width, autoPan i padding) i gwarantuję wywołanie `restoreViewPopup(marker, p)` przy zamknięciu, aby zawsze przywrócić widok w czystym stanie.

### Testing
- Potwierdzono obecność zmodyfikowanych funkcji poleceniem `rg -n "function restoreViewPopup|function edytuj\(" index.html`, które zakończyło się sukcesem.
- Wyświetlono fragmenty pliku z dokonanymi zmianami przy pomocy `sed -n '5438,5515p;7050,7165p' index.html` i sprawdzono poprawność zamian, co zakończyło się sukcesem.
- Zweryfikowano pozycję i kontekst zmian poprzez `nl -ba index.html | sed -n '5448,5490p;7124,7175p'`, które potwierdziło wprowadzone poprawki.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c5df50c8c8330b62be3a5778b40aa)