### PR TITLE
Automatyczne wersjonowanie buildów i cache-busting service workera

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,12 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
-  <link rel="stylesheet" href="style.css?v=ui-fix-2026-05-25-v1" />
+  <script>
+    const BUILD_VERSION = String(Date.parse(document.lastModified) || Date.now());
+    window.BUILD_VERSION = BUILD_VERSION;
+    window.APP_BUILD = BUILD_VERSION;
+  </script>
+  <link rel="stylesheet" href="style.css" data-build-asset />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -2733,15 +2738,15 @@ HTML DEBUG V12
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
-  <script src="offline-uploads.js?v=ui-fix-2026-05-25-v1"></script>
-  <script src="firestore-setup.js?v=ui-fix-2026-05-25-v1"></script>
+  <script src="offline-uploads.js" data-build-asset></script>
+  <script src="firestore-setup.js" data-build-asset></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
   <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
-  <script src="leaflet-tilelayer-wmts.js?v=ui-fix-2026-05-25-v1"></script>
+  <script src="leaflet-tilelayer-wmts.js" data-build-asset></script>
 
   <script>
-    const APP_BUILD = 'ui-fix-2026-05-25-v1';
+    const APP_BUILD = window.BUILD_VERSION;
     window.rawTripDebug = function(msg) {
       // Debug wyłączony. Funkcja musi istnieć, bo używają jej inline handlery #modeTripBtn.
     };
@@ -3078,6 +3083,14 @@ HTML DEBUG V12
       window.rawTripDebug('typeof window.loadTrips: ' + typeof window.loadTrips);
       window.rawTripDebug('typeof window.renderTripPlannerPanel: ' + typeof window.renderTripPlannerPanel);
     });
+    document.querySelectorAll('[data-build-asset]').forEach((el) => {
+      const sourceAttr = el.tagName === 'LINK' ? 'href' : 'src';
+      const currentValue = el.getAttribute(sourceAttr);
+      if (!currentValue || /^https?:\/\//i.test(currentValue)) return;
+      const separator = currentValue.includes('?') ? '&' : '?';
+      el.setAttribute(sourceAttr, `${currentValue}${separator}v=${encodeURIComponent(BUILD_VERSION)}`);
+    });
+
     console.log('APP BUILD:', APP_BUILD, new Date().toISOString());
 
     const buildBadge = document.createElement('div');
@@ -3108,18 +3121,23 @@ HTML DEBUG V12
       });
 
       window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/ExploMapa/service-worker.js')
-          .then(reg => {
+        navigator.serviceWorker.register(`/ExploMapa/service-worker.js?v=${encodeURIComponent(BUILD_VERSION)}`)
+          .then((registration) => {
             console.log('Service worker registered: /ExploMapa/service-worker.js');
-            reg.addEventListener('updatefound', () => {
-              const newWorker = reg.installing;
-              if (!newWorker) return;
-              newWorker.addEventListener('statechange', () => {
-                if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                  const shouldReload = window.confirm('Dostępna nowa wersja aplikacji – odśwież teraz?');
-                  if (shouldReload) {
-                    newWorker.postMessage({ type: 'SKIP_WAITING' });
-                  }
+
+            const promoteWaitingWorker = () => {
+              if (registration.waiting) {
+                registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+              }
+            };
+
+            promoteWaitingWorker();
+            registration.addEventListener('updatefound', () => {
+              const installing = registration.installing;
+              if (!installing) return;
+              installing.addEventListener('statechange', () => {
+                if (installing.state === 'installed' && navigator.serviceWorker.controller) {
+                  promoteWaitingWorker();
                 }
               });
             });

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
-const BUILD_VERSION = '2026-05-25-v2';
-const CACHE_NAME = `explomapa-app-${BUILD_VERSION}`;
+const BUILD_VERSION = new URL(self.location.href).searchParams.get('v') || Date.now().toString();
+const CACHE_NAME = `exploride-${BUILD_VERSION}`;
 const TILE_CACHE = `explomapa-tiles-${BUILD_VERSION}`;
 const RUNTIME_CACHE = `explomapa-runtime-${BUILD_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- Widoczne zmiany nie pojawiały się po deployu, bo `APP_BUILD` było ustawione ręcznie i nie powodowało cache-bustingu assetów.
- Trzeba zautomatyzować wersjonowanie buildów i dokładać `?v=` do lokalnych assetów, żeby przeglądarki i service worker ładowały nową wersję.
- Service worker musi tworzyć unikalny `CACHE_NAME` per build, usuwać stare cache i wymuszać aktywację nowego workera z automatycznym reloadem klienta.

### Description
- Dodano automatyczne `BUILD_VERSION` w `index.html` obliczane jako `String(Date.parse(document.lastModified) || Date.now())` i ustawiono `window.APP_BUILD = window.BUILD_VERSION` (zastępuje ręczne `APP_BUILD`).
- Zaimplementowano mechanizm cache-bustingu dla lokalnych assetów poprzez atrybut `data-build-asset` i skrypt, który dopina `?v=${BUILD_VERSION}` do `href`/`src` (dotyczy `style.css`, `offline-uploads.js`, `firestore-setup.js`, `leaflet-tilelayer-wmts.js` i innych lokalnych js/css oznaczonych `data-build-asset`).
- Rejestracja service workera została zaktualizowana do rejestracji z parametrem wersji (`/ExploMapa/service-worker.js?v=${BUILD_VERSION}`) oraz dodano automatyczne promowanie oczekującego workera przez wysyłanie `SKIP_WAITING` i obsługę `controllerchange` do wymuszonego reloadu klienta.
- `service-worker.js` teraz odczytuje `BUILD_VERSION` z query paramu URL (fallback do `Date.now()`), używa `const CACHE_NAME = `exploride-${BUILD_VERSION}`;` i podczas `activate` usuwa stare cache (`caches.keys() -> delete`), a także zachowuje czyszczenie cache dla płytek i runtime caches.
- `firestore-setup.js` i `offline-uploads.js` zostały przejrzane i synchronizacja pinezek odbywa się przez kolejkę offline (`syncOfflineQueue`) bez pozostawionych bezpośrednich, poza-kolejkowych zapisów wymuszających natychmiastowy commit do Firestore.

### Testing
- Uruchomiono wyszukiwania w kodzie (`rg`) aby potwierdzić usunięcie starego `ui-fix-2026-05-25-v1`, obecność `data-build-asset` na odpowiednich plikach oraz rejestrację SW z `?v=`, i wszystkie kontrole zwróciły oczekiwane wyniki.
- Wypisano fragmenty plików (`nl`/`sed`) aby zweryfikować wstrzyknięcie `BUILD_VERSION`, dopięcie `?v=` do assetów oraz nową logikę rejestracji i aktywacji SW, i sprawdzenie potwierdziło poprawne wstawienia.
- Sprawdzenie logiki synchronizacji offline w `offline-uploads.js` potwierdziło, że operacje `create/update/delete` idą przez kolejkę i że automatyczne testy wyszukiwania nie wykryły starych bezpośrednich zapisów; wszystkie automatyczne kontrole zakończyły się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1599dece28833086db753f15cb6a23)