### PR TITLE
Fix #saveChanges visibility and deterministic update behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -1396,16 +1396,6 @@ body.mobile-layout #toggleBasemaps {
   padding: 5px 10px;
   display: block !important;
 }
-body.mobile-layout #saveChanges {
-  position: fixed;
-  top: calc(env(safe-area-inset-top, 0px) + 10px);
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 2000;
-  width: auto;
-  min-width: 150px;
-}
-
 @media (max-width: 700px) {
   #map { left: 0 !important; right: 0 !important; }
   #sidebar { position: fixed; transform: translateX(-100%); transition: transform 0.3s ease; width: 260px; z-index: 300; }
@@ -1444,16 +1434,6 @@ body.mobile-layout #saveChanges {
   .leaflet-control-zoom { left: 10px; }
   #toggleLayers { position: fixed; top: calc(env(safe-area-inset-top, 0px) + 10px); left: 10px; z-index: 400; background: #2b2b2b; color: #f0f0f0; border: 1px solid #444; padding: 5px 10px; display: block !important; }
   #toggleBasemaps { position: fixed; top: calc(env(safe-area-inset-top, 0px) + 10px); right: 10px; z-index: 400; background: #2b2b2b; color: #f0f0f0; border: 1px solid #444; padding: 5px 10px; display: block !important; }
-  #saveChanges {
-    display: none;
-    position: fixed;
-    top: 12px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 2000;
-    width: auto;
-    min-width: 180px;
-  }
 }
 
 @media (max-width: 1200px) {
@@ -2416,6 +2396,24 @@ html body .trip-special-point-modal label {
 
 #narzedzia .tool-btn:active {
   transform: none !important;
+}
+
+
+#saveChanges {
+  display: none;
+  position: fixed !important;
+  top: 12px !important;
+  left: 50% !important;
+  transform: translateX(-50%) !important;
+  z-index: 2147483600 !important;
+  width: auto !important;
+  min-width: 180px !important;
+  pointer-events: auto !important;
+}
+
+body.mobile-layout #saveChanges {
+  top: calc(env(safe-area-inset-top, 0px) + 10px) !important;
+  min-width: 150px !important;
 }
 </style>
 </head>
@@ -4802,6 +4800,9 @@ function slugify(str) {
         nowePinezkiLength: nowePinezki.length,
         pinsToDeleteLength: pinsToDelete.length
       });
+      if (pending === true) {
+        console.log('SAVE BTN RECT', btn.getBoundingClientRect(), getComputedStyle(btn));
+      }
       shouldWarnBeforeUnload = pending;
     }
 
@@ -12670,6 +12671,7 @@ function getTripPointEmoji(p) {
     const p = wszystkiePinezki.find(pp => String(pp.id) === String(id));
     if (!p) {
       if (!skipCloseModal) closeDeleteModal();
+      updateSaveButton();
       return;
     }
     const layerName = p.warstwa || 'Inne';
@@ -12703,7 +12705,6 @@ function getTripPointEmoji(p) {
     }
     wszystkiePinezki = wszystkiePinezki.filter(pp => pp !== p);
     if (!batch) finalizePinsBulkMutation();
-    else updateSaveButton();
     if (record && !batch) {
       pushAction({
         undo: () => {
@@ -12722,6 +12723,7 @@ function getTripPointEmoji(p) {
         redo: () => { deletePinLocal(id, false); }
       }, 'Usunięto pinezkę');
     }
+    updateSaveButton();
     if (!skipCloseModal) closeDeleteModal();
   }
 


### PR DESCRIPTION
### Motivation
- Ensure the save button is actually visible when `pending === true` by preventing media-query/style ordering from hiding it. 
- Make `updateSaveButton()` the single source of truth for showing/hiding the button while adding diagnostics to troubleshoot visibility issues.

### Description
- Added a final global override for `#saveChanges` appended after the UI SCALE OVERRIDES with desktop-centered positioning and a `body.mobile-layout #saveChanges` mobile tweak, using `!important` and a very high `z-index` to avoid being overridden. 
- Removed conflicting/duplicated `#saveChanges` rules inside `@media (max-width: 700px)` and an earlier mobile block that could hide the button. 
- Left `updateSaveButton()` to control only `btn.style.display = pending ? 'block' : 'none';` and added an emergency diagnostic log: `console.log('SAVE BTN RECT', btn.getBoundingClientRect(), getComputedStyle(btn));` when `pending === true`. 
- Ensured `deletePinLocal()` always calls `updateSaveButton()` on early-return (pin not found) and after the normal delete flow, and verified `saveCenterPin()` still ends with `updateSaveButton()`.

### Testing
- Searched and inspected occurrences with `rg -n "saveChanges|updateSaveButton|saveCenterPin|deletePinLocal|UI SCALE OVERRIDES|max-width: 700px" index.html` and verified updated locations (succeeded). 
- Reviewed the diff with `git diff -- index.html` to confirm style relocation and JS changes (succeeded). 
- Committed the change with `git commit` (succeeded). 
- Verified file edits by inspecting `index.html` regions (sed/nl checks shown in the rollout) and confirmed the new diagnostic log and `updateSaveButton()` call placements (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15a457b98c833090e6af75dcf48791)