### PR TITLE
Fix trip planner day scrolling behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -895,7 +895,7 @@ body.trip-planner-mode .trip-mode-toggle { display:flex !important; }
 .trip-segment-row,.trip-point-meta { color:var(--ui-text-muted); font-size:11px; }
 .trip-color-input { width:32px; height:24px; padding:0; border:0; background:none; }
 .trip-day-visible-toggle { display:inline-flex; align-items:center; gap:4px; font-size:11px; opacity:.9; }
-.trip-active-day { box-shadow:0 0 0 1px var(--ui-accent) inset; max-height:45vh; overflow-y:auto; overscroll-behavior:contain; -webkit-overflow-scrolling:touch; }
+.trip-active-day { box-shadow:0 0 0 1px var(--ui-accent) inset; max-height:none; overflow:visible; }
 .trip-muted-day { opacity:.7; }
 body.trip-planner-mode #sidebarTopControls,
 body.trip-planner-mode #pinTotalCounter,


### PR DESCRIPTION
### Motivation
- Prevent the active day card in the trip planner from having its own nested scroll so the parent day list (`#tripActiveBox`) handles scrolling for all days together when a day has many points.

### Description
- Updated `.trip-active-day` CSS in `index.html` to remove per-card scrolling by setting `max-height: none` and `overflow: visible`, replacing the previous `max-height: 45vh; overflow-y: auto;` behavior.

### Testing
- Verified the CSS change with `git diff -- index.html` to confirm the expected delta and created the commit with `git commit`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f957490208330ac09bab246e267d6)