### PR TITLE
Naprawa interakcji mobilnych w planie tripu

### DIFF
--- a/index.html
+++ b/index.html
@@ -13158,7 +13158,8 @@ function confirmLayerDelete() {
     });
     const handleTripActiveBoxAction = async (e) => {
       const trip = getActiveTrip(); if (!trip) return;
-      const targetEl = e.target instanceof Element ? e.target : null;
+      const eventTarget = e.target;
+      const targetEl = eventTarget instanceof Element ? eventTarget : eventTarget?.parentElement || null;
       const addDayBtn = targetEl?.closest('#tripAddDayBtn');
       const addPrivatePointBtn = targetEl?.closest('#tripAddPrivatePointBtn');
       const exportCsvBtn = targetEl?.closest('#tripExportCsvBtn');
@@ -13195,7 +13196,6 @@ function confirmLayerDelete() {
         e.stopPropagation();
         const action = actionEl.dataset.tripAction;
         if (action === 'focus-point') {
-          if (tripActiveBoxIsScrolling) return;
           const lat = Number(actionEl.dataset.lat);
           const lng = Number(actionEl.dataset.lng);
           const day = trip.days.find(x => x.id === actionEl.dataset.dayId);
@@ -13248,6 +13248,8 @@ function confirmLayerDelete() {
           if (!day || !Array.isArray(day.points)) return;
           const pointIndex = day.points.findIndex(x => x.id === pointId);
           if (pointIndex < 0) return;
+          const pointName = day.points[pointIndex]?.name || day.points[pointIndex]?.nameSnapshot || 'Punkt';
+          if (!confirm(`Czy na pewno chcesz usunąć ${pointName}?`)) return;
           const compatDb = getCompatDb();
           if (!compatDb) return;
           await compatDb.collection('trips').doc(activeTrip.id).collection('days').doc(day.id).collection('points').doc(pointId).delete().catch(() => {});
@@ -13275,9 +13277,9 @@ function confirmLayerDelete() {
         return;
       }
 
-      const dayCardEl = e.target.closest('.trip-day-card');
+      const dayCardEl = targetEl?.closest('.trip-day-card');
       if (dayCardEl) {
-        if (e.target.closest('.trip-point-item, button, input, select, textarea, label, a')) return;
+        if (targetEl?.closest('.trip-point-item, button, input, select, textarea, label, a')) return;
         activeTripDayId = dayCardEl.dataset.dayCard;
         trip.days.forEach(d => d.highlight = d.id === activeTripDayId);
         await saveTrip(trip.id);


### PR DESCRIPTION
### Motivation
- Poprawić obsługę dotyku w mobilnym panelu planu tripu tak, aby zachowywał się jak desktop: kliknięcie nazwy punktu przenosi mapę do punktu, strzałki zmieniają kolejność punktów, a usuwanie wymaga potwierdzenia z nazwą punktu.

### Description
- Ujednolicono rozpoznawanie elementu celu zdarzenia w `handleTripActiveBoxAction` przez normalizację `e.target` na `eventTarget` i przypisanie `targetEl`, co naprawia sytuacje gdy targetem jest węzeł tekstowy lub zagnieżdżony element.
- Usunięto blokadę scrolla, która uniemożliwiała wykonywanie akcji `focus-point`, aby kliknięcie nazwy punktu zawsze wywoływało `focusTripPointOnMap` lub `map.flyTo` (z zachowaniem istniejącego fallbacku).
- Zachowanie przycisków `move-point-up` / `move-point-down` pozostaje bez zmian lecz teraz działa poprawnie na urządzeniach mobilnych dzięki poprawionemu targetowaniu (obsługa `data-trip-action`).
- Dodano potwierdzenie przed usunięciem punktu, które wyświetla nazwę punktu w treści `confirm` (`Czy na pewno chcesz usunąć ${pointName}?`), oraz poprawiono wykrywanie kliknięć na karcie dnia używając znormalizowanego `targetEl`.
- Zmiana dotyczy pliku `index.html` (funkcja `handleTripActiveBoxAction` i powiązane warunki obsługi akcji `data-trip-action`).

### Testing
- Nie uruchamiano zautomatyzowanego zestawu testów dla tej zmiany.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fa0b260f4833099807af8c50edb48)