### PR TITLE
Przywrócenie statycznego ładowania assetów i przypięcie BUILD_VERSION

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,19 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = String(Date.parse(document.lastModified) || Date.now());
+    const BUILD_VERSION = '2026-05-26-savefix-1';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
-    function writeVersionedScript(src) {
-      document.write('<script src="' + src + '?v=' + encodeURIComponent(BUILD_VERSION) + '"><\\/script>');
-    }
-    function writeVersionedCss(href) {
-      document.write('<link rel="stylesheet" href="' + href + '?v=' + encodeURIComponent(BUILD_VERSION) + '">');
-    }
   </script>
-  <script>
-    writeVersionedCss('style.css');
-  </script>
+  <link rel="stylesheet" href="style.css?v=2026-05-26-savefix-1" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -2747,16 +2739,12 @@ HTML DEBUG V12
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
-  <script>
-    writeVersionedScript('offline-uploads.js');
-    writeVersionedScript('firestore-setup.js');
-  </script>
+  <script src="offline-uploads.js?v=2026-05-26-savefix-1"></script>
+  <script src="firestore-setup.js?v=2026-05-26-savefix-1"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
   <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
-  <script>
-    writeVersionedScript('leaflet-tilelayer-wmts.js');
-  </script>
+  <script src="leaflet-tilelayer-wmts.js?v=2026-05-26-savefix-1"></script>
 
   <script>
     const APP_BUILD = window.BUILD_VERSION;


### PR DESCRIPTION
### Motivation
- Dynamiczne wstrzykiwanie assetów przez `document.write()` powodowało problemy z kolejnością inicjalizacji i ładowaniem strony, dlatego trzeba przywrócić przewidywalne, statyczne tagi HTML.
- Wersjonowanie nie powinno być oparte na `Date.now()` lub `document.lastModified`, bo zmiana wartości zbyt często miesza się z cache/service workerem.

### Description
- Usunięto helpery `writeVersionedScript()` i `writeVersionedCss()` oraz powiązane `document.write(...)` użycia z `index.html`.
- Zastąpiono dynamiczne generowanie `BUILD_VERSION` stałą wartością: `const BUILD_VERSION = '2026-05-26-savefix-1';` przy zachowaniu `window.BUILD_VERSION` i `window.APP_BUILD`.
- Przywrócono normalne, statyczne tagi z ręcznie dopisaną wersją w query stringu dla lokalnych zasobów: `style.css?v=2026-05-26-savefix-1`, `offline-uploads.js?v=2026-05-26-savefix-1`, `firestore-setup.js?v=2026-05-26-savefix-1`, `leaflet-tilelayer-wmts.js?v=2026-05-26-savefix-1`.
- Usunięto użycie `Date.now()` / `document.lastModified` do celów wersjonowania w nagłówku, pozostawiając pozostałe `Date.now()` wystąpienia używane wewnętrznie przez aplikację bez zmian.

### Testing
- Potwierdzono wyszukiwaniem (`rg`) brak wystąpień `writeVersionedScript` i `writeVersionedCss` oraz obecność `BUILD_VERSION` z przypisanym stałym stringiem; wynik przeszedł pomyślnie.
- Sprawdzono fragmenty pliku (`sed`/przegląd linii) aby zweryfikować, że `style.css` i lokalne `*.js` są wczytywane przez normalne tagi `<link>`/`<script>` z `?v=2026-05-26-savefix-1` i test ten również przeszedł pomyślnie.
- Wykonano porównanie diff pliku (`git diff`) żeby upewnić się, że usunięto dynamiczne wstrzykiwanie i dodano statyczne tagi; check zakończył się pozytywnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15a1d5e1e08330b006c96e9db4663b)