### PR TITLE
Ujednolicenie rozmiaru przycisków modePinsBtn i modeTripBtn

### DIFF
--- a/index.html
+++ b/index.html
@@ -925,7 +925,7 @@ body, #sidebar, #basemap-switcher {
   margin-top: 0;
 }
 .trip-mode-toggle { display:flex; gap:6px; margin:8px 0; }
-.trip-mode-toggle button { flex:1; background:#1d2028; color:#ddd; border:1px solid var(--ui-border); border-radius:var(--ui-radius-sm); padding:6px; }
+.trip-mode-toggle button { flex:1; display:flex; align-items:center; justify-content:center; min-height:36px; box-sizing:border-box; background:#1d2028; color:#ddd; border:1px solid var(--ui-border); border-radius:var(--ui-radius-sm); padding:6px; }
 .trip-mode-toggle button.active { background:var(--ui-accent); color:#fff; border-color:var(--ui-accent); }
 #modeTripBtn,
 #modePinsBtn {


### PR DESCRIPTION
### Motivation
- Przyciski trybu "Pinezki" i "Plan tripu" miały różne wymiary i wyrównanie, co zaburzało spójność interfejsu użytkownika; celem jest ujednolicenie ich wyglądu.

### Description
- Zmieniono regułę `.trip-mode-toggle button` w `index.html` — dodano `display:flex`, `align-items:center`, `justify-content:center`, `min-height:36px` oraz `box-sizing:border-box`, aby oba przyciski miały tę samą wysokość i centrowanie treści (1 plik zmodyfikowany).

### Testing
- Nie uruchomiono automatycznych testów dla tej zmiany.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b57340e88330a035dd6eead275c1)