### PR TITLE
Freeze GPS location on "ZAPISZ PIN" in moving/follow mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -12734,6 +12734,7 @@ function confirmLayerDelete() {
 
   const GPS_ARROW_BASE_TRANSFORM = 'translate(-50%, calc(-50% - 8px))';
   let currentLocation = null;
+  let pendingMovingPinLocation = null;
   let currentMarker = null;
   const gpsIcon = L.divIcon({
     className: 'gps-marker',
@@ -12873,7 +12874,8 @@ function confirmLayerDelete() {
   }
 
   async function saveMovingPin(name) {
-    if (!currentLocation) {
+    const capturedLocation = pendingMovingPinLocation;
+    if (!capturedLocation) {
       alert('Brak aktualnej lokalizacji');
       return;
     }
@@ -12896,12 +12898,13 @@ function confirmLayerDelete() {
         kraj: '',
         emoji: 'emoji39',
         trudnosc: 0,
-        lat: currentLocation[0],
-        lng: currentLocation[1],
+        lat: capturedLocation.lat,
+        lng: capturedLocation.lng,
         dataDodania: Date.now(),
         slug: slugify(name)
       };
-    const marker = L.marker(currentLocation, {icon: createEmojiIcon('emoji39', movingLayerId)}).addTo(warstwy['Tryb w ruchu'].layer);
+    const markerLocation = [capturedLocation.lat, capturedLocation.lng];
+    const marker = L.marker(markerLocation, {icon: createEmojiIcon('emoji39', movingLayerId)}).addTo(warstwy['Tryb w ruchu'].layer);
     const popupDiv = document.createElement('div');
     popupDiv.className = 'popup-container';
     popupDiv.innerHTML = createPopupHtml(data);
@@ -12914,9 +12917,9 @@ function confirmLayerDelete() {
     updateCategoryFilter();
     generujListeWarstw();
 
-    const trackingModeActive = followGps && !!currentLocation;
-    if (trackingModeActive) {
+    if (followGps) {
       await queueAndSyncPinCreate(data, 'moving');
+      pendingMovingPinLocation = null;
       delete data.unsaved;
       updateSaveButton();
       return;
@@ -13144,11 +13147,25 @@ function confirmLayerDelete() {
       if (currentTool === 'pin') {
         openCenterModal();
       } else {
+        if (!followGps || !currentLocation) {
+          alert('Brak aktualnej lokalizacji');
+          return;
+        }
+        pendingMovingPinLocation = {
+          lat: currentLocation[0],
+          lng: currentLocation[1],
+          capturedAt: Date.now()
+        };
         openGpsModal();
       }
     });
 
-    cancel.addEventListener('click', () => { modal.style.display = 'none'; });
+    cancel.addEventListener('click', () => {
+      if (currentTool !== 'pin') {
+        pendingMovingPinLocation = null;
+      }
+      modal.style.display = 'none';
+    });
     ok.addEventListener('click', async () => {
       const name = nameInput.value.trim();
       const layer = layerInput.value.trim();


### PR DESCRIPTION
### Motivation
- Użytkownik zapisujący pinezkę w trybie śledzenia GPS mógł zapisać ją w niewłaściwej lokalizacji, ponieważ współrzędne brały się dopiero przy potwierdzeniu nazwy w modalu.
- Cel zmian to natychmiastowe zrobienie snapshotu aktualnej lokalizacji przy kliknięciu `ZAPISZ PIN` i użycie tego snapshotu przy finalnym zapisie pinezki.

### Description
- Dodano zmienną stanu `pendingMovingPinLocation` i ustawianie jej snapshotem `currentLocation` przy kliknięciu przycisku zapisu w trybie ruchu w mobilnym UI (`btn` click handler). (zmiana w `index.html`).
- Zmieniono `saveMovingPin(name)` tak, by odczytywała współrzędne z `pendingMovingPinLocation` zamiast bezpośrednio z `currentLocation` i tworzyła marker na tych zamrożonych współrzędnych.
- Po udanym wysłaniu przez istniejący mechanizm queuing/sync (`queueAndSyncPinCreate(data, 'moving')`) snapshot jest czyszczony; snapshot jest także porzucany przy anulowaniu modala.
- Nie zmieniono flow dla ręcznego/center dodawania pinezek oraz zachowano istniejący mechanizm offline queue/sync bez modyfikacji.

### Testing
- Żadne automatyczne testy nie zostały uruchomione na zmianach.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16cb2eab608330b0046293a7151a8d)