### PR TITLE
Fix consistent UI scaling for toolbar buttons in #narzedzia

### DIFF
--- a/index.html
+++ b/index.html
@@ -2334,6 +2334,42 @@ html body .trip-special-point-modal button,
 html body .trip-special-point-modal label {
   font-size: inherit !important;
 }
+
+/* Tool buttons: stronger override after UI SCALE OVERRIDES */
+#narzedzia {
+  display: flex;
+  align-items: center;
+  gap: calc(6px * var(--ui-scale));
+}
+
+#narzedzia .tool-btn {
+  width: calc(36px * var(--ui-scale)) !important;
+  height: calc(36px * var(--ui-scale)) !important;
+  min-width: calc(36px * var(--ui-scale)) !important;
+  min-height: calc(36px * var(--ui-scale)) !important;
+  max-width: none !important;
+  max-height: none !important;
+  padding: 0 !important;
+  font-size: calc(24px * var(--ui-scale)) !important;
+  line-height: 1 !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  box-sizing: border-box !important;
+  transform: none !important;
+}
+
+#narzedzia .tool-btn img {
+  width: calc(24px * var(--ui-scale)) !important;
+  height: calc(24px * var(--ui-scale)) !important;
+  display: block !important;
+  max-width: none !important;
+  max-height: none !important;
+}
+
+#narzedzia .tool-btn:active {
+  transform: none !important;
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Global UI scale overrides for `button` were overriding `.tool-btn` and causing inconsistent scaling between image-based and emoji/text toolbar buttons. 
- The goal is to make all four toolbar buttons scale identically using only the `--ui-scale` CSS variable and avoid JS sizing hacks.

### Description
- Added a stronger CSS block placed after the `UI SCALE OVERRIDES` section that targets `#narzedzia`, `#narzedzia .tool-btn`, `#narzedzia .tool-btn img` and `#narzedzia .tool-btn:active` using `calc(... * var(--ui-scale))` and `!important` for precedence. 
- The new rules set explicit `width`, `height`, `min-*`, `max-*`, `padding`, `font-size`, `line-height`, `display`, alignment and `box-sizing`, and disable `transform` to prevent visual size drift. 
- Image icons inside tool buttons are explicitly sized to match text/emoji buttons so `handTool` and `pinTool` behave identically to `undoBtn`/`redoBtn`.
- This is a CSS-only change inside `index.html` and does not touch Leaflet marker scaling or `.emoji-marker` styles.

### Testing
- Located relevant selectors with `rg` and confirmed the new CSS block is present in `index.html` using `nl`/`sed`, and the block appears after the `UI SCALE OVERRIDES` section. 
- Verified the inserted rules contain the expected `calc(... * var(--ui-scale))` properties and `!important` declarations. 
- No automated unit tests exist for this UI tweak; file-level checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1435a160f08330b13e800145e1105e)