### PR TITLE
Wyśrodkowanie przycisku "Zapisz edycję mapy" na górze w mobilnym layoucie

### DIFF
--- a/index.html
+++ b/index.html
@@ -1260,6 +1260,15 @@ body.mobile-layout #toggleBasemaps {
   padding: 5px 10px;
   display: block !important;
 }
+body.mobile-layout #saveChanges {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 400;
+  width: auto;
+  min-width: 150px;
+}
 
 @media (max-width: 700px) {
   #map { left: 0 !important; right: 0 !important; }
@@ -1299,6 +1308,15 @@ body.mobile-layout #toggleBasemaps {
   .leaflet-control-zoom { left: 10px; }
   #toggleLayers { position: fixed; top: calc(env(safe-area-inset-top, 0px) + 10px); left: 10px; z-index: 400; background: #2b2b2b; color: #f0f0f0; border: 1px solid #444; padding: 5px 10px; display: block !important; }
   #toggleBasemaps { position: fixed; top: calc(env(safe-area-inset-top, 0px) + 10px); right: 10px; z-index: 400; background: #2b2b2b; color: #f0f0f0; border: 1px solid #444; padding: 5px 10px; display: block !important; }
+  #saveChanges {
+    position: fixed;
+    top: calc(env(safe-area-inset-top, 0px) + 10px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 400;
+    width: auto;
+    min-width: 150px;
+  }
 }
 
 @media (max-width: 1200px) {


### PR DESCRIPTION
### Motivation
- Przyciski „Warstwy” i „Mapy” są na górnej belce w mobile, więc przeniesiono przycisk „Zapisz edycję mapy” z panelu bocznego na środek górnej belki w widoku mobilnym, bez zmian dla desktopu.

### Description
- Dodano reguły CSS w `index.html` (`body.mobile-layout #saveChanges` oraz w `@media (max-width: 700px)`) ustawiające `position: fixed`, `top: calc(env(safe-area-inset-top, 0px) + 10px)`, `left: 50%`, `transform: translateX(-50%)`, `z-index: 400` oraz `min-width: 150px` dla `#saveChanges`.

### Testing
- Nie uruchomiono zautomatyzowanych testów UI; zmiana to wyłącznie pozycjonowanie CSS i nie ma testów automatycznych w repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cdb6d756c8330aab80e375e2f2f48)