### PR TITLE
Fix mobile popup edit button not responding after switching pins

### DIFF
--- a/index.html
+++ b/index.html
@@ -4990,6 +4990,7 @@ function emojiHtml(str) {
         };
 
         element.addEventListener('pointerdown', blockEvent, { passive: false });
+        element.addEventListener('pointerup', runAction, { passive: false });
         element.addEventListener('mousedown', blockEvent, { passive: false });
         element.addEventListener('touchstart', blockEvent, { passive: false });
         element.addEventListener('click', runAction);


### PR DESCRIPTION
### Motivation
- On mobile the popup action buttons (e.g. edit) could be ignored right after switching pins because the first interaction was swallowed by the map, so the edit button must respond immediately when the user taps it.

### Description
- Added a `pointerup` handler to `bindPopupAction` in `index.html` so popup actions run on `pointerup` in addition to existing `click`/`touchend` handlers while keeping the existing `popupActionRunning` guard.

### Testing
- Ran the commit workflow (`git add index.html` and `git commit`) and created the PR via the automated `make_pr` call, and those steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d043b09e483308f12b657b41726ba)