### PR TITLE
Fix mobile trip/pins mode activation event handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -12361,24 +12361,29 @@ function confirmLayerDelete() {
   }
 
     function reset(){ els.start.disabled=false; els.stop.disabled=true; abortFlag=false; }
-    let tripModeTapLock = 0;
+    function isTouchOrPointerEvent(e) {
+      return !!e && (e.type === 'touchend' || e.type === 'pointerup');
+    }
 
     async function activateTripModeFromEvent(e) {
-      if (e) {
+      if (isTouchOrPointerEvent(e)) {
         e.preventDefault();
         e.stopPropagation();
       }
-      const now = Date.now();
-      if (now - tripModeTapLock < 350) return;
-      tripModeTapLock = now;
 
-      console.log('Plan tripu clicked', e?.type);
+      console.log(`Trip mode activated by: ${e?.type || 'unknown'}`);
 
       setTripMode('trip');
+      document.body.classList.add('trip-planner-mode');
 
       const tripPanel = document.getElementById('tripPlannerPanel');
       if (tripPanel) {
         tripPanel.style.display = 'block';
+      }
+
+      if (document.body.classList.contains('mobile-layout')) {
+        const sidebar = document.getElementById('sidebar');
+        sidebar?.classList.add('show');
       }
 
       const user = firebase.auth().currentUser;
@@ -12393,18 +12398,16 @@ function confirmLayerDelete() {
       applyTripPlannerPinVisibility();
 
       if (document.body.classList.contains('mobile-layout')) {
-        const sidebar = document.getElementById('sidebar');
-        sidebar?.classList.add('show');
         setTimeout(() => tripPanel?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 100);
       }
     }
 
     function activatePinsModeFromEvent(e) {
-      if (e) {
+      if (isTouchOrPointerEvent(e)) {
         e.preventDefault();
         e.stopPropagation();
       }
-      console.log('Pinezki clicked', e?.type);
+      console.log(`Pins mode activated by: ${e?.type || 'unknown'}`);
       setTripMode('pins');
     }
 
@@ -12429,16 +12432,24 @@ function confirmLayerDelete() {
     const modePinsBtn = document.getElementById('modePinsBtn');
     const modeTripBtn = document.getElementById('modeTripBtn');
 
+    const supportsPointerEvents = typeof window !== 'undefined' && 'PointerEvent' in window;
+
     if (modePinsBtn) {
-      modePinsBtn.addEventListener('click', activatePinsModeFromEvent);
-      modePinsBtn.addEventListener('touchend', activatePinsModeFromEvent, { passive: false });
-      modePinsBtn.addEventListener('pointerup', activatePinsModeFromEvent);
+      if (supportsPointerEvents) {
+        modePinsBtn.addEventListener('pointerup', activatePinsModeFromEvent);
+      } else {
+        modePinsBtn.addEventListener('touchend', activatePinsModeFromEvent, { passive: false });
+        modePinsBtn.addEventListener('click', activatePinsModeFromEvent);
+      }
     }
 
     if (modeTripBtn) {
-      modeTripBtn.addEventListener('click', activateTripModeFromEvent);
-      modeTripBtn.addEventListener('touchend', activateTripModeFromEvent, { passive: false });
-      modeTripBtn.addEventListener('pointerup', activateTripModeFromEvent);
+      if (supportsPointerEvents) {
+        modeTripBtn.addEventListener('pointerup', activateTripModeFromEvent);
+      } else {
+        modeTripBtn.addEventListener('touchend', activateTripModeFromEvent, { passive: false });
+        modeTripBtn.addEventListener('click', activateTripModeFromEvent);
+      }
     }
     document.getElementById('tripSelect')?.addEventListener('change', e => { activeTripId = e.target.value || null; activeTripDayId = null; renderTripPlannerPanel(); renderTripMapLayers(); applyTripPlannerPinVisibility(); });
     document.getElementById('tripPinsVisibilityToggle')?.addEventListener('click', () => { hideMainPinsInTripMode = !hideMainPinsInTripMode; applyTripPlannerPinVisibility(); });


### PR DESCRIPTION
### Motivation
- Real phones experienced missed activations because buttons had `click` + `touchend` + `pointerup` listeners and a 350ms tap lock, causing event conflicts or suppression. 
- The goal is to provide a single, robust tap/click handling path that works reliably on modern phones and fallbacks for older browsers without removing existing trip-planner functions.

### Description
- Replaced the 350ms `tripModeTapLock` logic with a small helper `isTouchOrPointerEvent(e)` and explicit handling that only prevents default/propagation for touch/pointer events. 
- Added capability detection `supportsPointerEvents` and bound listeners so that when `PointerEvent` is available only `pointerup` is attached, otherwise `touchend` + `click` are used as a fallback. 
- Ensured `activateTripModeFromEvent` always performs the requested UI changes before loading data: `setTripMode('trip')`, `document.body.classList.add('trip-planner-mode')`, `tripPlannerPanel.style.display = 'block'`, and on mobile `sidebar.classList.add('show')`. 
- Added informative logs with event type: `Trip mode activated by: ...` and `Pins mode activated by: ...`, and left all existing trip planner helper functions intact.

### Testing
- Ran `git diff -- index.html` to inspect the patch and it succeeded showing the intended changes. 
- Committed the change with `git commit -m "Fix trip mode button handling on real mobile devices"` and the commit succeeded. 
- Created the PR metadata and verification via the repository PR helper and it completed; there were no automated unit tests to run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0853f6c08330868fad19a03e5b26)