### PR TITLE
Add trip planner mobile diagnostics and robust activation handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -9629,7 +9629,10 @@ function getTripPointEmoji(p) {
       if (!sel || !box) return;
       sel.innerHTML = '<option value="">Wybierz trip</option>' + tripPlannerTrips.map(t => `<option value="${t.id}" ${t.id===activeTripId?'selected':''}>${t.name}</option>`).join('');
       const trip = getActiveTrip();
-      if (!trip) { box.innerHTML = '<div>Brak aktywnego tripa.</div>'; return; }
+      if (!trip) {
+        box.innerHTML = '<div class="trip-empty-state"><b>Wybierz albo utwórz trip</b><div><small>Użyj listy „Wybierz trip” albo przycisku „+ Nowy trip”.</small></div></div>';
+        return;
+      }
       ensureActiveTripDay(trip);
       const tripRange = trip.startDate && trip.endDate ? `<div><small>${formatTripHeaderDate(trip.startDate)} → ${formatTripHeaderDate(trip.endDate)}</small></div>` : '';
       box.innerHTML = `<div><b>${trip.name}</b></div>${tripRange}<button id="tripAddDayBtn" type="button">+ Dodaj dzień</button><button id="tripAddPrivatePointBtn" type="button">+ Punkt tylko do tripa</button><button id="tripExportCsvBtn" type="button">⬇️ CSV</button><button id="tripExportPdfBtn" type="button">⬇️ PDF</button><button id="tripDeleteBtn" class="trip-icon-btn" type="button" title="Usuń trip" aria-label="Usuń trip">🗑️</button>` + trip.days.map((d, idx) => {
@@ -12377,13 +12380,60 @@ function confirmLayerDelete() {
       return !!e && (e.type === 'touchend' || e.type === 'pointerup');
     }
 
+    let tripModeMutationObserverAttached = false;
+    function attachTripModeMutationObserver() {
+      if (tripModeMutationObserverAttached || typeof MutationObserver === 'undefined') return;
+      const tripPanel = document.getElementById('tripPlannerPanel');
+      const observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+          if (mutation.type !== 'attributes') return;
+          if (mutation.target === document.body && mutation.attributeName === 'class') {
+            console.log('[trip-mode][observer] body.class changed', document.body.className);
+          }
+          if (tripPanel && mutation.target === tripPanel && mutation.attributeName === 'style') {
+            console.log('[trip-mode][observer] tripPlannerPanel.style changed', tripPanel.getAttribute('style') || '');
+          }
+        });
+      });
+      observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+      if (tripPanel) observer.observe(tripPanel, { attributes: true, attributeFilter: ['style'] });
+      tripModeMutationObserverAttached = true;
+      console.log('[trip-mode] mutation observers attached');
+    }
+
+    function logTripModeDiagnostics(eventType) {
+      const tripPanel = document.getElementById('tripPlannerPanel');
+      const tripActiveBox = document.getElementById('tripActiveBox');
+      const sidebar = document.getElementById('sidebar');
+      const styles = tripPanel ? window.getComputedStyle(tripPanel) : null;
+      console.log('[trip-mode][diagnostics]', {
+        eventType,
+        bodyHasTripPlannerMode: document.body.classList.contains('trip-planner-mode'),
+        bodyClassName: document.body.className,
+        tripPlannerPanelExists: !!tripPanel,
+        tripPlannerPanelComputedDisplay: styles?.display,
+        tripPlannerPanelInlineDisplay: tripPanel?.style?.display ?? null,
+        tripPlannerPanelComputedVisibility: styles?.visibility,
+        tripPlannerPanelComputedOpacity: styles?.opacity,
+        tripActiveBoxExists: !!tripActiveBox,
+        tripActiveBoxInnerHtmlLength: tripActiveBox?.innerHTML?.length ?? 0,
+        tripPlannerTripsLength: Array.isArray(tripPlannerTrips) ? tripPlannerTrips.length : -1,
+        activeTripId,
+        sidebarHasShow: !!sidebar?.classList?.contains('show'),
+        windowInnerWidth: window.innerWidth,
+        pointerCoarse: window.matchMedia('(pointer: coarse)').matches,
+        userAgent: navigator.userAgent
+      });
+    }
+
     async function activateTripModeFromEvent(e) {
       if (isTouchOrPointerEvent(e)) {
         e.preventDefault();
         e.stopPropagation();
       }
 
-      console.log(`Trip mode activated by: ${e?.type || 'unknown'}`);
+      attachTripModeMutationObserver();
+      logTripModeDiagnostics(e?.type || 'unknown:before');
 
       setTripMode('trip');
       document.body.classList.add('trip-planner-mode');
@@ -12401,17 +12451,51 @@ function confirmLayerDelete() {
       const user = firebase.auth().currentUser;
       if (!user) {
         showToast('Najpierw zaloguj się');
+        logTripModeDiagnostics(e?.type || 'unknown:no-user');
         return;
       }
 
-      await loadTrips();
-      renderTripPlannerPanel();
-      renderTripMapLayers();
-      applyTripPlannerPinVisibility();
+      try {
+        await loadTrips();
+      } catch (err) {
+        console.error('[trip-mode] loadTrips failed', err);
+        showToast('Błąd ładowania planu tripu: ' + (err?.message || err));
+      }
+      try {
+        renderTripPlannerPanel();
+      } catch (err) {
+        console.error('[trip-mode] renderTripPlannerPanel failed', err);
+        showToast('Błąd renderowania planu tripu: ' + (err?.message || err));
+      }
+      try {
+        renderTripMapLayers();
+      } catch (err) {
+        console.error('[trip-mode] renderTripMapLayers failed', err);
+        showToast('Błąd renderowania warstw tripu: ' + (err?.message || err));
+      }
+      try {
+        applyTripPlannerPinVisibility();
+      } catch (err) {
+        console.error('[trip-mode] applyTripPlannerPinVisibility failed', err);
+        showToast('Błąd widoczności pinezek tripu: ' + (err?.message || err));
+      }
+
+      document.body.classList.add('trip-planner-mode');
+      if (tripPanel) {
+        tripPanel.style.removeProperty('display');
+        tripPanel.offsetHeight;
+        tripPanel.style.display = 'block';
+      }
 
       if (document.body.classList.contains('mobile-layout')) {
-        setTimeout(() => tripPanel?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 100);
+        const sidebar = document.getElementById('sidebar');
+        setTimeout(() => {
+          sidebar?.classList.add('show');
+          tripPanel?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 150);
       }
+
+      logTripModeDiagnostics(e?.type || 'unknown:after');
     }
 
     function activatePinsModeFromEvent(e) {
@@ -12424,6 +12508,10 @@ function confirmLayerDelete() {
     }
 
     function setTripMode(mode) {
+      const prevMode = tripPlannerMode;
+      if (prevMode !== mode) {
+        console.log('[trip-mode] setTripMode', { prevMode, nextMode: mode });
+      }
       tripPlannerMode = mode;
       document.getElementById('modePinsBtn')?.classList.toggle('active', mode === 'pins');
       document.getElementById('modeTripBtn')?.classList.toggle('active', mode === 'trip');


### PR DESCRIPTION
### Motivation
- Real-device reports showed `#tripPlannerPanel` and `#tripActiveBox` do not appear on actual phones while desktop/DevTools mobile emulation works, indicating a timing/state race or post-render mutation rather than simple CSS or event binding issues.
- The change aims to add observability and make the activation flow resilient without changing trip planner features, pins, Firestore calls or layer logic.

### Description
- Added diagnostics logging via `logTripModeDiagnostics` to print event type, `body` classes, computed/inline styles for `#tripPlannerPanel`, existence and size of `#tripActiveBox`, `tripPlannerTrips.length`, `activeTripId`, sidebar state, `window.innerWidth`, pointer coarse match and `navigator.userAgent`.
- Added a temporary `MutationObserver` (`attachTripModeMutationObserver`) to watch `document.body.class` and `#tripPlannerPanel.style` for post-click mutations and log them for debugging.
- Hardened `activateTripModeFromEvent` by making it `async`, `await loadTrips()`, and wrapping `loadTrips()`, `renderTripPlannerPanel()`, `renderTripMapLayers()` and `applyTripPlannerPinVisibility()` in `try/catch` blocks that `console.error('[trip-mode] ... failed', err)` and call `showToast(...)` on error.
- Enforced panel visibility after activation by re-adding `body.trip-planner-mode`, `tripPlannerPanel.style.removeProperty('display')`, forcing reflow with `tripPlannerPanel.offsetHeight`, setting `tripPlannerPanel.style.display = 'block'`, re-applying `sidebar.classList.add('show')` and scrolling into view on mobile inside a short `setTimeout(150)`.
- Added `console.log` in `setTripMode` to detect unexpected mode switches and improved `renderTripPlannerPanel()` empty state to show a clear message (`"Wybierz albo utwórz trip"`) so controls remain discoverable when no active trip exists.

### Testing
- Ran repository validation commands `git status --short` and `git diff -- index.html` to inspect the patch, which completed successfully.
- Staged and committed the change with `git add index.html && git commit -m "Add trip mode diagnostics and resilient mobile activation flow"`, which succeeded.
- Created the PR metadata via the automated `make_pr` call, which returned the PR title and body successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eb831bb448330a747a6d2f46d8c79)