### PR TITLE
Przenieś `saveChanges` poza wysuwany panel `basemap-switcher` (mobile)

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,23 +84,6 @@
       overflow-y: auto;
       padding-right: 4px;
     }
-    #basemap-actions {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-      margin-top: auto;
-    }
-    #basemap-actions button {
-      width: 100%;
-      background: #2b2b2b;
-      border: 1px solid #444;
-      border-radius: 4px;
-      color: #f0f0f0;
-      cursor: pointer;
-      padding: 8px 10px;
-      font-size: 13px;
-      font-weight: 600;
-    }
     #history-log {
       border-top: 1px solid #444;
       margin-top: 10px;
@@ -2240,6 +2223,7 @@ img.emoji {
   <div id="planOptions" class="plan-option-panel" style="display:none;"></div>
   <button id="toggleLayers">☰ Warstwy</button>
   <button id="toggleBasemaps">☰ Mapy</button>
+  <button id="saveChanges">Zapisz edycję mapy</button>
   <div id="basemap-switcher">
     <div id="basemap-content">
       <h3>Rodzaj mapy</h3>
@@ -2316,9 +2300,6 @@ img.emoji {
       </div>
       <h3>Historia edycji</h3>
       <div id="history-log"></div>
-    </div>
-    <div id="basemap-actions">
-      <button id="saveChanges">Zapisz edycję mapy</button>
     </div>
   </div>
   <div id="layer-editor">


### PR DESCRIPTION
### Motivation
- Na mobilnej wersji przycisk zapisu `#saveChanges` był częścią wysuwanego panelu `#basemap-switcher`, przez co mógł być niewidoczny kiedy panel jest schowany.
- Celem zmiany jest, aby przycisk zapisu był zawsze dostępny na ekranie mobilnym i nie przewijał się razem z panelem bazmap.

### Description
- Przeniesiono element `button id="saveChanges"` z wnętrza `#basemap-switcher` do paska obok `#toggleBasemaps` w `index.html` (przed elementem `#basemap-switcher`).
- Usunięto nieużywany kontener `#basemap-actions` oraz powiązany blok stylów CSS znajdujący się w `index.html`.
- Logika JavaScript odwołująca się do elementu `#saveChanges` pozostała bez zmian (identyfikator elementu nie został zmodyfikowany).

### Testing
- Uruchomiono `rg -n "basemap-actions|id=\"saveChanges\"" index.html` aby potwierdzić pozycję elementu i brak starego kontenera, komenda zakończyła się pomyślnie.
- Sprawdzono różnicę pliku poleceniem `git diff -- index.html` oraz potwierdzono zapis zmian przez `git commit`, oba kroki zakończyły się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d06aa19bc8330b1451da52e1ddc19)