### PR TITLE
Add inline mobile trip diagnostics and bump debug build to v6

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
-  <link rel="stylesheet" href="style.css?v=trip-debug-2026-05-21-v5" />
+  <link rel="stylesheet" href="style.css?v=trip-debug-2026-05-21-v6" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -2108,9 +2108,9 @@ img.emoji {
   </style>
 </head>
 <body>
-  <div id="mobileTripDebug">MOBILE TRIP DEBUG V5 - HTML STATIC</div>
+  <div id="mobileTripDebug">MOBILE TRIP DEBUG V6 - HTML STATIC</div>
 <div id="htmlHardDebugV3" style="position:fixed;top:90px;left:10px;z-index:2147483647;background:blue;color:white;padding:20px;font-size:20px;display:block!important;">
-HTML DEBUG V5
+HTML DEBUG V6
 </div>
   <div id="offlineBar" style="display:none;position:fixed;top:0;left:0;right:0;background:#cc0000;color:#fff;text-align:center;padding:4px;z-index:2000;">Offline</div>
   <div id="banner" style="display:none;position:fixed;top:40px;left:50%;transform:translateX(-50%);background:#333;color:#fff;padding:6px 12px;border-radius:4px;z-index:2000;"></div>
@@ -2133,7 +2133,13 @@ HTML DEBUG V5
       </div>
       <div class="trip-mode-toggle">
         <button id="modePinsBtn" class="active" type="button">Pinezki</button>
-        <button id="modeTripBtn" type="button">Plan tripu</button>
+        <button id="modeTripBtn" type="button"
+  onpointerdown="window.rawTripDebug('INLINE pointerdown modeTripBtn')"
+  onpointerup="window.rawTripDebug('INLINE pointerup modeTripBtn'); window.forceTripFromInline && window.forceTripFromInline(event)"
+  ontouchstart="window.rawTripDebug('INLINE touchstart modeTripBtn')"
+  ontouchend="window.rawTripDebug('INLINE touchend modeTripBtn'); window.forceTripFromInline && window.forceTripFromInline(event)"
+  onclick="window.rawTripDebug('INLINE click modeTripBtn'); window.forceTripFromInline && window.forceTripFromInline(event)"
+>Plan tripu</button>
       </div>
       <button id="mobileControlsToggle" type="button" aria-expanded="false" aria-controls="sidebarTopControls">
         Filtry i akcje <span class="mobile-controls-indicator">▼</span>
@@ -2385,15 +2391,39 @@ HTML DEBUG V5
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
-  <script src="offline-uploads.js?v=trip-debug-2026-05-21-v5"></script>
-  <script src="firestore-setup.js?v=trip-debug-2026-05-21-v5"></script>
+  <script src="offline-uploads.js?v=trip-debug-2026-05-21-v6"></script>
+  <script src="firestore-setup.js?v=trip-debug-2026-05-21-v6"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
   <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
-  <script src="leaflet-tilelayer-wmts.js?v=trip-debug-2026-05-21-v5"></script>
+  <script src="leaflet-tilelayer-wmts.js?v=trip-debug-2026-05-21-v6"></script>
 
   <script>
-    const APP_BUILD = 'trip-debug-2026-05-21-v5';
+    const APP_BUILD = 'trip-debug-2026-05-21-v6';
+    window.rawTripDebug = function(msg) {
+      var el = document.getElementById('mobileTripDebug');
+      if (!el) {
+        el = document.createElement('div');
+        el.id = 'mobileTripDebug';
+        document.body.appendChild(el);
+      }
+      el.style.cssText = 'position:fixed!important;top:180px!important;left:10px!important;z-index:2147483647!important;background:magenta!important;color:white!important;font-size:14px!important;padding:10px!important;max-width:90vw!important;white-space:pre-wrap!important;display:block!important;visibility:visible!important;opacity:1!important;';
+      el.textContent += '\n' + msg;
+    };
+
+    window.onerror = function(msg, src, line, col, err) {
+      window.rawTripDebug('WINDOW ERROR: ' + msg + ' line:' + line);
+    };
+
+    window.addEventListener('unhandledrejection', function(e) {
+      window.rawTripDebug('PROMISE ERROR: ' + (e.reason && e.reason.message ? e.reason.message : e.reason));
+    });
+
+    document.addEventListener('DOMContentLoaded', function() {
+      window.rawTripDebug('DOM READY V6');
+      window.rawTripDebug('modeTripBtn exists: ' + !!document.getElementById('modeTripBtn'));
+      window.rawTripDebug('modeTripBtn count: ' + document.querySelectorAll('#modeTripBtn').length);
+    });
     console.log('APP BUILD:', APP_BUILD, new Date().toISOString());
 
     const buildBadge = document.createElement('div');
@@ -12698,6 +12728,57 @@ function confirmLayerDelete() {
     }
 
     const modePinsBtn = document.getElementById('modePinsBtn');
+    window.forceTripFromInline = async function(e) {
+      try {
+        if (e) {
+          e.preventDefault();
+          e.stopPropagation();
+          if (e.stopImmediatePropagation) e.stopImmediatePropagation();
+        }
+
+        window.rawTripDebug('FORCE INLINE TRIP START');
+
+        setTripMode('trip');
+        window.rawTripDebug('setTripMode OK');
+
+        document.body.classList.add('trip-planner-mode');
+        window.rawTripDebug('body class OK');
+
+        var panel = document.getElementById('tripPlannerPanel');
+        var sidebar = document.getElementById('sidebar');
+
+        if (panel) {
+          panel.style.display = 'block';
+          panel.style.visibility = 'visible';
+          panel.style.opacity = '1';
+          window.rawTripDebug('panel forced visible');
+        } else {
+          window.rawTripDebug('ERROR: tripPlannerPanel not found');
+        }
+
+        if (sidebar) {
+          sidebar.classList.add('show');
+          window.rawTripDebug('sidebar show OK');
+        }
+
+        await loadTrips();
+        window.rawTripDebug('loadTrips OK');
+
+        renderTripPlannerPanel();
+        window.rawTripDebug('renderTripPlannerPanel OK');
+
+        renderTripMapLayers();
+        window.rawTripDebug('renderTripMapLayers OK');
+
+        applyTripPlannerPinVisibility();
+        window.rawTripDebug('applyTripPlannerPinVisibility OK');
+
+        window.rawTripDebug('FORCE INLINE TRIP DONE');
+      } catch (err) {
+        window.rawTripDebug('FORCE INLINE ERROR: ' + err.message);
+      }
+    };
+
     const modeTripBtn = document.getElementById('modeTripBtn');
     let mobileTripForceLock = false;
 


### PR DESCRIPTION
### Motivation
- Real-device testing showed touch/pointer events for `#modeTripBtn` were not logged, suggesting JS listeners were not running or code failed before they were attached, so a brutal inline diagnostic was added to verify event firing on phones.
- The build/version markers were bumped to isolate this diagnostic run from the previous `v5` artifacts and ensure the badge reflects the instrumented build.

### Description
- Bumped debug build/version markers from `trip-debug-2026-05-21-v5` to `trip-debug-2026-05-21-v6` in asset query params, `APP_BUILD`, and badge generation.
- Updated visible debug labels from `MOBILE TRIP DEBUG V5` and `HTML DEBUG V5` to V6 for clarity in the UI.
- Added an early global inline logger `window.rawTripDebug(msg)` that creates/forces visibility of `#mobileTripDebug` and appends messages for immediate on-device feedback.
- Added `window.onerror` and an `unhandledrejection` listener to surface runtime errors into the debug panel, an early `DOMContentLoaded` probe, inline HTML event attributes on `#modeTripBtn`, and `window.forceTripFromInline` which force-activates trip mode and logs each step without relying on existing event listeners.

### Testing
- Ran targeted pattern searches with `rg` to confirm replacements and new symbols were present, and the searches returned expected hits.
- Executed a Python patch script to apply the changes to `index.html` and verified the file updated successfully.
- Inspected changes with `git diff` and committed the modified `index.html` with `git commit`, both of which completed successfully.
- Generated PR metadata via the automated `make_pr` step, which returned the created title/body payload successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ecd43a0d88330a502f51675d0765a)