### PR TITLE
Position geosearch-suggestions to the right on desktop; update page title and version

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="pl">
 <head>
   <meta charset="UTF-8" />
-  <title>ExploMapa V3 DEBUG</title>
+  <title>ExploMapa</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="manifest" href="/ExploMapa/manifest.json" />
   <meta name="theme-color" content="#000000" />
@@ -642,16 +642,24 @@ width: 15px;
       flex: 0 0 auto;
     }
     #geosearch-suggestions {
-      position: absolute;
-      top: calc(100% + 60px);
-      left: 4px;
-      right: 4px;
+      position: fixed;
+      top: 56px;
+      left: 472px;
+      width: min(380px, calc(100vw - 488px));
       background: #2b2b2be0;
       border: 1px solid #444;
       max-height: 200px;
       overflow-y: auto;
       display: none;
       z-index: 1001;
+    }
+
+    @media (max-width: 980px) and (min-width: 701px) {
+      #geosearch-suggestions {
+        left: 296px;
+        top: 102px;
+        width: min(560px, calc(100vw - 312px));
+      }
     }
     #geosearch-suggestions div {
       padding: 4px;
@@ -1352,6 +1360,8 @@ body.mobile-layout #geosearch-container {
 }
 body.mobile-layout #geosearch-suggestions {
   left: 52px;
+  right: 10px;
+  width: auto;
   top: calc(100% + 56px);
 }
 body.mobile-layout #gpsFollowBtn {
@@ -1414,6 +1424,8 @@ body.mobile-layout #toggleBasemaps {
   }
   #geosearch-suggestions {
     left: 52px;
+    right: 10px;
+    width: auto;
     top: calc(100% + 56px);
   }
   #gpsFollowBtn {
@@ -2419,9 +2431,9 @@ body.mobile-layout #saveChanges {
 </style>
 </head>
 <body>
-  <div id="mobileTripDebug">MOBILE TRIP DEBUG V12 - HTML STATIC</div>
+  <div id="mobileTripDebug">27-05-26 v.0.543</div>
 <div id="htmlHardDebugV3" style="position:fixed;top:90px;left:10px;z-index:2147483647;background:blue;color:white;padding:20px;font-size:20px;display:block!important;">
-HTML DEBUG V12
+27-05-26 v.0.543
 </div>
   <div id="offlineBar" style="display:none;position:fixed;top:0;left:0;right:0;background:#cc0000;color:#fff;text-align:center;padding:4px;z-index:2000;">Offline</div>
   <div id="banner" style="display:none;position:fixed;top:40px;left:50%;transform:translateX(-50%);background:#333;color:#fff;padding:6px 12px;border-radius:4px;z-index:2000;"></div>


### PR DESCRIPTION
### Motivation
- Align the `#geosearch-suggestions` panel to the right of the toolbar at the same vertical position on desktop while keeping it responsive so it drops below the toolbar when the browser is too narrow. 
- Replace the debug page name with the production-friendly `ExploMapa` title. 
- Surface the requested visible version string `27-05-26 v.0.543` in the UI debug/version markers.

### Description
- Changed the HTML `<title>` from `ExploMapa V3 DEBUG` to `ExploMapa` by updating the `index.html` title element. 
- Replaced visible debug/version strings inside the page with `27-05-26 v.0.543` for `#mobileTripDebug` and the floating debug panel. 
- Reworked `#geosearch-suggestions` CSS from `position: absolute` to `position: fixed` with `top: 56px`, `left: 472px` and `width: min(380px, calc(100vw - 488px))` so suggestions appear to the right of the tools at the same height. 
- Added a media query `@media (max-width: 980px) and (min-width: 701px)` that repositions `#geosearch-suggestions` below the toolbar and adjusts width, and adjusted mobile rules (`body.mobile-layout` / small-screen `@media`) to set `right: 10px` and `width: auto` to preserve mobile behavior.

### Testing
- Ran content and pattern checks with `rg -n` to confirm all expected strings and CSS selectors were updated successfully. 
- Inspected the updated `index.html` sections with `nl`/`sed` to verify the new title, version strings, and CSS rules appear at the expected lines. 
- No automated unit/integration test suite was executed because this is a CSS/HTML UI adjustment; the above automated file inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a169204b0088330896f9cfa06fb14e3)