### PR TITLE
Show save button only after `saveNew`; move desktop `#saveChanges` to bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2402,7 +2402,7 @@ html body .trip-special-point-modal label {
 #saveChanges {
   display: none;
   position: fixed !important;
-  top: 12px !important;
+  bottom: 12px !important;
   left: 50% !important;
   transform: translateX(-50%) !important;
   z-index: 2147483600 !important;
@@ -2413,6 +2413,7 @@ html body .trip-special-point-modal label {
 
 body.mobile-layout #saveChanges {
   top: calc(env(safe-area-inset-top, 0px) + 10px) !important;
+  bottom: auto !important;
   min-width: 150px !important;
 }
 </style>
@@ -8181,8 +8182,6 @@ function zaladujPinezkiZFirestore() {
 
     async function openNewPinPopup(latlng) {
       await emojiListReady;
-      const saveBtnTmp = document.getElementById('saveChanges');
-      if (saveBtnTmp) saveBtnTmp.style.display = 'block';
       const defaultEmoji = 'emoji38';
       const marker = L.marker(latlng, {icon: createEmojiIcon(defaultEmoji, null, 24)}).addTo(map);
       let addedPin = null;


### PR DESCRIPTION
### Motivation
- The save button `#saveChanges` must appear only when there are real unsaved changes (e.g. after `saveNew`), not immediately when the temporary pin marker is placed by `openNewPinPopup`.
- On desktop the save button should be positioned at the bottom of the screen while mobile layout keeps it at the top.

### Description
- Removed the forced display line in `openNewPinPopup` that set `saveChanges` visible (`const saveBtnTmp = document.getElementById('saveChanges'); if (saveBtnTmp) saveBtnTmp.style.display = 'block';`).
- Updated CSS in `index.html` to change `#saveChanges` positioning from `top: 12px` to `bottom: 12px`, and added `body.mobile-layout #saveChanges { bottom: auto; }` so mobile stays at the top.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1639eaecbc8330879f3efd98bd65f9)