### PR TITLE
Fit map to trip/day on mobile and desktop; add fitMapToBounds helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -9975,17 +9975,8 @@ function getTripPointEmoji(p) {
     window.applyTripPlannerPinVisibility = applyTripPlannerPinVisibility;
 
 
-    function fitMapToTripPoints(trip) {
-      if (!map || !trip || !Array.isArray(trip.days)) return false;
-      const bounds = L.latLngBounds([]);
-      (trip.days || []).forEach(day => {
-        (day.points || []).forEach(point => {
-          const lat = Number(point.lat);
-          const lng = Number(point.lng);
-          if (Number.isFinite(lat) && Number.isFinite(lng)) bounds.extend([lat, lng]);
-        });
-      });
-      if (!bounds.isValid()) return false;
+    function fitMapToBounds(bounds) {
+      if (!map || !bounds?.isValid?.()) return false;
       try {
         map.fitBounds(bounds, {
           animate: true,
@@ -9999,6 +9990,30 @@ function getTripPointEmoji(p) {
         map.fitBounds(bounds.pad(0.3));
       }
       return true;
+    }
+
+    function fitMapToTripPoints(trip) {
+      if (!map || !trip || !Array.isArray(trip.days)) return false;
+      const bounds = L.latLngBounds([]);
+      (trip.days || []).forEach(day => {
+        (day.points || []).forEach(point => {
+          const lat = Number(point.lat);
+          const lng = Number(point.lng);
+          if (Number.isFinite(lat) && Number.isFinite(lng)) bounds.extend([lat, lng]);
+        });
+      });
+      return fitMapToBounds(bounds);
+    }
+
+    function fitMapToTripDayPoints(day) {
+      if (!map || !day || !Array.isArray(day.points)) return false;
+      const bounds = L.latLngBounds([]);
+      (day.points || []).forEach(point => {
+        const lat = Number(point.lat);
+        const lng = Number(point.lng);
+        if (Number.isFinite(lat) && Number.isFinite(lng)) bounds.extend([lat, lng]);
+      });
+      return fitMapToBounds(bounds);
     }
 
     function focusTripPointOnMap(point, dayId) {
@@ -13131,6 +13146,7 @@ function confirmLayerDelete() {
       document.getElementById('toggleLayers').textContent = mode === 'trip' ? '☰ Plan tripu' : '☰ Warstwy';
       renderTripMapLayers();
       applyTripPlannerPinVisibility();
+      if (tripPlannerMode === 'trip') fitMapToTripPoints(getActiveTrip());
     }
 
     window.setTripMode = setTripMode;
@@ -13400,7 +13416,10 @@ function confirmLayerDelete() {
         activeTripDayId = dayCardEl.dataset.dayCard;
         trip.days.forEach(d => d.highlight = d.id === activeTripDayId);
         await saveTrip(trip.id);
-        renderTripPlannerPanel(); renderTripMapLayers(); return;
+        renderTripPlannerPanel();
+        renderTripMapLayers();
+        fitMapToTripDayPoints(trip.days.find(d => d.id === activeTripDayId));
+        return;
       }
     };
     function updateTripActiveBoxMaxHeight() {
@@ -13486,6 +13505,7 @@ function confirmLayerDelete() {
       renderTripPlannerPanel();
       renderTripMapLayers();
       applyTripPlannerPinVisibility();
+      if (tripPlannerMode === 'trip') fitMapToTripPoints(getActiveTrip());
     });
     let tripDraggedPointId = null;
     let tripDraggedDayId = null;


### PR DESCRIPTION
### Motivation
- Synchronize mobile behavior with desktop so opening the trip view always fits the map to the active trip's points. 
- Allow tapping a trip day (background/title) to focus the map onto that day's points. 
- Avoid triggering the map fit when interacting with controls inside day cards (buttons/inputs/etc.).

### Description
- Extracted a shared `fitMapToBounds(bounds)` helper and refactored `fitMapToTripPoints(trip)` to reuse it for consistent fit behavior. 
- Added `fitMapToTripDayPoints(day)` to compute bounds for a single day and fit the map to those bounds. 
- Wired automatic fitting to entering trip mode by calling `fitMapToTripPoints(getActiveTrip())` from `setTripMode` and after loading trips. 
- Updated the day-card click handler to set the active day and call `fitMapToTripDayPoints(...)`, while preserving existing guards so clicks on embedded controls do not trigger the fit.

### Testing
- Ran repository inspections with `rg` to locate trip-related handlers and verify edits, which completed successfully. 
- Performed `git diff -- index.html`, `git status --short`, and `git commit` to validate the patch and record the change, and the commit succeeded. 
- No automated unit/integration test suite exists for this area, so only these automated repository checks were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1015d440d48330a243852aea5b8cc2)