### PR TITLE
Make trip-day selection local and update UI immediately; bump build to v18

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
-  <link rel="stylesheet" href="style.css?v=trip-debug-2026-05-21-v17" />
+  <link rel="stylesheet" href="style.css?v=trip-debug-2026-05-21-v18" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -2412,15 +2412,15 @@ HTML DEBUG V12
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
-  <script src="offline-uploads.js?v=trip-debug-2026-05-21-v17"></script>
-  <script src="firestore-setup.js?v=trip-debug-2026-05-21-v17"></script>
+  <script src="offline-uploads.js?v=trip-debug-2026-05-21-v18"></script>
+  <script src="firestore-setup.js?v=trip-debug-2026-05-21-v18"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
   <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
-  <script src="leaflet-tilelayer-wmts.js?v=trip-debug-2026-05-21-v17"></script>
+  <script src="leaflet-tilelayer-wmts.js?v=trip-debug-2026-05-21-v18"></script>
 
   <script>
-    const APP_BUILD = 'trip-debug-2026-05-21-v17';
+    const APP_BUILD = 'trip-debug-2026-05-21-v18';
     window.rawTripDebug = function(msg) {
       // Debug wyłączony. Funkcja musi istnieć, bo używają jej inline handlery #modeTripBtn.
     };
@@ -2598,9 +2598,7 @@ HTML DEBUG V12
       if (action === 'focus-point') {
         const pointData = point ? { ...point } : null;
         if (dayId && activeTripDayId !== dayId) {
-          activeTripDayId = dayId;
-          trip.days.forEach(d => d.highlight = d.id === activeTripDayId);
-          await saveTrip(trip.id);
+          setActiveTripDayLocal(dayId);
           renderTripPlannerPanel();
           renderTripMapLayers();
         }
@@ -2721,22 +2719,32 @@ HTML DEBUG V12
       }
     };
 
-    window.forceTripDayFromInline = async function(e, el) {
+    window.forceTripDaySelectFromInline = async function(e, el) {
       if (e && (e.type === 'touchend' || e.type === 'pointerup') && tripTapWasScroll(e)) return;
 
       const target = e?.target instanceof Element ? e.target : null;
-      if (target?.closest('button, input, select, textarea, label, a, [data-trip-action], .trip-point-item')) return;
+
+      if (target?.closest('button, input, select, textarea, label, a, [data-trip-action], .trip-point-item')) {
+        return;
+      }
 
       if (e) {
         e.preventDefault?.();
         e.stopPropagation?.();
       }
 
-      const card = el?.closest?.('.trip-day-card');
-      const dayId = card?.dataset.dayCard;
+      const dayId =
+        el?.dataset?.tripDaySelect ||
+        el?.closest?.('[data-trip-day-select]')?.dataset?.tripDaySelect ||
+        el?.closest?.('.trip-day-card')?.dataset?.dayCard;
+
       if (!dayId) return;
 
-      await activateTripDayAndFit(dayId);
+      await activateTripDayAndFit(dayId, { save: false });
+    };
+
+    window.forceTripDayFromInline = async function(e, el) {
+      return window.forceTripDaySelectFromInline(e, el);
     };
 
     document.addEventListener('DOMContentLoaded', function() {
@@ -10059,23 +10067,30 @@ function getTripPointEmoji(p) {
       return (trip?.days || []).flatMap(d => d.points || []);
     }
 
+    function setActiveTripDayLocal(dayId) {
+      const trip = getActiveTrip();
+      if (!trip || !dayId) return null;
+
+      const day = trip.days.find(d => d.id === dayId);
+      if (!day) return null;
+
+      activeTripDayId = dayId;
+      trip.days.forEach(d => {
+        d.highlight = d.id === activeTripDayId;
+      });
+
+      return day;
+    }
+
     async function activateTripDayAndFit(dayId, options = {}) {
       const trip = getActiveTrip();
       if (!trip || !dayId) return;
 
-      const day = trip.days.find(d => d.id === dayId);
+      const day = setActiveTripDayLocal(dayId);
       if (!day) return;
-
-      activeTripDayId = dayId;
-      trip.days.forEach(d => d.highlight = d.id === activeTripDayId);
-
-      if (options.save !== false && typeof saveTrip === 'function') {
-        await saveTrip(trip.id);
-      }
 
       renderTripPlannerPanel();
       renderTripMapLayers();
-
       fitMapToTripPoints(day.points || [], { maxZoom: 16, pad: 0.22 });
     }
 
@@ -10130,7 +10145,7 @@ function getTripPointEmoji(p) {
         const summary = d.routeSummary || {};
         const points = (d.points || []).sort((a,b)=>(a.order||0)-(b.order||0));
         const ptsHtml = `<div class="trip-point-list" data-day-id="${d.id}">` + points.map((p, i) => `<div class="trip-point-item" data-day-id="${d.id}" data-trip-day-id="${d.id}" data-point-id="${p.id}" data-trip-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}"><span class="trip-drag-handle" draggable="true" title="Przeciągnij" data-stop-row-click="1">☰</span><span class="trip-point-name" onpointerup="window.forceTripActionFromInline(event, this)" ontouchend="window.forceTripActionFromInline(event, this)" onclick="window.forceTripActionFromInline(event, this)" data-trip-action="focus-point" data-day-id="${d.id}" data-point-id="${p.id}" data-trip-day-id="${d.id}" data-trip-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}">${i+1}. ${getTripPointEmoji(p)} ${p.name || p.nameSnapshot || 'Punkt'}</span> <span class="trip-point-meta">(${p.pointType || 'inny'})</span> <button type="button" data-trip-action="move-point-up" data-day-id="${d.id}" data-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}" data-stop-row-click="1" class="trip-mobile-only trip-icon-btn" onpointerup="window.forceTripActionFromInline(event, this)" ontouchend="window.forceTripActionFromInline(event, this)" onclick="window.forceTripActionFromInline(event, this)">↑</button><button type="button" data-trip-action="move-point-down" class="trip-mobile-only trip-icon-btn" data-day-id="${d.id}" data-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}" data-stop-row-click="1" onpointerup="window.forceTripActionFromInline(event, this)" ontouchend="window.forceTripActionFromInline(event, this)" onclick="window.forceTripActionFromInline(event, this)">↓</button><button type="button" data-trip-action="delete-point" data-day-id="${d.id}" data-point-id="${p.id}" data-lat="${Number(p.lat)}" data-lng="${Number(p.lng)}" data-stop-row-click="1" class="trip-icon-btn" title="Usuń punkt" aria-label="Usuń punkt" onpointerup="window.forceTripActionFromInline(event, this)" ontouchend="window.forceTripActionFromInline(event, this)" onclick="window.forceTripActionFromInline(event, this)">🗑️</button></div>${i < (d.routeSegments||[]).length ? `<div class="trip-segment-row">↓ Trasa: ${formatTripDuration(d.routeSegments[i].durationSeconds)} / ${formatTripDistance(d.routeSegments[i].distanceMeters)}</div>` : ''}`).join('') + `</div>`;
-        return `<div class="trip-day-card ${d.highlight ? 'trip-active-day' : 'trip-muted-day'}" data-day-card="${d.id}" onpointerup="window.forceTripDayFromInline(event, this)" ontouchend="window.forceTripDayFromInline(event, this)" onclick="window.forceTripDayFromInline(event, this)"><div class="trip-day-header"><b class="trip-day-title">${d.name || `Dzień ${idx+1}`}</b><label><input type="date" data-day-date="${d.id}" value="${d.date || ''}"></label><input class="trip-color-input" type="color" data-day-color="${d.id}" value="${d.color || '#ff3b3b'}"><label class="trip-day-visible-toggle" title="Pokaż/ukryj trasę dnia"><input type="checkbox" data-day-visible="${d.id}" ${d.visible === false ? '' : 'checked'}> Trasa</label><button data-day-delete="${d.id}" class="trip-icon-btn" title="Usuń dzień" aria-label="Usuń dzień">🗑️</button></div><div class="trip-day-summary">Jazda: ${formatTripDuration(summary.durationSeconds || 0)} | Zwiedzanie: ${formatTripDuration(summary.visitSeconds || 0)} | Razem: ${formatTripDuration(summary.totalSeconds || 0)} | Dystans: ${formatTripDistance(summary.distanceMeters || 0)}</div>${ptsHtml}</div>`;
+        return `<div class="trip-day-card ${d.highlight ? 'trip-active-day' : 'trip-muted-day'}" data-day-card="${d.id}" onpointerup="window.forceTripDayFromInline(event, this)" ontouchend="window.forceTripDayFromInline(event, this)" onclick="window.forceTripDayFromInline(event, this)"><div class="trip-day-header"><div class="trip-day-select-zone" data-trip-day-select="${d.id}" onpointerup="window.forceTripDaySelectFromInline(event, this)" ontouchend="window.forceTripDaySelectFromInline(event, this)" onclick="window.forceTripDaySelectFromInline(event, this)"><b class="trip-day-title">${d.name || `Dzień ${idx+1}`}</b></div><label><input type="date" data-day-date="${d.id}" value="${d.date || ''}"></label><input class="trip-color-input" type="color" data-day-color="${d.id}" value="${d.color || '#ff3b3b'}"><label class="trip-day-visible-toggle" title="Pokaż/ukryj trasę dnia"><input type="checkbox" data-day-visible="${d.id}" ${d.visible === false ? '' : 'checked'}> Trasa</label><button data-day-delete="${d.id}" class="trip-icon-btn" title="Usuń dzień" aria-label="Usuń dzień">🗑️</button></div><div class="trip-day-summary">Jazda: ${formatTripDuration(summary.durationSeconds || 0)} | Zwiedzanie: ${formatTripDuration(summary.visitSeconds || 0)} | Razem: ${formatTripDuration(summary.totalSeconds || 0)} | Dystans: ${formatTripDistance(summary.distanceMeters || 0)}</div>${ptsHtml}</div>`;
       }).join('');
     }
     window.renderTripPlannerPanel = renderTripPlannerPanel;


### PR DESCRIPTION
### Motivation
- Improve UX so clicking/tapping a day title/zone switches the active day instantly on mobile and desktop without waiting for Firestore writes. 
- Keep active-day state purely local (session UI) and avoid persisting `highlight` or active-day changes to Firestore. 
- Make the build/cache-bust badge reflect the new change set version.

### Description
- Bumped app build/cache-bust tag from `trip-debug-2026-05-21-v17` to `trip-debug-2026-05-21-v18` and updated references used by the build badge and script/style URLs (`APP_BUILD`, `style.css`, `offline-uploads.js`, `firestore-setup.js`, `leaflet-tilelayer-wmts.js`).
- Added `function setActiveTripDayLocal(dayId)` which sets `activeTripDayId` and runtime-only `d.highlight` flags and returns the matched day without any persistence.
- Reworked `activateTripDayAndFit(dayId, options = {})` to call the local helper first, then immediately call `renderTripPlannerPanel()`, `renderTripMapLayers()` and `fitMapToTripPoints(...)`, and not block UI changes on `saveTrip` (no save required for pure UI active-day changes).
- Added a dedicated clickable zone in the planner card header: a `.trip-day-select-zone` with `data-trip-day-select` and pointer/touch/click bindings, and added `window.forceTripDaySelectFromInline(e, el)` as the global handler that validates the event (scroll/tap guard and excludes inputs/buttons/points) and calls `activateTripDayAndFit(dayId, { save: false })` without invoking `saveTrip`. Also simplified `window.forceTripDayFromInline` to delegate to the new function.
- Updated `forceTripActionFromInline` for `action === 'focus-point'` so that focusing a point from a non-active day uses `setActiveTripDayLocal(dayId)` and re-renders panel/map before focusing the point, without persisting the active-day state.
- Preserved existing functions and click/scroll guards; kept `data-day-card` attribute on `.trip-day-card` while making title/select-zone clicks more reliable.

### Testing
- Ran a repository file list check with `rg --files | head` and it completed successfully.
- Verified code locations and substitutions with `rg -n "trip-debug-2026-05-21-v17|activateTripDayAndFit|forceTripDayFromInline|forceTripActionFromInline|renderTripPlannerPanel|highlight|saveTrip\(" index.html` and the expected occurrences were found and updated; the search succeeded.
- Inspected modified code segments using `sed -n '2550,2765p;9950,10160p' index.html` and `nl -ba index.html | sed -n '1,25p;2588,2760p;10058,10160p'` to confirm the inserted helper, new handler and HTML changes; these inspections completed successfully.
- No unit/CI tests were present in this change; all performed automated command checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10220dbe548330bfbda4787beb9d3f)