### PR TITLE
Hide mobile trip debug UI and keep trip fallback handlers (trip-debug-2026-05-21-v11)

### DIFF
--- a/index.html
+++ b/index.html
@@ -834,6 +834,9 @@ body, #sidebar, #basemap-switcher {
 #htmlHardDebugV3,
 #tripDebugTest {
   display: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
 }
 #mobileTripDebug {
   position: fixed !important;
@@ -2115,9 +2118,9 @@ img.emoji {
   </style>
 </head>
 <body>
-  <div id="mobileTripDebug">MOBILE TRIP DEBUG V10 - HTML STATIC</div>
+  <div id="mobileTripDebug">MOBILE TRIP DEBUG V11 - HTML STATIC</div>
 <div id="htmlHardDebugV3" style="position:fixed;top:90px;left:10px;z-index:2147483647;background:blue;color:white;padding:20px;font-size:20px;display:block!important;">
-HTML DEBUG V10
+HTML DEBUG V11
 </div>
   <div id="offlineBar" style="display:none;position:fixed;top:0;left:0;right:0;background:#cc0000;color:#fff;text-align:center;padding:4px;z-index:2000;">Offline</div>
   <div id="banner" style="display:none;position:fixed;top:40px;left:50%;transform:translateX(-50%);background:#333;color:#fff;padding:6px 12px;border-radius:4px;z-index:2000;"></div>
@@ -2408,15 +2411,7 @@ HTML DEBUG V10
   <script>
     const APP_BUILD = 'trip-debug-2026-05-21-v11';
     window.rawTripDebug = function(msg) {
-      var el = document.getElementById('mobileTripDebug');
-      if (!el) {
-        el = document.createElement('div');
-        el.id = 'mobileTripDebug';
-        document.body.appendChild(el);
-      }
-      el.style.cssText = 'position:fixed!important;top:180px!important;left:10px!important;z-index:2147483647!important;background:rgba(255,0,255,0.95)!important;color:white!important;font-size:13px!important;padding:10px!important;width:calc(100vw - 20px)!important;max-width:calc(100vw - 20px)!important;height:45vh!important;max-height:45vh!important;overflow-y:auto!important;overflow-x:hidden!important;white-space:pre-wrap!important;word-break:break-word!important;pointer-events:auto!important;touch-action:pan-y!important;-webkit-overflow-scrolling:touch!important;border:2px solid white!important;display:block!important;visibility:visible!important;opacity:1!important;';
-      el.textContent += '\n' + msg;
-      el.scrollTop = el.scrollHeight;
+      // Debug wyłączony. Funkcja musi istnieć, bo używają jej inline handlery #modeTripBtn.
     };
 
     window.onerror = function(msg, src, line, col, err) {
@@ -2524,7 +2519,7 @@ HTML DEBUG V10
     };
 
     document.addEventListener('DOMContentLoaded', function() {
-      window.rawTripDebug('DOM READY V10');
+      window.rawTripDebug('DOM READY V11');
       window.rawTripDebug('modeTripBtn exists: ' + !!document.getElementById('modeTripBtn'));
       window.rawTripDebug('modeTripBtn count: ' + document.querySelectorAll('#modeTripBtn').length);
       window.rawTripDebug('typeof forceTripFromInline: ' + typeof window.forceTripFromInline);


### PR DESCRIPTION
### Motivation
- Remove visible mobile debug panels on phones while preserving the trip planner fallback and the visible build badge so the "Plan tripu" button continues to work. 
- Keep debug scaffolding functions available for inline handlers but stop them from forcing UI visibility. 

### Description
- Updated the build/version markers and labels from `V10`/`trip-debug-2026-05-21-v10` to `V11`/`trip-debug-2026-05-21-v11` (`APP_BUILD` and static debug text). 
- Hardened CSS for `#mobileTripDebug`, `#htmlHardDebugV3`, and `#tripDebugTest` to fully hide them by adding `visibility: hidden`, `opacity: 0`, and `pointer-events: none` in addition to `display: none`. 
- Replaced the previous `window.rawTripDebug` body with a silent no-op function comment so the function still exists for inline `#modeTripBtn` handlers but no longer creates or forces the debug panel or manipulates `style.cssText`, `display:block`, `visibility:visible`, or `opacity:1`. 
- Left `#app-build-badge`, `window.forceTripFromInline`, `window.activateTripModeFallback`, `loadTrips()`, `renderTripPlannerPanel()`, `renderTripMapLayers()`, `applyTripPlannerPinVisibility()` and all inline handlers on `#modeTripBtn` (`onpointerdown`, `onpointerup`, `ontouchstart`, `ontouchend`, `onclick`) untouched. 

### Testing
- Ran a code search with `rg -n "trip-debug-2026-05-21-v10|rawTripDebug|mobileTripDebug|htmlHardDebugV3|tripDebugTest|app-build-badge|modeTripBtn|forceTripFromInline|activateTripModeFallback"` to verify presence and updates of relevant symbols, which succeeded. 
- Inspected the modified `index.html` segments with `sed`/`nl` to confirm the CSS additions, `rawTripDebug` replacement, and `APP_BUILD` text changes, which succeeded. 
- Verified the working diff and PR metadata generation through the automated PR tooling, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee40915bc833090d43513b846430b)