### PR TITLE
Fix mobile tap vs scroll in trip planner (#tripActiveBox) and bump build to v14

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
-  <link rel="stylesheet" href="style.css?v=trip-debug-2026-05-21-v13" />
+  <link rel="stylesheet" href="style.css?v=trip-debug-2026-05-21-v14" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -2412,15 +2412,15 @@ HTML DEBUG V12
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
-  <script src="offline-uploads.js?v=trip-debug-2026-05-21-v13"></script>
-  <script src="firestore-setup.js?v=trip-debug-2026-05-21-v13"></script>
+  <script src="offline-uploads.js?v=trip-debug-2026-05-21-v14"></script>
+  <script src="firestore-setup.js?v=trip-debug-2026-05-21-v14"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
   <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
-  <script src="leaflet-tilelayer-wmts.js?v=trip-debug-2026-05-21-v13"></script>
+  <script src="leaflet-tilelayer-wmts.js?v=trip-debug-2026-05-21-v14"></script>
 
   <script>
-    const APP_BUILD = 'trip-debug-2026-05-21-v13';
+    const APP_BUILD = 'trip-debug-2026-05-21-v14';
     window.rawTripDebug = function(msg) {
       // Debug wyłączony. Funkcja musi istnieć, bo używają jej inline handlery #modeTripBtn.
     };
@@ -9934,7 +9934,7 @@ function getTripPointEmoji(p) {
       box.innerHTML = `<div><b>${trip.name}</b></div>${tripRange}<button id="tripAddDayBtn" type="button">+ Dodaj dzień</button><button id="tripAddPrivatePointBtn" type="button">+ Punkt tylko do tripa</button><button id="tripExportCsvBtn" type="button">⬇️ CSV</button><button id="tripExportPdfBtn" type="button">⬇️ PDF</button><button id="tripDeleteBtn" class="trip-icon-btn" type="button" title="Usuń trip" aria-label="Usuń trip">🗑️</button>` + trip.days.map((d, idx) => {
         const summary = d.routeSummary || {};
         const points = (d.points || []).sort((a,b)=>(a.order||0)-(b.order||0));
-        const ptsHtml = `<div class="trip-point-list" data-day-id="${d.id}">` + points.map((p, i) => `<div class="trip-point-item" data-day-id="${d.id}" data-trip-day-id="${d.id}" data-point-id="${p.id}" data-trip-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}"><span class="trip-drag-handle" draggable="true" title="Przeciągnij" data-stop-row-click="1">☰</span><span class="trip-point-name" data-trip-action="focus-point" data-day-id="${d.id}" data-point-id="${p.id}" data-trip-day-id="${d.id}" data-trip-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}">${i+1}. ${getTripPointEmoji(p)} ${p.name || p.nameSnapshot || 'Punkt'}</span> <span class="trip-point-meta">(${p.pointType || 'inny'})</span> <button type="button" data-trip-action="move-point-up" data-day-id="${d.id}" data-point-id="${p.id}" data-stop-row-click="1" class="trip-mobile-only">↑</button><button type="button" data-trip-action="move-point-down" class="trip-mobile-only" data-day-id="${d.id}" data-point-id="${p.id}" data-stop-row-click="1">↓</button><button type="button" data-trip-action="delete-point" data-day-id="${d.id}" data-point-id="${p.id}" data-stop-row-click="1" title="Usuń punkt" aria-label="Usuń punkt">🗑️</button></div>${i < (d.routeSegments||[]).length ? `<div class="trip-segment-row">↓ Trasa: ${formatTripDuration(d.routeSegments[i].durationSeconds)} / ${formatTripDistance(d.routeSegments[i].distanceMeters)}</div>` : ''}`).join('') + `</div>`;
+        const ptsHtml = `<div class="trip-point-list" data-day-id="${d.id}">` + points.map((p, i) => `<div class="trip-point-item" data-day-id="${d.id}" data-trip-day-id="${d.id}" data-point-id="${p.id}" data-trip-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}"><span class="trip-drag-handle" draggable="true" title="Przeciągnij" data-stop-row-click="1">☰</span><span class="trip-point-name" data-trip-action="focus-point" data-day-id="${d.id}" data-point-id="${p.id}" data-trip-day-id="${d.id}" data-trip-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}">${i+1}. ${getTripPointEmoji(p)} ${p.name || p.nameSnapshot || 'Punkt'}</span> <span class="trip-point-meta">(${p.pointType || 'inny'})</span> <button type="button" data-trip-action="move-point-up" data-day-id="${d.id}" data-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}" data-stop-row-click="1" class="trip-mobile-only trip-icon-btn">↑</button><button type="button" data-trip-action="move-point-down" class="trip-mobile-only trip-icon-btn" data-day-id="${d.id}" data-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}" data-stop-row-click="1">↓</button><button type="button" data-trip-action="delete-point" data-day-id="${d.id}" data-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}" data-stop-row-click="1" class="trip-icon-btn" title="Usuń punkt" aria-label="Usuń punkt">🗑️</button></div>${i < (d.routeSegments||[]).length ? `<div class="trip-segment-row">↓ Trasa: ${formatTripDuration(d.routeSegments[i].durationSeconds)} / ${formatTripDistance(d.routeSegments[i].distanceMeters)}</div>` : ''}`).join('') + `</div>`;
         return `<div class="trip-day-card ${d.highlight ? 'trip-active-day' : 'trip-muted-day'}" data-day-card="${d.id}"><div class="trip-day-header"><b>${d.name || `Dzień ${idx+1}`}</b><label><input type="date" data-day-date="${d.id}" value="${d.date || ''}"></label><input class="trip-color-input" type="color" data-day-color="${d.id}" value="${d.color || '#ff3b3b'}"><label class="trip-day-visible-toggle" title="Pokaż/ukryj trasę dnia"><input type="checkbox" data-day-visible="${d.id}" ${d.visible === false ? '' : 'checked'}> Trasa</label><button data-day-delete="${d.id}" class="trip-icon-btn" title="Usuń dzień" aria-label="Usuń dzień">🗑️</button></div><div class="trip-day-summary">Jazda: ${formatTripDuration(summary.durationSeconds || 0)} | Zwiedzanie: ${formatTripDuration(summary.visitSeconds || 0)} | Razem: ${formatTripDuration(summary.totalSeconds || 0)} | Dystans: ${formatTripDistance(summary.distanceMeters || 0)}</div>${ptsHtml}</div>`;
       }).join('');
     }
@@ -13286,6 +13286,9 @@ function confirmLayerDelete() {
         renderTripPlannerPanel(); renderTripMapLayers(); return;
       }
     };
+    function shouldIgnoreTripTapBecauseScrolled(startX, startY, endX, endY) {
+      return Math.hypot(endX - startX, endY - startY) > 8;
+    }
     function updateTripActiveBoxMaxHeight() {
       const box = document.getElementById('tripActiveBox');
       if (!box) return;
@@ -13301,40 +13304,58 @@ function confirmLayerDelete() {
     window.visualViewport?.addEventListener('resize', updateTripActiveBoxMaxHeight);
     window.visualViewport?.addEventListener('scroll', updateTripActiveBoxMaxHeight);
     const tripActiveBoxEl = document.getElementById('tripActiveBox');
-    let tripActiveBoxIsScrolling = false;
-    let tripActiveBoxScrollResetTimer = null;
-    let tripActiveBoxTouchStartY = null;
-    const markTripActiveBoxScrolling = () => {
-      tripActiveBoxIsScrolling = true;
-      if (tripActiveBoxScrollResetTimer) clearTimeout(tripActiveBoxScrollResetTimer);
-      tripActiveBoxScrollResetTimer = setTimeout(() => { tripActiveBoxIsScrolling = false; }, 140);
-    };
-    tripActiveBoxEl?.addEventListener('scroll', markTripActiveBoxScrolling, { passive: true });
+    let tripTouchMoved = false;
+    let tripTouchStartX = 0;
+    let tripTouchStartY = 0;
+    let tripTouchEndX = 0;
+    let tripTouchEndY = 0;
+    let tripBlockNextClickAfterScroll = false;
     tripActiveBoxEl?.addEventListener('touchstart', (event) => {
-      tripActiveBoxTouchStartY = event.changedTouches?.[0]?.clientY ?? null;
+      const touch = event.changedTouches?.[0];
+      if (!touch) return;
+      tripTouchStartX = touch.clientX;
+      tripTouchStartY = touch.clientY;
+      tripTouchEndX = touch.clientX;
+      tripTouchEndY = touch.clientY;
+      tripTouchMoved = false;
+      tripBlockNextClickAfterScroll = false;
     }, { passive: true });
     tripActiveBoxEl?.addEventListener('touchmove', (event) => {
-      const currentY = event.changedTouches?.[0]?.clientY;
-      if (!Number.isFinite(currentY) || !Number.isFinite(tripActiveBoxTouchStartY)) return;
-      if (Math.abs(currentY - tripActiveBoxTouchStartY) > 8) markTripActiveBoxScrolling();
-    }, { passive: true });
-    tripActiveBoxEl?.addEventListener('pointermove', (event) => {
-      if (event.pointerType === 'touch' && event.buttons === 0) markTripActiveBoxScrolling();
-    }, { passive: true });
-    tripActiveBoxEl?.addEventListener('click', handleTripActiveBoxAction);
-    tripActiveBoxEl?.addEventListener('pointerup', handleTripActiveBoxAction);
-    tripActiveBoxEl?.addEventListener('touchend', handleTripActiveBoxAction, { passive: false });
-    const mobileTripPointCaptureFallback = (event) => {
-      const target = event.target instanceof Element ? event.target : null;
-      if (!target) return;
-      if (tripActiveBoxIsScrolling) return;
-      if (target.closest('.trip-point-name')) {
-        window.forceTripPointFocusFromMobile(event, target);
+      const touch = event.changedTouches?.[0];
+      if (!touch) return;
+      tripTouchEndX = touch.clientX;
+      tripTouchEndY = touch.clientY;
+      if (shouldIgnoreTripTapBecauseScrolled(tripTouchStartX, tripTouchStartY, tripTouchEndX, tripTouchEndY)) {
+        tripTouchMoved = true;
       }
-    };
-    tripActiveBoxEl?.addEventListener('pointerup', mobileTripPointCaptureFallback, true);
-    tripActiveBoxEl?.addEventListener('touchend', mobileTripPointCaptureFallback, { capture: true, passive: false });
-    tripActiveBoxEl?.addEventListener('click', mobileTripPointCaptureFallback, true);
+    }, { passive: true });
+    tripActiveBoxEl?.addEventListener('touchend', (event) => {
+      const touch = event.changedTouches?.[0];
+      if (touch) {
+        tripTouchEndX = touch.clientX;
+        tripTouchEndY = touch.clientY;
+      }
+      if (shouldIgnoreTripTapBecauseScrolled(tripTouchStartX, tripTouchStartY, tripTouchEndX, tripTouchEndY)) {
+        tripTouchMoved = true;
+      }
+      tripBlockNextClickAfterScroll = tripTouchMoved === true;
+      if (!tripTouchMoved) handleTripActiveBoxAction(event);
+    }, { passive: true });
+    tripActiveBoxEl?.addEventListener('click', (event) => {
+      if (!tripBlockNextClickAfterScroll) {
+        handleTripActiveBoxAction(event);
+        return;
+      }
+      const target = event.target instanceof Element ? event.target : null;
+      const allowDuringScroll = !!target?.closest('[data-trip-action], button, .trip-point-name, .trip-icon-btn, .trip-point-item button');
+      if (allowDuringScroll) {
+        tripBlockNextClickAfterScroll = false;
+        handleTripActiveBoxAction(event);
+        return;
+      }
+      tripBlockNextClickAfterScroll = false;
+    }, true);
+    tripActiveBoxEl?.addEventListener('pointerup', handleTripActiveBoxAction);
     tripActiveBoxEl?.addEventListener('change', async (e) => {
       const trip = getActiveTrip(); if (!trip) return;
       if (e.target.dataset.dayColor) {


### PR DESCRIPTION
### Motivation
- Mobile "Plan tripu" lost tap actions in `#tripActiveBox` after adding a scroll-click lock, so buttons/point-name taps were blocked while desktop still worked. 
- The lock must remain to avoid accidental clicks during scrolling but must not block legitimate short taps on interactive trip controls.
- The version badge and build tag must be updated to reflect the release containing the fix (`v14`).

### Description
- Bumped build/version references from `trip-debug-2026-05-21-v13` to `trip-debug-2026-05-21-v14` including `APP_BUILD` and asset query strings so the badge shows `v14`.
- Added helper `shouldIgnoreTripTapBecauseScrolled(startX, startY, endX, endY)` which returns `Math.hypot(...) > 8` and used an 8px threshold to distinguish taps vs scrolls.
- Rewrote touch handling inside `#tripActiveBox` to record `touchstart` coordinates, set a `tripTouchMoved` flag in `touchmove` only when the helper threshold is exceeded, and in `touchend` set a one-shot `tripBlockNextClickAfterScroll` flag and only call the delegated handler for genuine taps.
- Replaced the previous capture-based mobile fallback that used global `touchend/click` capture and propagation-stopping with a conditional capture click listener that suppresses only the synthetic click after a detected scroll and explicitly allows interactive targets (`[data-trip-action]`, `button`, `.trip-point-name`, `.trip-icon-btn`, `.trip-point-item button`), restoring original delegation via `handleTripActiveBoxAction`.
- Ensured trip point action elements include expected attributes (`data-trip-action="focus-point"`, `data-trip-action="move-point-up"`, `data-trip-action="move-point-down"`, `data-trip-action="delete-point"`, `data-day-id`, `data-point-id`, `data-lat`, `data-lng`) and added `trip-icon-btn` class where appropriate, without removing `activateTripModeFallback`, `forceTripFromInline`, `forcePinsFromInline` or debug badge.

### Testing
- Verified presence/absence and updated strings with a code search using `rg -n` for `trip-debug-2026-05-21-v13|shouldIgnoreTripTapBecauseScrolled|tripTouchMoved|mobileTripPointCaptureFallback|data-trip-action` which returned the expected updated references and new helper.
- Inspected the resulting source regions with `nl -ba index.html | sed -n '8,20p;2410,2428p;9928,9942p;13284,13362p'` to confirm `APP_BUILD`, asset query strings, injected helper and modified touch/click handlers were placed correctly.
- Reviewed the file diff to confirm only the intended changes to `index.html` were introduced and that `#tripActiveBox` delegation remains handled by `handleTripActiveBoxAction`; the checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff504ff108330b7e6caadee38f606)