### PR TITLE
Ustaw domyślnie zwiniętą sekcję „Filtry i akcje”

### DIFF
--- a/index.html
+++ b/index.html
@@ -2481,7 +2481,7 @@ body.mobile-layout #saveChanges {
       <button id="mobileControlsToggle" type="button" aria-expanded="false" aria-controls="sidebarTopControls">
         Filtry i akcje <span class="mobile-controls-indicator">▼</span>
       </button>
-      <div id="sidebarTopControls" class="mobile-open">
+      <div id="sidebarTopControls">
       <div class="search-input-row">
         <input type="text" id="wyszukiwarka" placeholder="Szukaj pinezki...">
         <button id="clearWyszukiwarkaBtn" type="button" aria-label="Wyczyść wyszukiwarkę">✕</button>


### PR DESCRIPTION
### Motivation
- Sekcja „Filtry i akcje” powinna startować zwinięta, a w HTML była domyślnie otwarta przez klasę `mobile-open`.

### Description
- Usunięto klasę `mobile-open` z kontenera `#sidebarTopControls` w `index.html`, co powoduje, że sekcja startuje zwinięta przy zachowaniu istniejącego przycisku `#mobileControlsToggle` do rozwijania.

### Testing
- Wykonano przeszukanie i inspekcję pliku (`rg`, `nl`), modyfikację przez skrypt Pythona, oraz weryfikację zmian i zatwierdzenie (`git diff`, `git commit`), wszystkie polecenia zakończyły się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16ab0575ec8330907e275d2c112e14)