### PR TITLE
Add temporary cache/PWA diagnostics and on-screen build badge for mobile verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css?v=trip-debug-2026-05-21-v1" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -2353,14 +2353,50 @@ img.emoji {
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
-  <script src="offline-uploads.js"></script>
-  <script src="firestore-setup.js"></script>
+  <script src="offline-uploads.js?v=trip-debug-2026-05-21-v1"></script>
+  <script src="firestore-setup.js?v=trip-debug-2026-05-21-v1"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
   <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
-  <script src="leaflet-tilelayer-wmts.js"></script>
+  <script src="leaflet-tilelayer-wmts.js?v=trip-debug-2026-05-21-v1"></script>
 
   <script>
+    const APP_BUILD = 'trip-debug-2026-05-21-v1';
+    console.log('APP BUILD:', APP_BUILD, new Date().toISOString());
+
+    const buildBadge = document.createElement('div');
+    buildBadge.id = 'app-build-badge';
+    buildBadge.textContent = APP_BUILD;
+    Object.assign(buildBadge.style, {
+      position: 'fixed',
+      right: '8px',
+      bottom: '8px',
+      zIndex: '99999',
+      background: 'rgba(0, 0, 0, 0.7)',
+      color: '#7CFF7C',
+      font: '11px/1.2 monospace',
+      padding: '3px 6px',
+      borderRadius: '4px',
+      pointerEvents: 'none'
+    });
+    document.addEventListener('DOMContentLoaded', () => {
+      document.body.appendChild(buildBadge);
+    });
+
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations().then(regs => {
+        regs.forEach(reg => reg.unregister());
+        console.log('Service workers unregistered:', regs.length);
+      });
+    }
+
+    if ('caches' in window) {
+      caches.keys().then(keys => {
+        keys.forEach(key => caches.delete(key));
+        console.log('Caches cleared:', keys);
+      });
+    }
+
     const DEFAULT_ROUTE_COLOR = '#00ccff';
     const DEFAULT_ROUTE_OPACITY = 1;
 


### PR DESCRIPTION
### Motivation
- Confirm whether real phones are loading a stale cached/PWA version by making the build visible in console and UI. 
- Provide quick, temporary diagnostics to force-unregister service workers and clear `Cache Storage` so the device fetches fresh assets. 
- Do not change map functionality; this is purely diagnostic to validate that JS fixes actually reach on-device users.

### Description
- Inserted `const APP_BUILD = 'trip-debug-2026-05-21-v1'` and `console.log('APP BUILD:', APP_BUILD, ...)` at the top of the main inline script in `index.html` so the build string appears in DevTools. 
- Added a small, non-interactive on-screen build badge that displays `trip-debug-2026-05-21-v1` in the bottom-right corner for visibility on real devices. 
- Added temporary runtime code to unregister all service workers and clear `caches` when available so cached PWA assets are removed during diagnosis. 
- Added cache-busting query parameters `?v=trip-debug-2026-05-21-v1` to local assets `style.css`, `offline-uploads.js`, `firestore-setup.js`, and `leaflet-tilelayer-wmts.js` in `index.html`.

### Testing
- No automated unit tests were added for this diagnostic change. 
- Performed repository verification and file inspections including `git diff -- index.html` and line-level checks to confirm the `APP_BUILD` badge, cache-busting parameters, and SW/cache-clearing snippets are present, and those checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eb9a568348330a7b1c65003f573d8)