### PR TITLE
Enqueue offline pin operations only on Save Changes

### DIFF
--- a/firestore-setup.js
+++ b/firestore-setup.js
@@ -49,14 +49,10 @@ window.addPinOffline = async function({ lat, lng, name, opis, warstwa, emoji, ka
     updatedAt: firebase.firestore.FieldValue.serverTimestamp()
   };
 
-  if (!navigator.onLine && window.upsertQueueOperation) {
-    const queueEntry = await window.upsertQueueOperation({
-      operation: 'createPin',
-      payload,
-      syncStatus: 'pending'
-    });
-    window.dispatchEvent(new CustomEvent('offline-pin-created', { detail: { ...payload, localId: queueEntry.localId, offline: true } }));
-    return { id: queueEntry.localId, offline: true };
+  if (!navigator.onLine) {
+    const localId = `local-${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+    window.dispatchEvent(new CustomEvent('offline-pin-created', { detail: { ...payload, localId, offline: true } }));
+    return { id: localId, offline: true, queued: false };
   }
 
   return db.collection('pinezki2').add(payload);

--- a/index.html
+++ b/index.html
@@ -11753,12 +11753,102 @@ function getTripPointEmoji(p) {
       updatePerformanceDebug('layers header render', performance.now() - sidebarRenderStartTs);
     }
 
+    async function enqueueApprovedOfflineChanges() {
+      const queuedAt = Date.now();
+
+      const updateOps = Object.entries(zmianyDoZapisania).map(async ([id, data]) => {
+        const p = wszystkiePinezki.find(pp => pp.id === id);
+        if (!p || !p.firebaseId) return;
+        const payload = { ...(data || {}) };
+        delete payload.plany;
+        delete payload.activeTripDay;
+        if (!Object.keys(payload).length) return;
+        await window.upsertQueueOperation({
+          localId: `update-${p.firebaseId}`,
+          operation: 'updatePin',
+          firebaseId: p.firebaseId,
+          payload,
+          createdAt: queuedAt,
+          syncStatus: 'pending'
+        });
+      });
+
+      const addOps = nowePinezki.map(async (p, idx) => {
+        const suffix = generateSuffix();
+        const firebaseId = `${sanitize(p.nazwa)}_${suffix}`;
+        p.firebaseId = firebaseId;
+        const layerInfo = resolveLayerInfo(p.warstwa, p.warstwaId);
+        const payload = {
+          nazwa: p.nazwa,
+          opis: p.opis,
+          warstwa: layerInfo.warstwaId || null,
+          warstwaId: layerInfo.warstwaId || null,
+          kategoria: p.kategoria,
+          kategoriaGlowna: getPinMainCategory(p),
+          kraj: p.kraj || '',
+          emoji: p.emoji,
+          nieaktywne: p.nieaktywne || false,
+          zamkniete: p.zamkniete || false,
+          tajne: p.tajne || false,
+          doSprawdzenia: p.doSprawdzenia || false,
+          zdewastowane: p.zdewastowane || false,
+          zwiedzone: p.zwiedzone || false,
+          wyroznione: p.wyroznione || false,
+          lat: p.lat,
+          lng: p.lng,
+          IDpinezki: p.id,
+          odKogo: p.odKogo || '',
+          trasy: (p.trasy || []).map(t => serializeRoute(t)),
+          plany: []
+        };
+        if (p.trudnosc !== undefined) payload.trudnosc = p.trudnosc;
+        await window.upsertQueueOperation({
+          localId: `create-${firebaseId}-${idx}`,
+          operation: 'createPin',
+          firebaseId,
+          payload,
+          createdAt: queuedAt + idx + 1,
+          syncStatus: 'pending'
+        });
+      });
+
+      const deleteOps = pinsToDelete.map(async (info, idx) => {
+        const p = info?.firebaseId ? null : wszystkiePinezki.find(pp => pp.id === (info ? info.id : info));
+        const firebaseId = info?.firebaseId || p?.firebaseId;
+        if (!firebaseId) return;
+        await window.upsertQueueOperation({
+          localId: `delete-${firebaseId}-${idx}`,
+          operation: 'deletePin',
+          firebaseId,
+          payload: {},
+          createdAt: queuedAt + 1000 + idx,
+          syncStatus: 'pending'
+        });
+      });
+
+      await Promise.all([...updateOps, ...addOps, ...deleteOps]);
+    }
+
     async function zapiszZmiany() {
       const btn = document.getElementById('saveChanges'); // [CODEx CHANGED] fragment w zapiszZmiany()
       const origLabel = btn.textContent;
       btn.disabled = true;
       btn.textContent = 'Zapisywanie…';
       try {
+        if (!navigator.onLine && window.upsertQueueOperation) {
+          await enqueueApprovedOfflineChanges();
+          zmianyDoZapisania = {};
+          nowePinezki = [];
+          pinsToDelete = [];
+          pendingTripDeletes.clear();
+          localStorage.removeItem('nowePinezki');
+          shouldWarnBeforeUnload = false;
+          btn.textContent = 'Zapisano offline ✔';
+          updateSaveButton();
+          showToast('Zatwierdzono zmiany offline. Użyj „Synchronizuj”, gdy wróci internet.', 5000);
+          return;
+        }
+
         let totalAll = 0;
         Object.entries(zmianyDoZapisania).forEach(([id]) => {
           const p = wszystkiePinezki.find(pp => pp.id === id);


### PR DESCRIPTION
### Motivation
- Ensure offline pin add/edit/delete follow the existing ExploMapa workflow where changes are first stored in unsaved structures and only approved by the user via `#saveChanges` before being queued for synchronization.
- Prevent immediate enqueueing of `createPin`/`updatePin`/`deletePin` on each local edit, which created a parallel save path outside the single `saveChanges` flow.
- Keep synchronization gated by an explicit save step so unapproved transient edits are not synced after a page reload or exit.

### Description
- Modified `addPinOffline` in `firestore-setup.js` to stop writing directly to the offline queue and instead emit a local offline-created event with a generated local id when offline. 
- Added `enqueueApprovedOfflineChanges()` in `index.html` to convert approved changes from `zmianyDoZapisania`, `nowePinezki` and `pinsToDelete` into queued operations (`createPin`/`updatePin`/`deletePin`) using `upsertQueueOperation` with `pending` status. 
- Updated `zapiszZmiany()` to branch: when offline it calls `enqueueApprovedOfflineChanges()`, clears the unsaved buffers (`zmianyDoZapisania`, `nowePinezki`, `pinsToDelete`), updates UI state and returns, while the online path continues to write to Firestore as before. 
- Ensures `#syncBtn` / `syncOfflineQueue()` remain the sole mechanism to push pending queued operations to Firestore, preserving a single save workflow.

### Testing
- Performed a file diff inspection of `firestore-setup.js` and `index.html` to verify the new `enqueueApprovedOfflineChanges()` implementation and the `addPinOffline` behavior change, which succeeded. 
- Displayed and reviewed the modified code segments to confirm the offline branch in `zapiszZmiany()` clears buffers and enqueues only on save, which succeeded. 
- Verified repository file status to ensure changes were recorded and the working tree is clean, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a143cc607348330a5d7df6c17977151)