### PR TITLE
Add zoom percentage indicator and extend map max zoom to 22

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-05-27 v.0.545';
+    const BUILD_VERSION = '2026-05-31 v.0.546';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-05-26-savefix-1" />
+  <link rel="stylesheet" href="style.css?v=2026-05-31-zoom-1" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -6450,6 +6450,8 @@ function emojiHtml(str) {
       const WMS_HI_TIME_URL = WMS_ARCH_HI_URL;
       const COPERNICUS_WMS_URL = 'https://sh.dataspace.copernicus.eu/ogc/wms/f387b61a-858d-459a-b9b0-77dab4fdbe79';
       const MAPBOX_ACCESS_TOKEN = "pk.eyJ1IjoiY3pyYnJ6IiwiYSI6ImNtbnlnZWs0NTAwZWcyb3NlYzNrdW53YmoifQ.rN_RTUqLtI5Fnk5tocolMA";
+      const MAX_MAP_ZOOM = 22;
+      const NATIVE_TILE_ZOOM = 19;
       const COPERNICUS_MONTH_WINDOW = 24;
       const COPERNICUS_MONTH_NAMES_PL = [
         'Styczeń', 'Luty', 'Marzec', 'Kwiecień', 'Maj', 'Czerwiec',
@@ -6463,6 +6465,8 @@ function emojiHtml(str) {
           tilematrixSet: 'EPSG:3857',
           format: 'image/jpeg',
           style: 'default',
+          maxNativeZoom: NATIVE_TILE_ZOOM,
+          maxZoom: MAX_MAP_ZOOM,
           attribution: ORTO_ATTR
         });
       }
@@ -6475,6 +6479,8 @@ function emojiHtml(str) {
           version: '1.3.0',
           uppercase: true,
           crs: L.CRS.EPSG3857,
+          maxNativeZoom: NATIVE_TILE_ZOOM,
+          maxZoom: MAX_MAP_ZOOM,
           attribution: ORTO_ATTR,
           ...options
         });
@@ -6613,6 +6619,32 @@ function emojiHtml(str) {
         start();
       }
 
+      function setupZoomPercentageControl() {
+        const zoomControlEl = document.querySelector('.leaflet-control-zoom');
+        if (!map || !zoomControlEl) return;
+
+        let zoomPercentEl = zoomControlEl.querySelector('.zoom-percent-indicator');
+        if (!zoomPercentEl) {
+          zoomPercentEl = document.createElement('div');
+          zoomPercentEl.className = 'zoom-percent-indicator';
+          zoomPercentEl.setAttribute('aria-live', 'polite');
+          zoomControlEl.appendChild(zoomPercentEl);
+        }
+
+        const minZoom = Number.isFinite(map.getMinZoom()) ? map.getMinZoom() : 0;
+        const maxZoom = Number.isFinite(map.getMaxZoom()) ? map.getMaxZoom() : MAX_MAP_ZOOM;
+        const zoomRange = Math.max(1, maxZoom - minZoom);
+        const updateZoomPercent = () => {
+          const zoom = map.getZoom();
+          const percent = Math.round(((zoom - minZoom) / zoomRange) * 100);
+          zoomPercentEl.textContent = `${Math.max(0, Math.min(100, percent))}%`;
+          zoomPercentEl.title = `Przybliżenie: ${zoomPercentEl.textContent} (zoom ${zoom}/${maxZoom})`;
+        };
+
+        updateZoomPercent();
+        map.on('zoomend zoomlevelschange', updateZoomPercent);
+      }
+
       function panMapAfterPopupOpen(popup, token) {
         if (!map || !popup) return;
         if (popup._autoPanHandledToken === token) return;
@@ -6684,8 +6716,9 @@ function emojiHtml(str) {
         popupAutoPanState.duringAutoPan = false;
       }
 
-      map = L.map('map', { crs: L.CRS.EPSG3857 }).setView([52.1, 20.9], 7);
+      map = L.map('map', { crs: L.CRS.EPSG3857, maxZoom: MAX_MAP_ZOOM }).setView([52.1, 20.9], 7);
       window.map = map;
+      setupZoomPercentageControl();
       map.whenReady(() => {
         mapWhenReadyExecuted = true;
         console.log('[map:whenReady] Map ready', getMapDiagnosticsSnapshot());
@@ -6736,13 +6769,16 @@ function emojiHtml(str) {
       // Popup pan is handled after render in popupopen (see panMapAfterPopupOpen).
 
       const sat = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-        attribution: 'Esri'
+        attribution: 'Esri',
+        maxNativeZoom: NATIVE_TILE_ZOOM,
+        maxZoom: MAX_MAP_ZOOM
       });
        const mapboxSatelliteLayer = L.tileLayer(
         `https://api.mapbox.com/styles/v1/mapbox/satellite-v9/tiles/256/{z}/{x}/{y}?access_token=${MAPBOX_ACCESS_TOKEN}`,
         {
           attribution: "© Mapbox © OpenStreetMap",
-          maxZoom: 19,
+          maxNativeZoom: NATIVE_TILE_ZOOM,
+          maxZoom: MAX_MAP_ZOOM,
           tileSize: 256
         }
       );
@@ -6755,23 +6791,29 @@ function emojiHtml(str) {
         uppercase: true,
         crs: L.CRS.EPSG3857,
         attribution: '© Copernicus Sentinel data',
-        maxZoom: 19
+        maxNativeZoom: NATIVE_TILE_ZOOM,
+        maxZoom: MAX_MAP_ZOOM
       });
       const hill = wmsShadedReliefLayer();
       const osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; OpenStreetMap contributors'
+        attribution: '&copy; OpenStreetMap contributors',
+        maxNativeZoom: NATIVE_TILE_ZOOM,
+        maxZoom: MAX_MAP_ZOOM
       });
-      const labels = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}');
-      const roadsFull = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}');
-      const roadsSimple = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}', { maxNativeZoom: 12, maxZoom: 18 });
+      const labels = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}', { maxNativeZoom: NATIVE_TILE_ZOOM, maxZoom: MAX_MAP_ZOOM });
+      const roadsFull = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}', { maxNativeZoom: NATIVE_TILE_ZOOM, maxZoom: MAX_MAP_ZOOM });
+      const roadsSimple = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}', { maxNativeZoom: 12, maxZoom: MAX_MAP_ZOOM });
 
       const baseOpenTopoPlusTrails = {
         base: L.tileLayer('https://tile.opentopomap.org/{z}/{x}/{y}.png', {
-          maxZoom: 17,
+          maxNativeZoom: 17,
+          maxZoom: MAX_MAP_ZOOM,
           attribution: '© OpenTopoMap (CC BY-SA), © OpenStreetMap'
         }),
         overlay: L.tileLayer('https://tile.waymarkedtrails.org/hiking/{z}/{x}/{y}.png', {
           opacity: 0.6,
+          maxNativeZoom: NATIVE_TILE_ZOOM,
+          maxZoom: MAX_MAP_ZOOM,
           attribution: '© waymarkedtrails.org, © OpenStreetMap (CC BY-SA)'
         })
       };

--- a/style.css
+++ b/style.css
@@ -5,6 +5,23 @@
   z-index: 1000;
 }
 
+.leaflet-control-zoom .zoom-percent-indicator {
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  min-width: 46px;
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: rgba(27, 31, 39, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: #f8fafc;
+  font: 700 12px/1.1 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  text-align: center;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.28);
+  pointer-events: none;
+}
+
 .leaflet-pane.leaflet-popup-pane,
 .leaflet-popup {
   z-index: 2147483600 !important;


### PR DESCRIPTION
### Motivation
- Users need to be able to zoom the map further than the previous limit and see the current zoom expressed as a percentage next to the Leaflet +/- controls.

### Description
- Add `MAX_MAP_ZOOM` and `NATIVE_TILE_ZOOM` constants and set the map `maxZoom` to `MAX_MAP_ZOOM` so the map can zoom up to level 22.
- Configure tile/WMS/WMTS and main tile layers with `maxNativeZoom` and `maxZoom` so tiles are upscaled beyond native resolutions instead of blocking zoom.
- Add `setupZoomPercentageControl()` which injects a `.zoom-percent-indicator` element next to the `.leaflet-control-zoom` and updates it on `zoomend`/`zoomlevelschange` with a localized tooltip.
- Add CSS for the percentage badge and bump the build/versioned stylesheet reference so clients fetch the updated styles.

### Testing
- Ran `git diff --check` to validate spacing and simple issues and it succeeded.
- Extracted inline scripts from `index.html` and ran `node --check` on each script block to verify JavaScript syntax and it succeeded.
- Attempted to run Playwright-based visual tests, but installing Playwright failed due to `npm` registry access returning `403 Forbidden` in this environment so automated screenshot tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c14073b0c83309044b77a252415f2)