### PR TITLE
Zmniejsz czcionkę przycisków collapse/toggle w sidebarze

### DIFF
--- a/index.html
+++ b/index.html
@@ -1857,8 +1857,8 @@ img.emoji {
       flex: 1 1 0;
       width: auto;
       min-height: 26px;
-      font-size: 11px;
-      line-height: 1.15;
+      font-size: 9px;
+      line-height: 1.1;
       white-space: nowrap;
     }
 


### PR DESCRIPTION
### Motivation
- Po ustawieniu przycisków `collapseAllLayers` i `toggleVisibility` w jednej linii ich etykiety wychodziły poza szerokość paska bocznego, więc zmniejszono rozmiar tekstu, aby zapobiec overflow.

### Description
- W `index.html` w sekcji `.layer-actions-row #collapseAllLayers, .layer-actions-row #toggleVisibility` zmieniono `font-size: 11px` na `9px` oraz `line-height: 1.15` na `1.1`.

### Testing
- Uruchomiono `git -C /workspace/ExploMapa diff -- index.html` w celu weryfikacji różnic i wykonano `git commit`, które zakończyło się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14481288388330b6588748aed10d1d)