### PR TITLE
Enable vertical scrolling for #tripActiveBox

### DIFF
--- a/index.html
+++ b/index.html
@@ -872,7 +872,7 @@ body.trip-planner-mode .trip-mode-toggle { display:flex !important; }
 .trip-planner-panel { background:#17191f; border:1px solid var(--ui-border); border-radius:var(--ui-radius-sm); padding:8px; margin-bottom:8px; }
 .trip-select-row { display:flex; gap:6px; margin-bottom:8px; }
 .trip-planner-toggle-row { margin-top:8px; padding-top:8px; border-top:1px solid var(--ui-border); }
-.trip-select-row + #tripActiveBox { border-top:1px solid var(--ui-border); margin-top:8px; padding-top:8px; max-height:52vh; overflow-y:auto; overscroll-behavior: contain; touch-action: pan-y; }
+#tripActiveBox { border-top:1px solid var(--ui-border); margin-top:8px; padding-top:8px; max-height:52vh; overflow-y:auto; overscroll-behavior: contain; -webkit-overflow-scrolling: touch; touch-action: pan-y; }
 .trip-select-row select,.trip-select-row button { background:#1d2028; color:#eee; border:1px solid var(--ui-border); border-radius:var(--ui-radius-sm); font-size:12px; padding:5px; }
 .trip-day-card { border:1px solid var(--ui-border); border-radius:var(--ui-radius-sm); padding:7px; margin-bottom:8px; background:#1d2028; }
 .trip-day-header,.trip-point-actions { display:flex; gap:6px; align-items:center; flex-wrap:wrap; }


### PR DESCRIPTION
### Motivation
- The adjacent-sibling selector `.trip-select-row + #tripActiveBox` didn't reliably target the active trip panel in the current DOM, so vertical overflow/scrolling wasn't applied when trip days exceeded the available height.

### Description
- Touched `index.html` CSS: replaced `.trip-select-row + #tripActiveBox` with a direct `#tripActiveBox` rule, preserved `max-height` and `overflow-y:auto`, and added `-webkit-overflow-scrolling: touch` for smoother mobile scrolling.

### Testing
- No automated tests were run for this small CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f9882dcbc83308bf9fdef9e876c61)