### PR TITLE
Show connectionStatusPanel only on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,9 @@
     #rightStatusPanelWrap {
       margin-bottom: 8px;
     }
+    #connectionStatusPanel {
+      display: none;
+    }
 
     #uiScaleControls .ui-scale-row {
       display: grid;
@@ -1407,6 +1410,7 @@ body.mobile-layout #toggleBasemaps {
   display: block !important;
 }
 @media (max-width: 700px) {
+  #connectionStatusPanel { display: block; }
   #map { left: 0 !important; right: 0 !important; }
   #sidebar { position: fixed; transform: translateX(-100%); transition: transform 0.3s ease; width: 260px; z-index: 300; }
   #sidebar.show { transform: translateX(0); }


### PR DESCRIPTION
### Motivation
- Keep desktop/tablet UI cleaner by hiding the connection status panel while keeping it visible on mobile where the information is more relevant.

### Description
- Added a default CSS rule `#connectionStatusPanel { display: none; }` to hide the panel by default in `index.html`.
- Added a mobile breakpoint override inside `@media (max-width: 700px)` to set `#connectionStatusPanel { display: block; }` so the panel appears on narrow screens.
- Change is limited to `index.html` and only adjusts presentation (CSS) without modifying behavior or JS.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1696e60988833084fabd5b966f6864)