### PR TITLE
Przenieś przycisk „Synchronizuj” do prawego panelu nad suwakiem UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -2499,7 +2499,6 @@ HTML DEBUG V12
         <div id="tripActiveBox"></div>
       </div>
       <div id="lista-warstw"></div>
-      <button id="syncBtn">Synchronizuj (<span id="syncCountBtn">0</span>)</button>
     </div>
   </div>
   <div id="bulk-pin-panel">
@@ -2655,6 +2654,7 @@ HTML DEBUG V12
         <ul id="offlinePinsList"></ul>
       </div>
     </div>
+    <button id="syncBtn">Synchronizuj (<span id="syncCountBtn">0</span>)</button>
     <div id="uiScaleControls" aria-label="Skalowanie interfejsu">
       <div class="ui-scale-row">
         <div class="ui-scale-buttons">


### PR DESCRIPTION
### Motivation
- Przyciski mobilnego UI mają być dostępne w prawym panelu obok ustawień mapy, więc `Synchronizuj` powinien być nad suwakiem skali interfejsu dla lepszej ergonomii na mobile.
- Zmiana ma jedynie poprawić układ bez modyfikowania istniejącej logiki synchronizacji.

### Description
- Przeniesiono element `<button id="syncBtn">` z sekcji przy `#lista-warstw` do prawego panelu (`rightStatusPanelWrap`) bezpośrednio nad kontrolką `#uiScaleControls` w `index.html`.
- Nie zmieniano identyfikatorów ani skryptów obsługujących przycisk, więc istniejące eventy i logika pozostają bez zmian.
- Zmiana to pojedyncza modyfikacja struktury HTML (1 wstawienie, 1 usunięcie).

### Testing
- Uruchomiono `rg -n "id=\"syncBtn\"" index.html` aby zweryfikować lokalizację przycisku i test zwrócił nową pozycję w pliku, co potwierdza przeniesienie.
- Sprawdzono różnicę poleceniem `git diff -- index.html` i wynik zawiera tylko oczekiwane przeniesienie elementu, bez dodatkowych zmian.
- Wykonano `git commit -m "Przenieś przycisk synchronizacji nad suwak skali UI w prawym panelu"` i commit zakończył się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a144bf8c5d08330bc23b79ad8d247b1)