### PR TITLE
Defer trip create/delete and point mutations until global Save Changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3751,6 +3751,7 @@ function slugify(str) {
     let hideMainPinsInTripMode = false;
     let tripPointMarkers = new Map();
     let activeTripDayId = null;
+    let pendingTripDeletes = new Set();
 
     function getClusterIconSize(count) {
       return count >= BIG_CLUSTER_COUNT ? 56 : count >= 100 ? 46 : 38;
@@ -4720,7 +4721,9 @@ function slugify(str) {
         hasUnsavedPinChanges() ||
         nowePinezki.length > 0 ||
         pinsToDelete.length > 0 ||
-        layerChanges
+        layerChanges ||
+        pendingTripDeletes.size > 0 ||
+        tripPlannerTrips.some(t => t?.unsaved)
       );
     }
 
@@ -10147,12 +10150,12 @@ function getTripPointEmoji(p) {
       day.points = day.points || [];
       day.points.push({ ...pointData, id: pointData.id || `pt_${Date.now()}`, name: dialogResult.name, pointType: dialogResult.pointType, emoji: customEmoji, visitMinutes: dialogResult.visitMinutes, note: '', order: day.points.length + 1 });
       day.points.forEach((p, i) => p.order = i + 1);
+      trip.unsaved = true;
       renderTripPlannerPanel();
       renderTripMapLayers();
       applyTripPlannerPinVisibility();
-      if (day.points.length >= 2) await recalculateTripDay(activeTripId, day.id);
-      else await saveTrip(activeTripId);
-      showToast('Dodano punkt do dnia');
+      updateSaveButton();
+      showToast('Dodano punkt do dnia (oczekuje na zapis zmian)');
     }
         function getCompatDb() {
       const compatDb = window.db || (typeof db !== 'undefined' ? db : null);
@@ -10244,6 +10247,7 @@ function getTripPointEmoji(p) {
         await dayRef.set({ name: safeDay.name, date: safeDay.date || '', order: di, color: safeDay.color || '#ff3b3b', routeSummary: safeDay.routeSummary || {}, routeSegments: safeDay.routeSegments || [], updatedAt: firebase.firestore.FieldValue.serverTimestamp() }, { merge: true });
         for (const [pi, point] of (safeDay.points || []).entries()) await dayRef.collection('points').doc(point.id).set({ ...point, order: pi }, { merge: true });
       }
+      trip.unsaved = false;
       showToast('Zapisano trip');
     }
     async function syncTripPointSnapshotsForPin(pin) {
@@ -11873,7 +11877,22 @@ function getTripPointEmoji(p) {
           return Promise.resolve();
         });
 
-        await Promise.all([...updatePromises, ...addPromises, ...deletePinPromises, ...layerUpdates, ...layerDeletes]);
+        const tripDeletePromises = [...pendingTripDeletes].map(async (tripId) => {
+          const tripToDelete = tripPlannerTrips.find(t => t.id === tripId);
+          const days = tripToDelete?.days || [];
+          for (const day of days) {
+            for (const pt of (day.points || [])) {
+              await db.collection('trips').doc(tripId).collection('days').doc(day.id).collection('points').doc(pt.id).delete().catch(()=>{});
+            }
+            await db.collection('trips').doc(tripId).collection('days').doc(day.id).delete().catch(()=>{});
+          }
+          await db.collection('trips').doc(tripId).delete().catch(()=>{});
+        });
+        const tripSavePromises = tripPlannerTrips
+          .filter(t => t && t.unsaved && !pendingTripDeletes.has(t.id))
+          .map(t => saveTrip(t.id));
+
+        await Promise.all([...updatePromises, ...addPromises, ...deletePinPromises, ...layerUpdates, ...layerDeletes, ...tripDeletePromises, ...tripSavePromises]);
         zmianyDoZapisania = {};
         nowePinezki = [];
         layersToAdd = [];
@@ -11883,6 +11902,7 @@ function getTripPointEmoji(p) {
         layerOrderChanged = false;
         initialLayerOrder = [...orderList];
         pinsToDelete = [];
+        pendingTripDeletes.clear();
         window.localTrasy = [];
         localStorage.removeItem('nowePinezki');
         shouldWarnBeforeUnload = false;
@@ -13762,9 +13782,8 @@ function confirmLayerDelete() {
     document.getElementById('tripSelect')?.addEventListener('change', e => { activeTripId = e.target.value || null; activeTripDayId = null; renderTripPlannerPanel(); renderTripMapLayers(); applyTripPlannerPinVisibility(); { const trip = getActiveTrip(); if (trip) fitMapToTripPoints(getAllActiveTripPoints(trip), { maxZoom: 15, pad: 0.2 }); } });
     document.getElementById('tripPinsVisibilityToggle')?.addEventListener('click', () => { hideMainPinsInTripMode = !hideMainPinsInTripMode; applyTripPlannerPinVisibility(); });
     document.getElementById('tripNewBtn')?.addEventListener('click', async () => {
-      const compatDb = getCompatDb();
       const user = firebase.auth().currentUser;
-      if (!compatDb || !user) { showToast('Najpierw zaloguj się'); return; }
+      if (!user) { showToast('Najpierw zaloguj się'); return; }
       const formData = await showCreateTripDialog();
       if (!formData) return;
       const { name, daysCount, startDate } = formData;
@@ -13772,40 +13791,20 @@ function confirmLayerDelete() {
       if (!Number.isFinite(daysCount) || daysCount < 1) { showToast('Podaj poprawną liczbę dni'); return; }
       if (!/^\d{4}-\d{2}-\d{2}$/.test(startDate)) { showToast('Podaj poprawną datę startu'); return; }
       const expectedEndDate = addDaysToIsoDate(startDate, daysCount - 1);
-      try {
-        const ref = compatDb.collection('trips').doc();
-        await ref.set({
-          name,
-          description: '',
-          startDate,
-          endDate: expectedEndDate,
-          ownerEmail: (user.email || '').toLowerCase(),
-          createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-          updatedAt: firebase.firestore.FieldValue.serverTimestamp()
-        });
-        for (let i = 0; i < daysCount; i++) {
-          const dayDate = addDaysToIsoDate(startDate, i);
-          await compatDb.collection('trips').doc(ref.id).collection('days').doc(`day_${Date.now()}_${i}`).set({
-            name: `Dzień ${i + 1}`,
-            date: dayDate,
-            order: i,
-            color: '#ff3b3b',
-            visible: true,
-            routeSummary: {},
-            routeSegments: [],
-            updatedAt: firebase.firestore.FieldValue.serverTimestamp()
-          }, { merge: true });
-        }
-        activeTripId = ref.id;
-        await loadTrips();
-        activeTripId = ref.id;
-        renderTripPlannerPanel();
-        renderTripMapLayers();
-      applyTripPlannerPinVisibility();
-        showToast('Utworzono trip');
-      } catch (err) {
-        console.error('Trip planner: błąd zapisu Firestore przy tworzeniu tripa.', err);
+      const tripId = `trip_${Date.now()}`;
+      const trip = { id: tripId, name, description: '', startDate, endDate: expectedEndDate, ownerEmail: (user.email || '').toLowerCase(), days: [], unsaved: true };
+      for (let i = 0; i < daysCount; i++) {
+        const dayDate = addDaysToIsoDate(startDate, i);
+        trip.days.push({ id: `day_${Date.now()}_${i}`, name: `Dzień ${i + 1}`, date: dayDate, order: i, color: '#ff3b3b', visible: true, routeSummary: {}, routeSegments: [], points: [] });
       }
+      pendingTripDeletes.delete(tripId);
+      tripPlannerTrips.push(trip);
+      activeTripId = tripId;
+      renderTripPlannerPanel();
+      renderTripMapLayers();
+      applyTripPlannerPinVisibility();
+      updateSaveButton();
+      showToast('Utworzono trip (oczekuje na Zapisz edycję mapy)');
     });
     const handleTripActiveBoxAction = async (e) => {
       const trip = getActiveTrip(); if (!trip) return;
@@ -13821,22 +13820,18 @@ function confirmLayerDelete() {
       if (addDayBtn) {
         const day = { id: `day_${Date.now()}`, name: `Dzień ${trip.days.length + 1}`, color: '#ff3b3b', visible: true, points: [], routeSummary: {} };
         if (!trip.days.length) activeTripDayId = day.id;
-        trip.days.push(day); await saveTrip(trip.id); renderTripPlannerPanel(); renderTripMapLayers(); return;
+        trip.days.push(day); trip.unsaved = true; renderTripPlannerPanel(); renderTripMapLayers(); updateSaveButton(); return;
       }
       if (addPrivatePointBtn) { tripPrivatePointArmed = true; showToast('Kliknij na mapie, aby dodać prywatny punkt tripa.'); return; }
       if (exportCsvBtn) { exportTripToCsv(trip); return; }
       if (exportPdfBtn) { exportTripToPdf(trip); return; }
       if (deleteTripBtn) {
         if (!confirm('Na pewno usunąć cały trip?')) return;
-        const compatDb = getCompatDb(); if (!compatDb) return;
-        for (const day of (trip.days || [])) {
-          for (const pt of (day.points || [])) await compatDb.collection('trips').doc(trip.id).collection('days').doc(day.id).collection('points').doc(pt.id).delete().catch(()=>{});
-          await compatDb.collection('trips').doc(trip.id).collection('days').doc(day.id).delete().catch(()=>{});
-        }
-        await compatDb.collection('trips').doc(trip.id).delete();
+        pendingTripDeletes.add(trip.id);
         tripPlannerTrips = tripPlannerTrips.filter(t => t.id !== trip.id);
         activeTripId = tripPlannerTrips[0]?.id || null;
         renderTripPlannerPanel(); renderTripMapLayers(); applyTripPlannerPinVisibility();
+        updateSaveButton();
         return;
       }
       const eventPath = (typeof e.composedPath === 'function') ? e.composedPath() : [];
@@ -13920,12 +13915,12 @@ function confirmLayerDelete() {
           if (pointIndex < 0) return;
           const pointName = day.points[pointIndex]?.name || day.points[pointIndex]?.nameSnapshot || 'Punkt';
           if (!confirm(`Czy na pewno chcesz usunąć ${pointName}?`)) return;
-          const compatDb = getCompatDb();
-          if (!compatDb) return;
-          await compatDb.collection('trips').doc(activeTrip.id).collection('days').doc(day.id).collection('points').doc(pointId).delete().catch(() => {});
           day.points.splice(pointIndex, 1);
-          await saveTripDayPointOrder(activeTrip.id, day.id, day.points);
-          await recalculateTripDay(activeTrip.id, day.id);
+          day.points.forEach((p, i) => { p.order = i + 1; });
+          activeTrip.unsaved = true;
+          day.routeSegments = [];
+          day.routeSummary = day.routeSummary || {};
+          updateSaveButton();
           showToast('Usunięto punkt z tripa');
           return;
         }
@@ -13935,15 +13930,13 @@ function confirmLayerDelete() {
         const dayId = deleteDayBtn.dataset.dayDelete;
         const dayIndex = trip.days.findIndex(d => d.id === dayId);
         if (dayIndex < 0) return;
-        const compatDb = getCompatDb(); if (!compatDb) return;
         const day = trip.days[dayIndex];
-        for (const pt of (day.points || [])) await compatDb.collection('trips').doc(trip.id).collection('days').doc(day.id).collection('points').doc(pt.id).delete().catch(()=>{});
-        await compatDb.collection('trips').doc(trip.id).collection('days').doc(day.id).delete().catch(()=>{});
         trip.days.splice(dayIndex, 1);
         if (activeTripDayId === dayId) activeTripDayId = null;
         recalculateTripDateRange(trip);
-        await saveTrip(trip.id);
+        trip.unsaved = true;
         renderTripPlannerPanel(); renderTripMapLayers(); applyTripPlannerPinVisibility();
+        updateSaveButton();
         return;
       }
 


### PR DESCRIPTION
### Motivation
- Trip creation, deletion and adding/removing trip points should not write immediately to Firestore but wait for an explicit confirmation via the global `Zapisz edycję mapy` (`saveChanges`) button.

### Description
- Introduced `pendingTripDeletes` set and `trip.unsaved` flag and wired them into `hasUnsavedChanges()` so trip edits show the global save button. 
- Changed the trip creation flow to create trips locally (marked `unsaved`) instead of writing directly to Firestore, and changed delete-trip to queue deletion in `pendingTripDeletes` instead of immediate Firestore delete. 
- Updated point/day add/remove handlers to mutate local trip state and mark the trip `unsaved` rather than immediately persisting, and updated UI rendering and save-button state accordingly. 
- Extended `zapiszZmiany()` to process queued `tripDeletePromises` and `tripSavePromises` during the global save, and to clear `pendingTripDeletes` on success; also set `trip.unsaved = false` inside `saveTrip()` after persisting.

### Testing
- Ran project file inspections and searches to verify modified call sites with `rg` and `sed` commands (no runtime errors observed during static checks). 
- Performed Git operations: `git status`, `git add index.html`, and `git commit -m "Defer trip create/delete and point deletions until Save Changes"`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1437cb2a0c8330b14fcd15343de447)