### PR TITLE
Keep active pin plan selection local

### DIFF
--- a/index.html
+++ b/index.html
@@ -3901,6 +3901,7 @@ function slugify(str) {
     let layersToDelete = [];
     let pinsToDelete = [];
       const planLayers = {};
+      const activePlanSessionOverrides = new Map();
       let pinPlansOverlayVisible = true;
       let activePlanPlacement = null;
       let planOptionsState = null;
@@ -5595,35 +5596,58 @@ function emojiHtml(str) {
     }
 
 
-    function getActivePlanIdForPin(pin) {
+    function getPinSessionKey(pin) {
+      if (!pin) return null;
+      return String(pin.id || pin.firebaseId || pin.IDpinezki || pin.slug || '');
+    }
+
+    function getStoredActivePlanIdForPin(pin) {
       const plans = Array.isArray(pin && pin.plany) ? pin.plany : [];
       const active = plans.find(plan => plan && plan.aktywny === true);
-      return active ? active.id : (plans[0] ? plans[0].id : null);
+      return active ? String(active.id) : (plans[0] && plans[0].id ? String(plans[0].id) : null);
+    }
+
+    function getActivePlanIdForPin(pin) {
+      const plans = Array.isArray(pin && pin.plany) ? pin.plany : [];
+      if (!plans.length) return null;
+      const sessionKey = getPinSessionKey(pin);
+      const sessionActiveId = sessionKey ? activePlanSessionOverrides.get(sessionKey) : null;
+      if (sessionActiveId && plans.some(plan => plan && String(plan.id) === sessionActiveId)) {
+        return sessionActiveId;
+      }
+      return getStoredActivePlanIdForPin(pin);
     }
 
     function normalizeActivePlanForPin(pin) {
       const plans = Array.isArray(pin && pin.plany) ? pin.plany : [];
       if (!plans.length) return;
-      let activeId = getActivePlanIdForPin(pin);
-      if (!activeId && plans[0]) activeId = plans[0].id;
-      plans.forEach(plan => { if (plan) plan.aktywny = plan.id === activeId; });
+      const activeId = getStoredActivePlanIdForPin(pin) || (plans[0] ? plans[0].id : null);
+      plans.forEach(plan => { if (plan) plan.aktywny = String(plan.id) === activeId; });
     }
 
     function isActivePlanForPin(pin, plan) {
-      if (!plan) return false;
-      normalizeActivePlanForPin(pin);
-      return plan.aktywny === true;
+      if (!pin || !plan) return false;
+      return String(plan.id) === getActivePlanIdForPin(pin);
+    }
+
+    function updatePlanActiveRadioStateForPin(pin) {
+      if (!pin) return;
+      const renderedPinId = String(pin.id);
+      const activePlanId = getActivePlanIdForPin(pin);
+      document.querySelectorAll('#lista-warstw .plan-item').forEach(item => {
+        if (item.dataset.pinId !== renderedPinId) return;
+        const input = item.querySelector('input.plan-visibility');
+        if (input) input.checked = String(item.dataset.planId) === activePlanId;
+      });
     }
 
     function selectActivePlanForPin(pin, selectedPlan) {
       if (!pin || !selectedPlan) return;
-      if (!pin.plany) pin.plany = [];
-      pin.plany.forEach(plan => { if (plan) plan.aktywny = plan === selectedPlan || plan.id === selectedPlan.id; });
-      selectedPlan.widoczny = true;
-      selectedPlan.unsaved = true;
+      const sessionKey = getPinSessionKey(pin);
+      if (!sessionKey || !selectedPlan.id) return;
+      activePlanSessionOverrides.set(sessionKey, String(selectedPlan.id));
       updatePlanVisibilityForPin(pin);
-      markPlanChange(pin);
-      generujListeWarstw();
+      updatePlanActiveRadioStateForPin(pin);
     }
 
     function cleanupPlanTransformOverlay(overlay) {


### PR DESCRIPTION
### Motivation
- Prevent toggling the active plan for a pin from mutating plan data that would be saved to Firestore, and make it a session-local UI choice. 
- Avoid triggering `generujListeWarstw()` or `markPlanChange()` when the active plan is changed so the layer collapse/expand state is preserved.

### Description
- Added an in-memory `activePlanSessionOverrides` map and helper `getPinSessionKey()` to store per-session active plan selections without persisting them to storage. 
- Split stored vs session active plan logic with `getStoredActivePlanIdForPin()` and updated `getActivePlanIdForPin()` to prefer the session override when present. 
- Reworked `selectActivePlanForPin()` to set the session override and call `updatePlanVisibilityForPin()` and `updatePlanActiveRadioStateForPin()` instead of mutating plan objects or marking data as changed. 
- Updated `isActivePlanForPin()`/`normalizeActivePlanForPin()` to use the stored/session lookup and added string coercions so id comparisons are robust; all changes are in `index.html`.

### Testing
- Extracted inline scripts and ran `node --check /tmp/index-inline.js` to validate syntax, which completed successfully. 
- Ran `git diff --check` to ensure no whitespace/merge issues, which returned no errors. 
- Verified the app code compiles syntactically after the change and no automated checks failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c91cb59e88330aae8930cf1681e74)