### PR TITLE
Restore panel collapse arrows after Twemoji parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -12259,6 +12259,9 @@ function getTripPointEmoji(p) {
         console.warn('twemoji.parse failed', err);
       }
     }
+    if (typeof updateDesktopPanelToggleLabels === 'function') {
+      updateDesktopPanelToggleLabels();
+    }
     const specialMenu = document.getElementById('specialMenu');
     const specialMenuToggle = document.getElementById('specialMenuToggle');
     const specialMenuContent = document.getElementById('specialMenuContent');


### PR DESCRIPTION
### Motivation
- Ensure panel collapse toggle labels remain as plain text arrows (`◀`/`▶`) and are not replaced by Twemoji images after `twemoji.parse(...)` executes.

### Description
- Add a guarded call to `updateDesktopPanelToggleLabels()` in the `DOMContentLoaded` handler in `index.html` so labels are restored after Twemoji parsing (`if (typeof updateDesktopPanelToggleLabels === 'function') { updateDesktopPanelToggleLabels(); }`).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1568e0b8e483309d975c313d06ea58)