### PR TITLE
Cieniowanie: domyślna przezroczystość 50% i suwak widoczny, nakładki przynoszone na wierzch

### DIFF
--- a/index.html
+++ b/index.html
@@ -2652,11 +2652,11 @@ body.mobile-layout #saveChanges {
           <input type="range" min="0" max="100" value="100" class="opacity-slider ukryta" id="opacity-archHi">
         </div>
         <div class="overlay-item">
-          <label><input type="checkbox" id="overlay-shade"> Cieniowanie (Geoportal WMTS)
+          <label><input type="checkbox" id="overlay-shade"> Cieniowanie (Geoportal)
             <button type="button" class="opacity-btn" data-target="shade">⚙</button>
             <button type="button" class="info-btn" data-info="Cieniowanie terenu z Geoportalu">i</button>
           </label><br>
-          <input type="range" min="0" max="100" value="100" class="opacity-slider ukryta" id="opacity-shade">
+          <input type="range" min="0" max="100" value="50" class="opacity-slider" id="opacity-shade">
         </div>
         <div class="overlay-item">
           <label><input type="checkbox" id="overlay-pin-plans" checked> Plany pinezek
@@ -6473,6 +6473,7 @@ function emojiHtml(str) {
       const MAX_MAP_ZOOM = 22;
       const NATIVE_TILE_ZOOM = 19;
       const COPERNICUS_MONTH_WINDOW = 24;
+      const DEFAULT_SHADE_OVERLAY_OPACITY = 0.5;
       const COPERNICUS_MONTH_NAMES_PL = [
         'Styczeń', 'Luty', 'Marzec', 'Kwiecień', 'Maj', 'Czerwiec',
         'Lipiec', 'Sierpień', 'Wrzesień', 'Październik', 'Listopad', 'Grudzień'
@@ -6506,10 +6507,11 @@ function emojiHtml(str) {
         });
       }
 
-      function wmsShadedReliefLayer() {
+      function wmsShadedReliefLayer(options = {}) {
         return wmsLayer(WMS_SHADED_RELIEF_URL, 'Raster', {
           format: 'image/png',
-          attribution: SHADED_RELIEF_ATTR
+          attribution: SHADED_RELIEF_ATTR,
+          ...options
         });
       }
 
@@ -6859,11 +6861,20 @@ function emojiHtml(str) {
       const overlays = {
         archStd: wmsLayer(WMS_ARCH_STD_URL),
         archHi: wmsLayer(WMS_ARCH_HI_URL),
-        shade: wmsShadedReliefLayer()
+        shade: wmsShadedReliefLayer({ opacity: DEFAULT_SHADE_OVERLAY_OPACITY })
       };
       overlays.archStd.on('tileerror', () => showToast('Sprawdź parametry warstwy (layers/CRS/format).'));
       overlays.archHi.on('tileerror', () => showToast('Sprawdź parametry warstwy (layers/CRS/format).'));
       overlays.shade.on('tileerror', () => showToast('Nie udało się załadować cieniowania (Geoportal WMS).'));
+
+      function bringActiveMapOverlaysToFront() {
+        ['archStd', 'archHi', 'shade'].forEach(key => {
+          const layer = overlays[key];
+          if (layer && map.hasLayer(layer) && typeof layer.bringToFront === 'function') {
+            layer.bringToFront();
+          }
+        });
+      }
 
       const mapDateBadgeEl = document.getElementById('map-date-badge');
       const mapYearSelect = document.getElementById('map-year-select');
@@ -7319,6 +7330,7 @@ function emojiHtml(str) {
           labels.addTo(map);
           if (roadsLayer) roadsLayer.addTo(map);
         }
+        bringActiveMapOverlaysToFront();
         currentBase = key;
         updateMapDateUI(key);
       }
@@ -7363,19 +7375,26 @@ function emojiHtml(str) {
         const checkbox = document.getElementById(overlayCheckboxIds[key]);
         if (checkbox) {
           checkbox.addEventListener('change', e => {
-            if (e.target.checked) overlays[key].addTo(map);
-            else map.removeLayer(overlays[key]);
+            if (e.target.checked) {
+              overlays[key].addTo(map);
+              bringActiveMapOverlaysToFront();
+            } else {
+              map.removeLayer(overlays[key]);
+            }
           });
         }
 
         const btn = document.querySelector(`.opacity-btn[data-target="${key}"]`);
         const slider = document.getElementById(`opacity-${key}`);
+        if (slider) {
+          overlays[key].setOpacity(slider.value / 100);
+          slider.addEventListener('input', ev => {
+            overlays[key].setOpacity(ev.target.value / 100);
+          });
+        }
         if (btn && slider) {
           btn.addEventListener('click', () => {
             slider.classList.toggle('ukryta');
-          });
-          slider.addEventListener('input', ev => {
-            overlays[key].setOpacity(ev.target.value / 100);
           });
         }
       });


### PR DESCRIPTION
### Motivation
- Ujednolicić zachowanie nakładki "Cieniowanie" z innymi bazami i zapewnić wygodny domyślny poziom przezroczystości przy jednoczesnym udostępnieniu suwaka do regulacji.
- Zapewnić, że włączone nakładki pozostają widoczne nad aktualną bazą mapy po przełączeniu lub aktywacji, aby cieniowanie było zawsze czytelne.

### Description
- Zmieniono etykietę nakładki na `Cieniowanie (Geoportal)` i ustawiono widoczny suwak `#opacity-shade` z domyślną wartością `50` (50%).
- Dodano stałą `DEFAULT_SHADE_OVERLAY_OPACITY = 0.5` i rozszerzono fabrykę `wmsShadedReliefLayer(options = {})`, aby przyjmowała opcje (np. `opacity`).
- Nakładka `shade` jest teraz tworzona przez `wmsShadedReliefLayer({ opacity: DEFAULT_SHADE_OVERLAY_OPACITY })` zamiast domyślnego 100%.
- Dodano funkcję `bringActiveMapOverlaysToFront()` oraz wywołania tej funkcji po przełączeniu bazy i po włączeniu nakładek, oraz inicjalne ustawienie opacity sliderów przy ładowaniu.

### Testing
- Uruchomiono statyczny check Pythonowy skryptem `python3` sprawdzającym obecność zmian w `index.html`, który zakończył się pomyślnie.
- Sprawdzono składnię/parsowanie zależnego pliku za pomocą `node --check leaflet-tilelayer-wmts.js`, co zakończyło się pomyślnie.
- Wykonano `git diff --check` i zatwierdzono zmianę bez konfliktów.
- Próba zrobienia zrzutu ekranu/testu przeglądarkowego przy użyciu `npx playwright` nie powiodła się z powodu ograniczeń dostępu do rejestru npm (403), co nie blokuje wprowadzonych zmian.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c442c80a0833086135c7b3390de44)