### PR TITLE
Initialize #mobileTripDebug immediately on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -835,6 +835,8 @@ body, #sidebar, #basemap-switcher {
   left: 8px;
   bottom: 8px;
   z-index: 2147483647;
+  display: block !important;
+  pointer-events: none;
   background: rgba(0,0,0,0.85);
   color: white;
   font-size: 11px;
@@ -12486,20 +12488,27 @@ function confirmLayerDelete() {
 
 
     const mobileTripDebugLines = [];
+    function ensureMobileTripDebugPanel() {
+      let panel = document.getElementById('mobileTripDebug');
+      if (!panel) {
+        panel = document.createElement('div');
+        panel.id = 'mobileTripDebug';
+        document.body.appendChild(panel);
+      }
+      return panel;
+    }
+
     function mobileTripDebug(message) {
       try {
         const line = `[${new Date().toLocaleTimeString('pl-PL', { hour12: false })}] ${String(message)}`;
         mobileTripDebugLines.push(line);
         if (mobileTripDebugLines.length > 80) mobileTripDebugLines.shift();
-        let panel = document.getElementById('mobileTripDebug');
-        if (!panel) {
-          panel = document.createElement('div');
-          panel.id = 'mobileTripDebug';
-          document.body.appendChild(panel);
-        }
+        const panel = ensureMobileTripDebugPanel();
         panel.textContent = mobileTripDebugLines.join('\n');
       } catch (_) {}
     }
+    ensureMobileTripDebugPanel();
+    mobileTripDebug('mobile trip debug ready');
 
     function mobileTripDebugState(stageLabel) {
       const tripPanel = document.getElementById('tripPlannerPanel');


### PR DESCRIPTION
### Motivation
- Zapewnić, że panel debugowania mobilnego jest tworzony natychmiast po załadowaniu strony zamiast dopiero po kliknięciu `modeTripBtn`.
- Wyświetlić od razu komunikat startowy `mobile trip debug ready` i dopuszczać późniejsze dopisywanie wiadomości.
- Wymusić wymagane reguły stylów (`position: fixed; left: 8px; bottom: 8px; z-index: 2147483647; display: block !important; pointer-events: none;`).

### Description
- Dodano helper `ensureMobileTripDebugPanel()` który tworzy i zwraca element `#mobileTripDebug`, a jeśli brakuje go w DOM to dopisuje go bezpośrednio do `document.body`.
- Zmieniono `mobileTripDebug()` aby zawsze korzystał z `ensureMobileTripDebugPanel()` zamiast tworzyć panel inline.
- Dodano wywołania inicjalizujące tuż po definicjach: `ensureMobileTripDebugPanel();` oraz `mobileTripDebug('mobile trip debug ready');` aby natychmiast pokazać gotowość.
- Zaktualizowano CSS `#mobileTripDebug` o `display: block !important;` i `pointer-events: none;` przy zachowaniu istniejących właściwości pozycji i `z-index`.

### Testing
- Brak uruchomionych testów automatycznych dla tej zmiany.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ebee6a4f083308aba24bd301e15f0)