### PR TITLE
Zatrzymaj natychmiastowy zapis pinezek do Firestore

### DIFF
--- a/firestore-setup.js
+++ b/firestore-setup.js
@@ -49,13 +49,9 @@ window.addPinOffline = async function({ lat, lng, name, opis, warstwa, emoji, ka
     updatedAt: firebase.firestore.FieldValue.serverTimestamp()
   };
 
-  if (!navigator.onLine) {
-    const localId = `local-${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
-    window.dispatchEvent(new CustomEvent('offline-pin-created', { detail: { ...payload, localId, offline: true } }));
-    return { id: localId, offline: true, queued: false };
-  }
-
-  return db.collection('pinezki2').add(payload);
+  const localId = `local-${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+  window.dispatchEvent(new CustomEvent('offline-pin-created', { detail: { ...payload, localId, offline: !navigator.onLine } }));
+  return { id: localId, offline: !navigator.onLine, queued: false };
 };
 
 window.getCurrentPositionOnce = function() {
@@ -113,6 +109,19 @@ window.showOfflineBar = function(show){
   if (el) el.style.display = show ? 'block' : 'none';
 };
 
+
+const isMobileClient = window.matchMedia && window.matchMedia('(max-width: 900px)').matches;
+function applySyncUiVisibility(){
+  const syncBtnEl = document.getElementById('syncBtn');
+  const offlinePanelEl = document.getElementById('offlinePinsPanel');
+  const syncStatusEl = document.getElementById('syncStatus');
+  if (!isMobileClient) {
+    if (syncBtnEl) syncBtnEl.style.display = 'none';
+    if (offlinePanelEl) offlinePanelEl.style.display = 'none';
+    if (syncStatusEl) syncStatusEl.style.display = 'none';
+  }
+}
+
 window.addEventListener('offline', () => {
   updateConnectionState();
   updateSyncStatus('offline');
@@ -133,7 +142,7 @@ window.addEventListener('online', () => {
     });
 });
 
-const syncBtn = document.getElementById('syncBtn');
+const syncBtn = isMobileClient ? document.getElementById('syncBtn') : null;
 if (syncBtn) {
   syncBtn.addEventListener('click', async () => {
     showBanner('Synchronizuję…', 'info');
@@ -148,6 +157,7 @@ if (syncBtn) {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
+  applySyncUiVisibility();
   updateConnectionState();
   if (navigator.onLine) {
     if (window.syncOfflineQueue) window.syncOfflineQueue().catch(()=>{});

--- a/index.html
+++ b/index.html
@@ -4643,39 +4643,17 @@ function slugify(str) {
         wszystkiePinezki.push(data);
         return data;
       });
-      generujListeWarstw();
-      const savePromises = createdPins.map(async p => {
-        const suffix = generateSuffix();
-        const firebaseId = `${sanitize(p.nazwa)}_${suffix}`;
-        p.firebaseId = firebaseId;
-        const layerInfo = resolveLayerInfo(p.warstwa, p.warstwaId);
-        const payload = {
-          nazwa: p.nazwa,
-          opis: p.opis,
-          warstwa: layerInfo.warstwaId || null,
-          warstwaId: layerInfo.warstwaId || null,
-          kategoria: p.kategoria,
-        kategoriaGlowna: getPinMainCategory(p),
-          kraj: p.kraj || '',
-          emoji: p.emoji,
-          nieaktywne: p.nieaktywne || false,
-          zamkniete: p.zamkniete || false,
-          tajne: p.tajne || false,
-          doSprawdzenia: p.doSprawdzenia || false,
-          zdewastowane: p.zdewastowane || false,
-          zwiedzone: p.zwiedzone || false,
-          wyroznione: p.wyroznione || false,
-          lat: p.lat,
-          lng: p.lng,
-          dataDodania: firebase.firestore.FieldValue.serverTimestamp(),
-          IDpinezki: p.id,
-          odKogo: p.odKogo || '',
-          trasy: [],
-          plany: []
-        };
-        await db.collection('pinezki2').doc(firebaseId).set(payload);
+      createdPins.forEach(p => {
+        p.unsaved = true;
+        p.firebaseId = null;
+        if (!nowePinezki.includes(p)) nowePinezki.push(p);
       });
-      await Promise.all(savePromises);
+      localStorage.setItem('nowePinezki', JSON.stringify(nowePinezki.map(p => {
+        const { marker, ...rest } = p;
+        return rest;
+      })));
+      generujListeWarstw();
+      updateSaveButton();
       return createdPins.length;
     };
     if (addLayerBtn && newLayerControls && newLayerInput) {
@@ -12852,6 +12830,7 @@ function confirmLayerDelete() {
       warstwy[name] = { lista: [], layer: createPinLayer().addTo(map), collapsed: true, emoji: '', defaultVisible: true };
     }
     generujListeWarstw();
+    updateSaveButton();
   }
 
   async function saveMovingPin(name) {
@@ -12864,28 +12843,11 @@ function confirmLayerDelete() {
       warstwy['Tryb w ruchu'].visible = true;
       warstwy['Tryb w ruchu'].layer.addTo(map);
     }
-    const suffix = generateSuffix();
-    const firebaseId = `${sanitize(name)}_${suffix}`;
     const IDpinezki = crypto.randomUUID();
-      await db.collection('pinezki2').doc(firebaseId).set({
-        nazwa: name,
-        opis: '',
-        warstwa: movingLayerId,
-        warstwaId: movingLayerId,
-        kategoria: '',
-        kategoriaGlowna: MAIN_CATEGORY_URBEX,
-        kraj: '',
-        emoji: 'emoji39',
-        trudnosc: 0,
-        lat: currentLocation[0],
-        lng: currentLocation[1],
-        dataDodania: firebase.firestore.FieldValue.serverTimestamp(),
-        IDpinezki
-      });
       const data = {
         id: IDpinezki,
         IDpinezki,
-        firebaseId,
+        firebaseId: null,
         nazwa: name,
         opis: '',
         warstwa: 'Tryb w ruchu',
@@ -12907,11 +12869,14 @@ function confirmLayerDelete() {
     marker.bindPopup(popupDiv);
     attachPopupHandlers(marker, data);
     data.marker = marker;
+    data.unsaved = true;
     warstwy['Tryb w ruchu'].lista.push(data);
     wszystkiePinezki.push(data);
+    nowePinezki.push(data);
     refreshCategoryCollectionsFromPins();
     updateCategoryFilter();
     generujListeWarstw();
+    updateSaveButton();
   }
 
   function saveCenterPin(form) {


### PR DESCRIPTION
### Motivation
- Zapobiec natychmiastowemu zapisywaniu pinezek do Firestore przy dodawaniu/importowaniu/trybie ruchu; wszystkie zmiany mają być najpierw lokalne i zatwierdzane przez `#saveChanges`.
- Ujednolicić zachowanie desktop vs mobile: desktop bez trybu offline/synchronizacji, mobile używa offline queue/synchronizacji.
- Zmniejszyć ryzyko niepożądanych zapisów i dać użytkownikowi kontrolę nad momentem wysłania zmian.

### Description
- `addImportedPinsToMap` (import KML) przestał wykonywać `db.collection('pinezki2').doc(...).set(...)`; tworzone pinezki są teraz oznaczane `unsaved`, dodawane do `nowePinezki`, zapisywane do `localStorage` i wywołują `updateSaveButton()` oraz `generujListeWarstw()`.
- `saveMovingPin` (Tryb w ruchu) usunięto bezpośredni `set(...)` do kolekcji; pinezka otrzymuje `firebaseId: null`, `unsaved = true` i trafia do `nowePinezki`, a UI jest aktualizowane (lista warstw i przycisk zapisu).
- `addPinOffline` (w `firestore-setup.js`) zmieniono tak, by nigdy nie wywoływał `db.collection('pinezki2').add(...)` przy tworzeniu pinezki; funkcja emituje tylko lokalne zdarzenie `offline-pin-created` i zwraca lokalny identyfikator z flagą `offline` zależną od `navigator.onLine`.
- Dodano detekcję klienta mobilnego (`isMobileClient`) i `applySyncUiVisibility()` aby ukrywać/wyłączać `syncBtn`, panel offline i status synchronizacji na desktopie oraz podpiąć handler `syncBtn` tylko na mobile.
- Utrzymano jedyny zapis do Firestore w ścieżce zatwierdzania zmian (`zapiszZmiany()` / `saveChanges`), który nadal wykonuje `set(...)`/`update(...)` podczas faktycznego zapisu.

### Testing
- Uruchomiono wyszukiwanie referencji zapisu do Firestore za pomocą `rg -n "db\.collection\('pinezki2'\)\.doc\([^\)]*\)\.set\(" index.html firestore-setup.js` i potwierdzono, że pozostał jedynie zapis w ścieżce zatwierdzania (`zapiszZmiany`), test zakończony pomyślnie.
- Sprawdzono zmodyfikowane fragmenty plików (`nl`/`sed`), potwierdzając zastąpienie bezpośrednich wywołań zapisu lokalnym oznaczaniem `unsaved` i dodaniem do `nowePinezki` oraz dodanie `applySyncUiVisibility()`; inspekcja zakończona pomyślnie.
- `git status --short` wykazał brak niezatwierdzonych zmian po wprowadzeniu poprawek, test wykonany pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a158a1e9b2c8330b5ca97cabc06e072)