### PR TITLE
Dodaj link Google Maps w popupie wyszukanego adresu

### DIFF
--- a/index.html
+++ b/index.html
@@ -9259,6 +9259,7 @@ function showRoutePopup(pinId, tr, latlng) {
       container.innerHTML = `
         <div>${label}</div>
         <div>${coordsDisplay}</div>
+        <div class="popup-info-item"><a href="https://maps.google.com/?q=${latNum},${lngNum}" target="_blank" rel="noopener noreferrer">📍 Google Maps</a></div>
         <div class="popup-route-actions">
           <button class="popup-direct-route-btn" id="routeSearchBtn">Wyznacz trasę do</button>
           <button class="popup-route-btn" id="addSearchPin">dodaj pinezkę</button>


### PR DESCRIPTION
### Motivation
- Ujednolicić popup wyszukanego adresu z popupem zapisanej pinezki przez dodanie szybkiego linku do otwarcia lokalizacji w Google Maps.

### Description
- W funkcji `showSearchMarker` w `index.html` dodano w `container.innerHTML` element z linkiem `https://maps.google.com/?q=${latNum},${lngNum}` otwieranym w nowej karcie (`target="_blank" rel="noopener noreferrer`), wyświetlanym jako `📍 Google Maps`.

### Testing
- Uruchomione polecenia `git diff -- index.html`, `git add index.html && git commit -m "Dodaj link Google Maps w popupie wyszukanego adresu"` oraz `nl -ba index.html | sed -n '9254,9270p'` i wszystkie zakończyły się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a141e74015c83308e3a2716d32f5426)