### PR TITLE
Wymuś odtwarzanie popupu widoku przy każdym zwykłym otwarciu pinezki

### DIFF
--- a/index.html
+++ b/index.html
@@ -3206,18 +3206,18 @@ function slugify(str) {
             : null;
           if (visibleParent === marker) {
             marker.fire('click');
-            marker.openPopup();
+            openPinViewPopup(marker);
             return;
           }
           if (clusterLayer && typeof clusterLayer.zoomToShowLayer === 'function') {
             clusterLayer.zoomToShowLayer(marker, () => {
               marker.fire('click');
-              marker.openPopup();
+              openPinViewPopup(marker);
             });
             return;
           }
           marker.fire('click');
-          marker.openPopup();
+          openPinViewPopup(marker);
         });
         return clone;
       }
@@ -5044,7 +5044,7 @@ function emojiHtml(str) {
       const handler = e => {
         const popupElement = marker.getPopup && marker.getPopup() ? marker.getPopup().getElement() : null;
         if (popupElement && popupElement.querySelector('.edit-popup') && !p._isEditing) {
-          restoreViewPopup(marker, p);
+          ensureViewPopup(marker, p);
           return;
         }
         bindCurrentPopupButtons();
@@ -5429,10 +5429,9 @@ function emojiHtml(str) {
         pendingToken: 0,
         duringAutoPan: false
       };
-      function restoreViewPopup(marker, p) {
+      function ensureViewPopup(marker, p) {
         if (!marker || !p) return;
-
-        p._isEditing = false;
+        if (p._isEditing === true) return;
         delete p._editDraft;
 
         if (marker._editCloseHandler) {
@@ -5454,6 +5453,16 @@ function emojiHtml(str) {
 
         attachPopupHandlers(marker, p);
         attachMarkerLongPress(marker, p);
+      }
+
+      function openPinViewPopup(marker, p) {
+        if (!marker) return;
+        const pin = p || marker.__pinRef || wszystkiePinezki.find(item => item && item.marker === marker);
+        if (!pin) return;
+        marker.__pinRef = pin;
+        pin._isEditing = false;
+        ensureViewPopup(marker, pin);
+        marker.openPopup();
       }
 
       const osmOverlayCache = new Map();
@@ -7122,7 +7131,7 @@ function zaladujPinezkiZFirestore() {
           marker._editCloseHandler = null;
 
           if (p._isEditing) {
-            restoreViewPopup(marker, p);
+            ensureViewPopup(marker, p);
           }
         };
 
@@ -7288,8 +7297,7 @@ function zaladujPinezkiZFirestore() {
           p.marker.off('popupclose', p.marker._editCloseHandler);
           p.marker._editCloseHandler = null;
         }
-        restoreViewPopup(p.marker, p);
-        p.marker.openPopup();
+        openPinViewPopup(p.marker, p);
       } else {
         map.closePopup();
       }
@@ -7889,13 +7897,13 @@ function zaladujPinezkiZFirestore() {
         updateMarkerVisibility();
         if (!p.marker || !layerData || typeof layerData.layer.zoomToShowLayer !== 'function') {
           if (p.marker) {
-            p.marker.openPopup();
+            openPinViewPopup(p.marker, p);
             rebindPinPopupAfterOpen(p.marker, p);
           }
           return;
         }
         layerData.layer.zoomToShowLayer(p.marker, () => {
-          p.marker.openPopup();
+          openPinViewPopup(p.marker, p);
           rebindPinPopupAfterOpen(p.marker, p);
         });
       };
@@ -8020,7 +8028,7 @@ function zaladujPinezkiZFirestore() {
       }
       marker._highlightHandler = () => {
         if (drawingRoute) return;
-        marker.openPopup();
+        openPinViewPopup(marker, marker.__pinRef || null);
       };
       marker.on('click', marker._highlightHandler);
 


### PR DESCRIPTION
### Motivation
- Poprawka ma usunąć błąd, w którym po zamknięciu popupu edycji kolejne zwykłe otwarcie pinezki wciąż pokazywało stary content edycyjny zamiast startowego popupu, więc zamiast polegać tylko na „sprzątaniu” przy zamknięciu trzeba odbudowywać popup przed każdym zwykłym otwarciem.

### Description
- Dodano centralny helper `ensureViewPopup(marker, p)` który odbudowuje zwykły popup od zera, czyści `p._editDraft`, odpina handlery `popupclose` związane z edycją i podłącza normalne handlery popupu/long-press; jeśli `p._isEditing === true` to nic nie robi.
- Dodano helper `openPinViewPopup(marker, p)` który wymusza `p._isEditing = false`, rozwiązuje referencję do pinezki (`p` lub `marker.__pinRef` lub wyszukiwanie po `marker`) i wywołuje `ensureViewPopup(...)` przed `marker.openPopup()`.
- Zastąpiono wybrane bezpośrednie wywołania `marker.openPopup()` (klony markerów w overlayu klastrów, otwieranie z listy w `openPinFromList`, zwykłe kliknięcia w `attachHighlight`, oraz przy ponownym otwarciu po zapisie edycji) przez `openPinViewPopup(...)` oraz w niektórych miejscach użyto `ensureViewPopup(...)` zamiast poprzedniego `restoreViewPopup(...)`.
- Wprowadzono minimalne dodatkowe wiązanie `marker.__pinRef` aby ułatwić rozpoznanie obiektu pinezki przy otwieraniu z klona/overlayu.

### Testing
- Brak automatycznego testu integracyjnego w repo dla tych interakcji UI; nie uruchomiono automatycznych testów.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd3e354c08330b2ff313c8c27140d)