### PR TITLE
Restore plan controls in pin list

### DIFF
--- a/index.html
+++ b/index.html
@@ -11757,6 +11757,46 @@ function getTripPointEmoji(p) {
           pinEditBtn.innerHTML = '✎';
           pinEditBtn.addEventListener('click', (ev) => { ev.preventDefault(); ev.stopPropagation(); edytuj(p.id, p.lat, p.lng); });
           nameRow.appendChild(nameSpan); nameRow.appendChild(pinEditBtn); el.appendChild(nameRow);
+          const plansForPin = Array.isArray(p.plany) ? p.plany : [];
+          plansForPin.forEach(plan => {
+            ensurePlanDefaults(plan, p);
+            const planEl = document.createElement('div');
+            planEl.className = 'plan-item';
+            planEl.dataset.pinId = String(p.id);
+            planEl.dataset.planId = String(plan.id);
+
+            const visibility = document.createElement('input');
+            visibility.type = 'checkbox';
+            visibility.className = 'plan-visibility';
+            visibility.checked = plan.widoczny !== false;
+            visibility.title = 'Pokaż / ukryj plan na mapie';
+            visibility.addEventListener('click', ev => ev.stopPropagation());
+            visibility.addEventListener('change', ev => {
+              ev.stopPropagation();
+              plan.widoczny = visibility.checked;
+              plan.unsaved = true;
+              updatePlanOverlay(p, plan);
+              markPlanChange(p);
+            });
+
+            const planName = document.createElement('span');
+            planName.className = 'plan-name';
+            planName.textContent = `🗺️ ${plan.nazwa || 'Plan'}`;
+            planName.title = 'Edytuj plan';
+
+            const editPlan = ev => {
+              ev.preventDefault();
+              ev.stopPropagation();
+              ensurePlanOverlay(p, plan);
+              openPlanOptions(p, plan, planEl);
+            };
+            planEl.addEventListener('click', editPlan);
+            planName.addEventListener('click', editPlan);
+
+            planEl.appendChild(visibility);
+            planEl.appendChild(planName);
+            el.appendChild(planEl);
+          });
           el.addEventListener('click', e => { const sel = handlePinSelectionClick(e, p, el); if (!sel) openPinFromList(p, el); });
           p.el = el;
           listaP.appendChild(el);


### PR DESCRIPTION
### Motivation
- Reintroduce the missing UI for saved map "plans" under their parent pin so plans can be seen and edited from the sidebar. 
- Allow quick toggling of per-plan visibility on the list and ensure changes are propagated to overlays and saved to the existing persistence flow.

### Description
- Render saved plans for each pin inside the sidebar list by iterating `p.plany` when building the pin list and creating `.plan-item` entries.  
- Add a per-plan visibility checkbox that updates `plan.widoczny`, calls `updatePlanOverlay(...)`, sets `plan.unsaved` and records the change via existing `markPlanChange(...)`/`zmianyDoZapisania` logic.  
- Wire clicking the plan row/name to open the existing plan options editor via `ensurePlanOverlay(...)` + `openPlanOptions(...)` so opacity/scale/image/position/rotation/delete actions reuse current UI.  
- Call `ensurePlanDefaults(...)` where needed for stability and keep overlays in sync by using existing `updatePlanOverlay(...)`/`ensurePlanOverlay(...)` helpers.

### Testing
- Extracted inline scripts and syntax-checked them with `node --check` (succeeded).  
- Ran `git diff --check` to ensure no whitespace/syntax diff problems (no issues found).  
- Automated checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c0b83813c8330b2c6e3c74d14a910)