### PR TITLE
Fix edit popup persistence after closing pin popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -4936,34 +4936,16 @@ function emojiHtml(str) {
       `;
     }
 
-    function rebindPinPopupAfterOpen(marker, p) {
+    function bindCurrentPopupButtons(marker, p) {
       if (!marker || !p) return;
+      const popup = marker.getPopup && marker.getPopup();
+      if (!popup || !popup.getElement || !popup.getElement()) return;
       attachPopupHandlers(marker, p);
+      attachMarkerLongPress(marker, p);
+    }
 
-      setTimeout(() => {
-        if (marker.getPopup && marker.getPopup()) {
-          marker.openPopup();
-        }
-      }, 0);
-
-      if (map) {
-        map.once('moveend', () => {
-          attachPopupHandlers(marker, p);
-          setTimeout(() => {
-            const popup = marker.getPopup && marker.getPopup();
-            if (popup && popup.getElement()) {
-              marker.fire('popupopen', { popup });
-            }
-          }, 0);
-        });
-      }
-
-      setTimeout(() => {
-        const popup = marker.getPopup && marker.getPopup();
-        if (popup && popup.getElement()) {
-          marker.fire('popupopen', { popup });
-        }
-      }, 150);
+    function rebindPinPopupAfterOpen(marker, p) {
+      bindCurrentPopupButtons(marker, p);
     }
 
     function attachPopupHandlers(marker, p) {
@@ -5450,28 +5432,26 @@ function emojiHtml(str) {
       function restoreViewPopup(marker, p) {
         if (!marker || !p) return;
 
-        // BEZWZGLĘDNY RESET STANU (Naprawa błędu otwierania edycji)
         p._isEditing = false;
-        if (p._editDraft) delete p._editDraft;
+        delete p._editDraft;
+
         if (marker._editCloseHandler) {
           marker.off('popupclose', marker._editCloseHandler);
+          if (map) map.off('popupclose', marker._editCloseHandler);
           marker._editCloseHandler = null;
         }
 
         const popupDiv = document.createElement('div');
         popupDiv.className = 'popup-container';
         popupDiv.innerHTML = createPopupHtml(p);
-        const popup = marker.getPopup && marker.getPopup();
-        if (popup) {
-          popup.setContent(popupDiv);
-          popup.options.maxWidth = 300;
-          delete popup.options.minWidth;
-          popup.options.autoPan = true;
-          popup.options.keepInView = false;
-          popup.update();
-        } else {
-          marker.bindPopup(popupDiv);
-        }
+
+        marker.unbindPopup();
+        marker.bindPopup(popupDiv, {
+          maxWidth: 300,
+          autoPan: true,
+          keepInView: false
+        });
+
         attachPopupHandlers(marker, p);
         attachMarkerLongPress(marker, p);
       }
@@ -7176,7 +7156,7 @@ function zaladujPinezkiZFirestore() {
         const closeBtn = popupEl?.querySelector('.leaflet-popup-close-button');
         if (closeBtn) {
           closeBtn.addEventListener('click', () => {
-            restoreViewPopup(marker, p);
+            // popupclose obsłuży twardy reset widoku
           }, { once: true });
         }
       }


### PR DESCRIPTION
### Motivation
- Closing an edit popup (via Leaflet X or clicking outside) could leave the marker bound to the edit popup state so subsequent clicks reopened the edit view instead of the standard popup.

### Description
- Introduced `bindCurrentPopupButtons(marker, p)` which only attaches handlers to the currently-open popup without calling `marker.openPopup()` or firing synthetic events.
- Replaced the previous logic in `rebindPinPopupAfterOpen()` to call `bindCurrentPopupButtons()` and removed all automatic popup reopening and synthetic `marker.fire('popupopen', ...)` calls.
- Changed `restoreViewPopup(marker, p)` to perform a hard reset by clearing editing flags, unbinding the marker popup with `marker.unbindPopup()` and binding a fresh standard popup via `marker.bindPopup(...)`, then re-attaching handlers.
- Stopped re-opening the popup in the edit-close click handler and rely on `popupclose` to trigger `restoreViewPopup()` so no timeouts or `moveend` listeners can re-open the edit popup after it was closed.

### Testing
- Verified removal and presence of expected patterns with `rg -n "rebindPinPopupAfterOpen|bindCurrentPopupButtons|marker\.fire\('popupopen'|openPopup\(\);"` which shows the new helper and absence of synthetic `popupopen` firing.
- Committed the change with `git add index.html && git commit -m "Fix pin popup reset after closing edit popup"` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd27e5aec8330adb96b8f6bb1da6e)