### PR TITLE
Reset popupu edycji po zamknięciu — zapobiegaj pozostawaniu trybu edycji

### DIFF
--- a/index.html
+++ b/index.html
@@ -5453,7 +5453,10 @@ function emojiHtml(str) {
         // BEZWZGLĘDNY RESET STANU (Naprawa błędu otwierania edycji)
         p._isEditing = false;
         if (p._editDraft) delete p._editDraft;
-        if (marker._editCloseHandler) marker._editCloseHandler = null;
+        if (marker._editCloseHandler) {
+          marker.off('popupclose', marker._editCloseHandler);
+          marker._editCloseHandler = null;
+        }
 
         const popupDiv = document.createElement('div');
         popupDiv.className = 'popup-container';
@@ -7134,10 +7137,13 @@ function zaladujPinezkiZFirestore() {
         }
         // --- POPRAWIONY HANDLER ZAMKNIĘCIA POPUPU EDYCJI ---
         const onEditPopupClose = () => {
-          map.off('popupclose', onEditPopupCloseGlobal);
           marker.off('popupclose', onEditPopupClose);
+          map.off('popupclose', onEditPopupCloseGlobal);
           marker._editCloseHandler = null;
-          restoreViewPopup(marker, p);
+
+          if (p._isEditing) {
+            restoreViewPopup(marker, p);
+          }
         };
 
         const onEditPopupCloseGlobal = (e) => {
@@ -7166,6 +7172,13 @@ function zaladujPinezkiZFirestore() {
 
         marker.openPopup();
         if (marker.getPopup()) marker.getPopup().update();
+        const popupEl = marker.getPopup()?.getElement?.();
+        const closeBtn = popupEl?.querySelector('.leaflet-popup-close-button');
+        if (closeBtn) {
+          closeBtn.addEventListener('click', () => {
+            restoreViewPopup(marker, p);
+          }, { once: true });
+        }
       }
     }
 


### PR DESCRIPTION
### Motivation
- Poprawka przy zawieraniu edycji powodowała efekt uboczny: po kliknięciu `X` edycja znikała, ale przy ponownym kliknięciu markera wciąż pokazywał się popup edycji zamiast startowego.  
- Celem jest zachować dotychczasowe podejście z `popup.setContent(container)` (żeby edycja nie znikała przy autoPan) oraz zapewnić, że każde zamknięcie edycji (przez `X`, klik poza popup lub `popupclose`) wykona pełny reset stanu popupu do trybu startowego.  

### Description
- W `restoreViewPopup(marker, p)` dodano odpinanie starego handlera przez `marker.off('popupclose', marker._editCloseHandler)` przed ustawieniem `marker._editCloseHandler = null`, oraz wykonanie bezwzględnego resetu `p._isEditing = false` i `delete p._editDraft`.  
- W `edytuj(...)` zmieniono `onEditPopupClose` tak, żeby sprzątał zarówno listener markerowy jak i globalny (`marker.off` i `map.off`), czyścił `marker._editCloseHandler` i wywoływał `restoreViewPopup(marker, p)` jedynie gdy `p._isEditing` jest prawdziwe.  
- Po podmianie contentu popupu edycji dodano bezpośredni, jednorazowy listener na przycisk `X` (`.leaflet-popup-close-button`) z `{ once: true }`, który wywołuje `restoreViewPopup(marker, p)` natychmiast przy kliknięciu.  
- Zachowano dotychczasowy mechanizm podmiany treści popupu (`popup.setContent(container)`) i konfigurację opcji popupu podczas edycji, aby nie wracać do wcześniejszego rozwiązania powodującego znikanie edycji przy autoPan.  

### Testing
- Nie uruchomiono automatycznych testów dla tej zmiany.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd10dcc808330aa15e52103661d98)