### PR TITLE
Hide mobile trip debug boxes via CSS and bump trip debug build to v11

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
-  <link rel="stylesheet" href="style.css?v=trip-debug-2026-05-21-v10" />
+  <link rel="stylesheet" href="style.css?v=trip-debug-2026-05-21-v11" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -829,6 +829,11 @@ body, #sidebar, #basemap-switcher {
   z-index: 2147483647 !important;
   pointer-events: auto !important;
   touch-action: manipulation !important;
+}
+#mobileTripDebug,
+#htmlHardDebugV3,
+#tripDebugTest {
+  display: none !important;
 }
 #mobileTripDebug {
   position: fixed !important;
@@ -2393,15 +2398,15 @@ HTML DEBUG V10
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
-  <script src="offline-uploads.js?v=trip-debug-2026-05-21-v10"></script>
-  <script src="firestore-setup.js?v=trip-debug-2026-05-21-v10"></script>
+  <script src="offline-uploads.js?v=trip-debug-2026-05-21-v11"></script>
+  <script src="firestore-setup.js?v=trip-debug-2026-05-21-v11"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
   <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
-  <script src="leaflet-tilelayer-wmts.js?v=trip-debug-2026-05-21-v10"></script>
+  <script src="leaflet-tilelayer-wmts.js?v=trip-debug-2026-05-21-v11"></script>
 
   <script>
-    const APP_BUILD = 'trip-debug-2026-05-21-v10';
+    const APP_BUILD = 'trip-debug-2026-05-21-v11';
     window.rawTripDebug = function(msg) {
       var el = document.getElementById('mobileTripDebug');
       if (!el) {


### PR DESCRIPTION
### Motivation
- Temporarily hide loud debug overlays on mobile while keeping the trip planner behavior unchanged and the build badge visible.
- Ensure no trip-planner logic, event wiring, fallbacks, inline handlers, or `console.log` calls are modified or removed.
- Bump the debug build identifier so deployed clients pick up the CSS change via cache-busting.

### Description
- Updated `index.html` to change the build string from `trip-debug-2026-05-21-v10` to `trip-debug-2026-05-21-v11` and updated cache-busting query params for `style.css`, `offline-uploads.js`, `firestore-setup.js`, and `leaflet-tilelayer-wmts.js` to match the new build.
- Inserted a CSS rule that hides only the debug overlay elements: `#mobileTripDebug`, `#htmlHardDebugV3`, and `#tripDebugTest` using `display: none !important;` placed immediately before the existing `#mobileTripDebug` rules.
- Left all runtime code intact, including `rawTripDebug`, `activateTripModeFallback`, `forceTripFromInline`, `forceTripFromMobile`, inline handlers, mobile fallbacks, listeners, and `console.log` statements.
- Did not add or modify any logic related to the trip planner or the version badge element so the `APP_BUILD` badge remains visible at the corner of the screen.

### Testing
- Ran pattern verification with `rg` for `trip-debug-2026-05-21-v10|trip-debug-2026-05-21-v11|mobileTripDebug|htmlHardDebugV3|tripDebugTest|APP_BUILD` to confirm replacements and presence of the new CSS selectors, which succeeded.
- Inspected the modified regions of `index.html` with `sed`/`nl` to confirm the CSS block insertion and `APP_BUILD` update, which succeeded.
- Verified the produced diff to ensure only the intended cache-busting strings and the CSS rule were added, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0edd19f2cc833098af6d3de2453d67)