### PR TITLE
Auto-commit pins in GPS follow (moving) mode to offline queue

### DIFF
--- a/index.html
+++ b/index.html
@@ -11863,31 +11863,7 @@ function getTripPointEmoji(p) {
         const suffix = generateSuffix();
         const firebaseId = `${sanitize(p.nazwa)}_${suffix}`;
         p.firebaseId = firebaseId;
-        const layerInfo = resolveLayerInfo(p.warstwa, p.warstwaId);
-        const payload = {
-          nazwa: p.nazwa,
-          opis: p.opis,
-          warstwa: layerInfo.warstwaId || null,
-          warstwaId: layerInfo.warstwaId || null,
-          kategoria: p.kategoria,
-          kategoriaGlowna: getPinMainCategory(p),
-          kraj: p.kraj || '',
-          emoji: p.emoji,
-          nieaktywne: p.nieaktywne || false,
-          zamkniete: p.zamkniete || false,
-          tajne: p.tajne || false,
-          doSprawdzenia: p.doSprawdzenia || false,
-          zdewastowane: p.zdewastowane || false,
-          zwiedzone: p.zwiedzone || false,
-          wyroznione: p.wyroznione || false,
-          lat: p.lat,
-          lng: p.lng,
-          IDpinezki: p.id,
-          odKogo: p.odKogo || '',
-          trasy: (p.trasy || []).map(t => serializeRoute(t)),
-          plany: []
-        };
-        if (p.trudnosc !== undefined) payload.trudnosc = p.trudnosc;
+        const payload = buildPinCreatePayload(p);
         await window.upsertQueueOperation({
           localId: `create-${firebaseId}-${idx}`,
           operation: 'createPin',
@@ -11991,32 +11967,8 @@ function getTripPointEmoji(p) {
           const suffix = generateSuffix();
           const firebaseId = `${sanitize(p.nazwa)}_${suffix}`;
           p.firebaseId = firebaseId;
-          const layerInfo = resolveLayerInfo(p.warstwa, p.warstwaId);
-          const payload = {
-            nazwa: p.nazwa,
-            opis: p.opis,
-            warstwa: layerInfo.warstwaId || null,
-            warstwaId: layerInfo.warstwaId || null,
-            kategoria: p.kategoria,
-        kategoriaGlowna: getPinMainCategory(p),
-            kraj: p.kraj || '',
-            emoji: p.emoji,
-            nieaktywne: p.nieaktywne || false,
-            zamkniete: p.zamkniete || false,
-            tajne: p.tajne || false,
-            doSprawdzenia: p.doSprawdzenia || false,
-            zdewastowane: p.zdewastowane || false,
-            zwiedzone: p.zwiedzone || false,
-            wyroznione: p.wyroznione || false,
-            lat: p.lat,
-            lng: p.lng,
-            dataDodania: firebase.firestore.FieldValue.serverTimestamp(),
-            IDpinezki: p.id,
-            odKogo: p.odKogo || '',
-            trasy: (p.trasy || []).map(t => serializeRoute(t)),
-            plany: []
-          };
-          if (p.trudnosc !== undefined) payload.trudnosc = p.trudnosc;
+          const payload = buildPinCreatePayload(p);
+          payload.dataDodania = firebase.firestore.FieldValue.serverTimestamp();
           await db.collection('pinezki2').doc(firebaseId).set(payload);
           const localPhotos = getStoredPhotos(p.slug);
           p.photos = await savePhotosForPin(firebaseId, p.slug, localPhotos, [], onProgress, 'pinezki2');
@@ -12872,6 +12824,54 @@ function confirmLayerDelete() {
     updateSaveButton();
   }
 
+  function buildPinCreatePayload(p) {
+    const layerInfo = resolveLayerInfo(p.warstwa, p.warstwaId);
+    const payload = {
+      nazwa: p.nazwa,
+      opis: p.opis,
+      warstwa: layerInfo.warstwaId || null,
+      warstwaId: layerInfo.warstwaId || null,
+      kategoria: p.kategoria,
+      kategoriaGlowna: getPinMainCategory(p),
+      kraj: p.kraj || '',
+      emoji: p.emoji,
+      nieaktywne: p.nieaktywne || false,
+      zamkniete: p.zamkniete || false,
+      tajne: p.tajne || false,
+      doSprawdzenia: p.doSprawdzenia || false,
+      zdewastowane: p.zdewastowane || false,
+      zwiedzone: p.zwiedzone || false,
+      wyroznione: p.wyroznione || false,
+      lat: p.lat,
+      lng: p.lng,
+      IDpinezki: p.id,
+      odKogo: p.odKogo || '',
+      trasy: (p.trasy || []).map(t => serializeRoute(t)),
+      plany: []
+    };
+    if (p.trudnosc !== undefined) payload.trudnosc = p.trudnosc;
+    return payload;
+  }
+
+  async function queueAndSyncPinCreate(p, localIdSuffix = '') {
+    if (!window.upsertQueueOperation) return false;
+    const suffix = generateSuffix();
+    const firebaseId = `${sanitize(p.nazwa)}_${suffix}`;
+    p.firebaseId = firebaseId;
+    await window.upsertQueueOperation({
+      localId: `create-${firebaseId}${localIdSuffix ? `-${localIdSuffix}` : ''}`,
+      operation: 'createPin',
+      firebaseId,
+      payload: buildPinCreatePayload(p),
+      createdAt: Date.now(),
+      syncStatus: 'pending'
+    });
+    if (window.syncOfflineQueue) {
+      await window.syncOfflineQueue();
+    }
+    return true;
+  }
+
   async function saveMovingPin(name) {
     if (!currentLocation) {
       alert('Brak aktualnej lokalizacji');
@@ -12908,13 +12908,22 @@ function confirmLayerDelete() {
     marker.bindPopup(popupDiv);
     attachPopupHandlers(marker, data);
     data.marker = marker;
-    data.unsaved = true;
     warstwy['Tryb w ruchu'].lista.push(data);
     wszystkiePinezki.push(data);
-    nowePinezki.push(data);
     refreshCategoryCollectionsFromPins();
     updateCategoryFilter();
     generujListeWarstw();
+
+    const trackingModeActive = followGps && !!currentLocation;
+    if (trackingModeActive) {
+      await queueAndSyncPinCreate(data, 'moving');
+      delete data.unsaved;
+      updateSaveButton();
+      return;
+    }
+
+    data.unsaved = true;
+    nowePinezki.push(data);
     markDataDirty('pin:add');
   }
 


### PR DESCRIPTION
### Motivation
- Wprowadzić wyjątek dla trybu śledzenia GPS/"w ruchu" tak, aby nowe pinezki dodane podczas aktywnego follow GPS były od razu zapisane do istniejącej kolejki offline i nie wymagały ręcznego `saveChanges`.

### Description
- Dodano helper `buildPinCreatePayload(p)` aby ujednolicić payload tworzenia pinezki używany zarówno przez kolejkę offline, jak i bezpośredni zapis do Firestore. 
- Dodano `queueAndSyncPinCreate(p, localIdSuffix)` który tworzy operację `createPin` używając istniejącego `upsertQueueOperation` i uruchamia `syncOfflineQueue()` (jeśli dostępne). 
- Zmieniono `saveMovingPin` tak, że jeśli wykryty jest aktywny tracking (`followGps && !!currentLocation`) pinezka jest natychmiast dodawana do lokalnego stanu i przekazywana do kolejki za pomocą `queueAndSyncPinCreate`; w tym przypadku nie ustawiany jest dirty state i nie jest wymagane `saveChanges`. 
- Zrefaktoryzowano miejsca tworzące payloady dla nowych Pinezek (`enqueueApprovedOfflineChanges` i zwykły zapis) aby używać `buildPinCreatePayload`, bez tworzenia nowego systemu zapisu.

### Testing
- Uruchomione automatyczne przeszukiwania i inspekcje plików (`rg`/`sed`) aby znaleźć i podmienić bloki kodu oraz sprawdzić spójność zmian, które zakończyły się sukcesem. 
- Sprawdzono diff zmian (`git diff`) oraz wykonano commit (`git commit`) potwierdzający aplikację poprawek, operacje zakończyły się sukcesem. 
- Nie wprowadzono nowych testów jednostkowych; zmiana korzysta z istniejącego mechanizmu `upsertQueueOperation`/`syncOfflineQueue`, więc integracja z dotychczasowym flow została zachowana i przejrzana ręcznie przez powyższe kroki.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16c30cd82883309bd9b877e58db881)