### PR TITLE
Fix PWA cache busting and service worker update activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
-  <link rel="stylesheet" href="style.css?v=trip-debug-2026-05-21-v18" />
+  <link rel="stylesheet" href="style.css?v=ui-fix-2026-05-25-v1" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -2706,15 +2706,15 @@ HTML DEBUG V12
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
-  <script src="offline-uploads.js?v=trip-debug-2026-05-21-v18"></script>
-  <script src="firestore-setup.js?v=trip-debug-2026-05-21-v18"></script>
+  <script src="offline-uploads.js?v=ui-fix-2026-05-25-v1"></script>
+  <script src="firestore-setup.js?v=ui-fix-2026-05-25-v1"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
   <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
-  <script src="leaflet-tilelayer-wmts.js?v=trip-debug-2026-05-21-v18"></script>
+  <script src="leaflet-tilelayer-wmts.js?v=ui-fix-2026-05-25-v1"></script>
 
   <script>
-    const APP_BUILD = 'trip-debug-2026-05-21-v18';
+    const APP_BUILD = 'ui-fix-2026-05-25-v1';
     window.rawTripDebug = function(msg) {
       // Debug wyłączony. Funkcja musi istnieć, bo używają jej inline handlery #modeTripBtn.
     };
@@ -3073,9 +3073,30 @@ HTML DEBUG V12
     });
 
     if ('serviceWorker' in navigator) {
+      let refreshing = false;
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (refreshing) return;
+        refreshing = true;
+        window.location.reload();
+      });
+
       window.addEventListener('load', () => {
         navigator.serviceWorker.register('/ExploMapa/service-worker.js')
-          .then(() => console.log('Service worker registered: /ExploMapa/service-worker.js'))
+          .then(reg => {
+            console.log('Service worker registered: /ExploMapa/service-worker.js');
+            reg.addEventListener('updatefound', () => {
+              const newWorker = reg.installing;
+              if (!newWorker) return;
+              newWorker.addEventListener('statechange', () => {
+                if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                  const shouldReload = window.confirm('Dostępna nowa wersja aplikacji – odśwież teraz?');
+                  if (shouldReload) {
+                    newWorker.postMessage({ type: 'SKIP_WAITING' });
+                  }
+                }
+              });
+            });
+          })
           .catch(err => console.error('Service worker registration error:', err));
       });
     }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
-const APP_CACHE = 'explomapa-app-v2';
-const TILE_CACHE = 'explomapa-tiles-v2';
+const CACHE_NAME = 'explomapa-ui-fix-2026-05-25-v1';
+const TILE_CACHE = 'explomapa-tiles-ui-fix-2026-05-25-v1';
 
 const APP_SHELL = [
   '/ExploMapa/',
@@ -26,7 +26,7 @@ const APP_SHELL = [
 
 self.addEventListener('install', event => {
   event.waitUntil((async () => {
-    const cache = await caches.open(APP_CACHE);
+    const cache = await caches.open(CACHE_NAME);
     await Promise.all(APP_SHELL.map(async (asset) => {
       try { await cache.add(asset); } catch (e) { console.warn('[SW] cache miss', asset, e); }
     }));
@@ -37,8 +37,8 @@ self.addEventListener('install', event => {
 self.addEventListener('activate', event => {
   event.waitUntil((async () => {
     const keys = await caches.keys();
-    await Promise.all(keys.filter(k => ![APP_CACHE, TILE_CACHE].includes(k)).map(k => caches.delete(k)));
-    await self.clients.claim();
+    await Promise.all(keys.filter(k => ![CACHE_NAME, TILE_CACHE].includes(k)).map(k => caches.delete(k)));
+    await clients.claim();
   })());
 });
 
@@ -49,6 +49,13 @@ function isTileRequest(url) {
 function isFirestoreOrAuth(url) {
   return url.hostname.includes('firestore') || url.hostname.includes('googleapis.com') || url.hostname.includes('firebase') || url.pathname.includes('/auth');
 }
+
+
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
 
 self.addEventListener('fetch', event => {
   const { request } = event;


### PR DESCRIPTION
### Motivation
- UI changes were not visible because clients were loading stale app-shell assets from the Service Worker cache and GitHub Pages served cached files.  
- The intent is to force cache invalidation for local assets and provide a deterministic SW update/activation flow so users see the new UI immediately or after a single confirmation.  

### Description
- Updated the `APP_BUILD` constant in `index.html` to `ui-fix-2026-05-25-v1`.  
- Bumped local asset query strings in `index.html` for `style.css`, `offline-uploads.js`, `firestore-setup.js`, and `leaflet-tilelayer-wmts.js` to `?v=ui-fix-2026-05-25-v1`.  
- Replaced cache keys in `service-worker.js` with `const CACHE_NAME = 'explomapa-ui-fix-2026-05-25-v1'` and `const TILE_CACHE = 'explomapa-tiles-ui-fix-2026-05-25-v1'` and switched SW code to open the new `CACHE_NAME`.  
- Ensured immediate activation hooks (`self.skipWaiting()` and `clients.claim()`), removed old caches during activation via `caches.keys()` filtering, added a `message` handler for `SKIP_WAITING`, and implemented an in-page SW registration flow that detects `updatefound`, prompts the user with "Dostępna nowa wersja aplikacji – odśwież teraz?", posts `SKIP_WAITING` to the waiting worker, and reloads on `controllerchange`.  

### Testing
- Ran a repository search with `rg -n "APP_BUILD|style.css\?v=|offline-uploads.js\?v=|firestore-setup.js\?v=|leaflet-tilelayer-wmts.js\?v=|const CACHE_NAME|skipWaiting\(|clients.claim\(|caches.keys\(|SKIP_WAITING|updatefound|Dostępna nowa wersja"` and confirmed the updated identifiers and strings; the check succeeded.  
- Inspected `index.html` and `service-worker.js` with line-numbered views (`nl`/`sed`) to verify the new `APP_BUILD`, query strings, SW cache names, `SKIP_WAITING` handler, and `updatefound`/`controllerchange` logic; the inspection succeeded.  
- Verified the working tree with `git status --short` and created a local commit containing these changes; the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1443b4548483309ad6fc5ca2c114e6)