### PR TITLE
Zwiń domyślnie sekcje „Widok ulic”, „Wyznacz trasę” i „Historia edycji”

### DIFF
--- a/index.html
+++ b/index.html
@@ -2612,14 +2612,14 @@ HTML DEBUG V12
         </div>
       </details>
 
-      <details open>
+      <details>
         <summary><strong>Widok ulic</strong></summary>
         <label><input type="radio" name="streets" value="full" checked> Wszystkie ulice</label><br>
         <label><input type="radio" name="streets" value="main"> Tylko główne trasy</label><br>
         <label><input type="radio" name="streets" value="none"> Brak ulic</label><br>
       </details>
 
-      <details open>
+      <details>
         <summary><strong>Wyznacz trasę</strong></summary>
         <div id="route-controls">
         <div class="route-input-group">
@@ -2639,7 +2639,7 @@ HTML DEBUG V12
         </div>
         </div>
       </details>
-      <details open>
+      <details>
         <summary><strong>Historia edycji</strong></summary>
         <div id="history-log"></div>
       </details>


### PR DESCRIPTION
### Motivation
- Zmniejszyć zajętość panelu bocznego i sprawić, by mniej istotne panele były domyślnie zwinięte podczas ładowania aplikacji.

### Description
- Usunięto atrybut `open` z trzech elementów `<details>` w `index.html` odpowiadających za sekcje `Widok ulic`, `Wyznacz trasę` i `Historia edycji`, dzięki czemu są one domyślnie zwinięte.

### Testing
- Zweryfikowano zmiany w pliku `index.html` przy pomocy `nl -ba` oraz wykonano `git add` i `git commit`, które zakończyły się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1449d0188483309e7898a7661cfe64)