### PR TITLE
Preserve Leaflet marker transforms and refine UI scale controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,15 +92,39 @@
       display: flex;
       flex-direction: column;
       gap: 6px;
+      box-sizing: border-box;
+      width: 100%;
+      min-width: 0;
     }
     #uiScaleControls .ui-scale-row {
       display: grid;
-      grid-template-columns: auto 1fr auto auto;
+      grid-template-columns: auto minmax(0, 1fr) auto;
       align-items: center;
       gap: 6px;
+      width: 100%;
+      min-width: 0;
     }
-    #uiScaleControls button { min-width: 30px; }
-    #uiScaleLabel { min-width: 46px; text-align: center; font-weight: 600; }
+    #uiScaleControls .ui-scale-buttons {
+      display: inline-flex;
+      gap: 4px;
+      flex-shrink: 0;
+    }
+    #uiScaleControls button {
+      min-width: 28px;
+      max-width: 42px;
+      padding-left: 6px;
+      padding-right: 6px;
+    }
+    #uiScaleSlider {
+      min-width: 0;
+      width: 100%;
+    }
+    #uiScaleLabel {
+      min-width: 42px;
+      text-align: right;
+      white-space: nowrap;
+      font-weight: 600;
+    }
     #history-log {
       border-top: 1px solid #444;
       margin-top: 10px;
@@ -2255,16 +2279,34 @@ html body #basemap-switcher { width: calc(264px * var(--ui-scale)); }
   }
 }
 
-/* Nie skaluj markerów mapy */
-html body .emoji-marker,
-html body .emoji-sztosy,
-html body .custom-cluster-icon,
-html body .status-icon,
-html body .sztosy-gwiazda,
-html body .leaflet-marker-icon,
-html body .leaflet-marker-shadow {
-  font-size: initial !important;
-  transform: none !important;
+/* Map markers must not be affected by UI scale */
+html body .leaflet-marker-icon.emoji-marker,
+html body .emoji-marker {
+  font-size: 12.4px !important;
+  line-height: 25.6px !important;
+  background: none !important;
+  border: none !important;
+}
+
+html body .emoji-marker span:not(.status-icon):not(.sztosy-gwiazda),
+html body .emoji-marker .emoji-sztosy {
+  font-size: 22.4px !important;
+  line-height: 25.6px !important;
+}
+
+html body .emoji-marker img.emoji-obrys,
+html body .emoji-marker img.emoji-obrys-sztosy {
+  width: 22.4px !important;
+  height: 22.4px !important;
+}
+
+html body .emoji-marker .status-icon {
+  font-size: 14px !important;
+  line-height: 1 !important;
+}
+
+html body .emoji-marker .sztosy-gwiazda {
+  font-size: 18px !important;
 }
 
 /* Trip special point modal: bez podwójnego skalowania */
@@ -2548,10 +2590,12 @@ HTML DEBUG V12
     </div>
     <div id="uiScaleControls" aria-label="Skalowanie interfejsu">
       <div class="ui-scale-row">
-        <button id="uiScaleMinus" type="button" aria-label="Zmniejsz skalę UI">−</button>
-        <input id="uiScaleSlider" type="range" min="50" max="150" step="5" value="100" aria-label="Skala UI">
+        <div class="ui-scale-buttons">
+          <button id="uiScaleMinus" type="button" aria-label="Zmniejsz skalę UI">−</button>
+          <button id="uiScalePlus" type="button" aria-label="Zwiększ skalę UI">+</button>
+        </div>
+        <input id="uiScaleSlider" type="range" min="70" max="130" step="2" value="100" aria-label="Skala UI">
         <span id="uiScaleLabel">100%</span>
-        <button id="uiScalePlus" type="button" aria-label="Zwiększ skalę UI">+</button>
       </div>
       <button id="uiScaleReset" type="button">Reset</button>
     </div>
@@ -3398,9 +3442,9 @@ function slugify(str) {
     let map, baseLayer, routingLayer, roadsLayer, baseTileErrorHandler, waymarkedErrorHandler;
     let pinRepositionState = null;
     const UI_SCALE_STORAGE_KEY = 'exploMapaUiScale';
-    const UI_SCALE_MIN = 50;
-    const UI_SCALE_MAX = 150;
-    const UI_SCALE_STEP = 5;
+    const UI_SCALE_MIN = 70;
+    const UI_SCALE_MAX = 130;
+    const UI_SCALE_STEP = 2;
 
     function getStoredUiScale() {
       const raw = Number(localStorage.getItem(UI_SCALE_STORAGE_KEY));


### PR DESCRIPTION
### Motivation
- Leaflet uses `transform` to position markers and existing `transform: none` overrides broke emoji marker positioning and visibility.
- Emoji markers should not scale with the UI slider but must remain positioned by Leaflet and render correctly.
- The UI scale slider was too coarse and its layout caused the `+` button to move at small scales, so finer control and a stable layout are needed.

### Description
- Removed the global `transform: none !important` override for `.leaflet-marker-icon` and related selectors and replaced it with fixed-size CSS that targets only emoji marker internals (no `transform`, `left`, `top`, `position` or `display` changes to `.leaflet-marker-icon`).
- Added specific CSS rules for `.emoji-marker` internals (font sizes, line-heights and image dimensions) so emoji markers stay visually consistent while Leaflet maintains positioning.
- Reworked the UI scale control markup to group `−` and `+` buttons in a `.ui-scale-buttons` container and changed the slider HTML to `min="70" max="130" step="2" value="100"`.
- Adjusted CSS for `#uiScaleControls` and `.ui-scale-row` to a grid layout with improved sizing constraints, and updated JS constants to `UI_SCALE_MIN = 70`, `UI_SCALE_MAX = 130`, `UI_SCALE_STEP = 2` while preserving existing scaling logic and storage behavior.

### Testing
- Ran `rg`/searches to verify the old `transform: none` override was removed and the new `min="70" max="130" step="2"` slider attributes are present (success).
- Inspected file excerpts with `sed`/`nl` to confirm the new CSS block for emoji markers and updated `#uiScaleControls` layout exist (success).
- Verified changes with `git diff` and committed the updated `index.html` with `git commit` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a143357d1d08330b47b022e0406faba)