### PR TITLE
Fix save button visibility, marker proportions and emoji picker positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -4789,6 +4789,7 @@ function slugify(str) {
       // dlatego o niezapisanych trasach decydujemy wyłącznie przez realne zmiany pinezek.
       return (
         hasUnsavedPinChanges() ||
+        wszystkiePinezki.some(pin => pin && pin.unsaved) ||
         nowePinezki.length > 0 ||
         pinsToDelete.length > 0 ||
         layerChanges ||
@@ -5018,10 +5019,12 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
       }
 
       if (!emojiOrUrl || String(emojiOrUrl).trim() === "" || emojiOrUrl === "undefined") {
+        const defaultMarkerWidth = 27 * markerScale;
+        const defaultMarkerHeight = 43 * markerScale;
         return L.icon({
           iconUrl: 'https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2_hdpi.png',
-          iconSize: [scaledSize * 0.56, scaledSize * 0.9],
-          iconAnchor: [scaledSize * 0.28, scaledSize * 0.9]
+          iconSize: [defaultMarkerWidth, defaultMarkerHeight],
+          iconAnchor: [defaultMarkerWidth / 2, defaultMarkerHeight]
         });
       }
 
@@ -6174,8 +6177,8 @@ function emojiHtml(str) {
       if (!isMobile) {
         grid.style.left = 'auto';
         grid.style.right = '0';
-        grid.style.top = 'auto';
-        grid.style.bottom = '34px';
+        grid.style.top = '34px';
+        grid.style.bottom = 'auto';
         return;
       }
 
@@ -6189,8 +6192,8 @@ function emojiHtml(str) {
         grid.style.top = '34px';
         grid.style.bottom = 'auto';
       } else {
-        grid.style.top = 'auto';
-        grid.style.bottom = '34px';
+        grid.style.top = '34px';
+        grid.style.bottom = 'auto';
       }
     }
 
@@ -12914,10 +12917,10 @@ function confirmLayerDelete() {
   function saveCenterPin(form) {
     const latlng = map.getCenter();
     const layerVal = form.warstwa.trim();
-    if (layerVal && !warstwy[layerVal]) addLayer(layerVal, true, mainCatVal);
     const resolvedCategory = resolveMainCategoryForCategory(form.kategoriaGlowna, form.kategoria);
     const mainCatVal = resolvedCategory.mainCategory;
     const catVal = resolvedCategory.category;
+    if (layerVal && !warstwy[layerVal]) addLayer(layerVal, true, mainCatVal);
     const newId = crypto.randomUUID();
     const data = {
       id: newId,


### PR DESCRIPTION
### Motivation
- Przywrócenie widoczności przycisku `#saveChanges` gdy są rzeczywiste, znaczące edycje pinezek (np. pinezka ma flagę `unsaved`) aby użytkownik mógł zapisać zmiany do Firestore.
- Naprawa widocznych regresji UI: rozciągnięta ikona markera oraz nieintuicyjne pozycjonowanie pickera emoji uniemożliwiające wygodną selekcję.

### Description
- Zaktualizowano logikę wykrywania niezapisanych zmian w `hasUnsavedChanges()` przez dodanie `wszystkiePinezki.some(pin => pin && pin.unsaved)` tak, żeby nowe/edytowane pinezki oznaczone `unsaved` powodowały pokazanie przycisku `#saveChanges`.
- Przeniesiono wywołanie `addLayer(layerVal, true, mainCatVal)` w `saveCenterPin()` tak, żeby najpierw wyliczyć `mainCatVal`, a następnie tworzyć warstwę, co zapobiegało użyciu nieustawionej wartości kategorii.
- Poprawiono domyślne wymiary i anchor dla natywnej ikony mapy w `createEmojiIcon()` (zamiast skalowania przez `scaledSize` używane są stałe proporcje `defaultMarkerWidth` / `defaultMarkerHeight`), dzięki czemu standardowy marker nie jest już rozciągnięty.
- Dostosowano pozycjonowanie gridu pickera emoji w `positionEmojiGrid()` tak, aby na desktopie i w mobilnych scenariuszach picker otwierał się w dół i w lewo względem przycisku (ustawienia `grid.style.top = '34px'` i `grid.style.bottom = 'auto'`).

### Testing
- Uruchomione polecenie `git diff -- index.html` weryfikujące zmiany i wyświetlające oczekiwany patch (sukces).
- Sprawdzono status repo za pomocą `git status --short` aby potwierdzić zmodyfikowany plik (sukces).
- Zacommitowano poprawki poleceniem `git add index.html && git commit -m "Fix unsaved-map button, marker proportions, and emoji picker direction"` co zakończyło się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15827e42588330bb6d4a256d0aaeea)