### PR TITLE
Remove click cursor from plan overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -5518,6 +5518,13 @@ function emojiHtml(str) {
       syncPlanTransformOverlay(overlay);
     }
 
+    function setPlanOverlayMapPassthrough(overlay) {
+      if (!overlay || !overlay._image) return;
+      overlay._image.style.pointerEvents = 'none';
+      overlay._image.style.cursor = '';
+      overlay._image.classList.remove('leaflet-interactive');
+    }
+
     function shouldPlanBeVisible(pin, plan) {
       if (activePlanPlacement && activePlanPlacement.plan === plan) return true;
       if (!pinPlansOverlayVisible) return false;
@@ -5531,7 +5538,7 @@ function emojiHtml(str) {
       let overlay = planLayers[plan.id];
       const bounds = getPlanBounds(plan);
       if (!overlay) {
-        overlay = L.imageOverlay(plan.url, bounds, { opacity: plan.przezroczystosc || 1, interactive: true });
+        overlay = L.imageOverlay(plan.url, bounds, { opacity: plan.przezroczystosc || 1, interactive: false });
         planLayers[plan.id] = overlay;
         plan.layer = overlay;
         if (!overlay._originalReset) {
@@ -5547,6 +5554,7 @@ function emojiHtml(str) {
       }
       overlay._planRef = plan;
       applyPlanRotation(overlay, plan);
+      if (!activePlanPlacement || activePlanPlacement.plan !== plan) setPlanOverlayMapPassthrough(overlay);
       if (shouldPlanBeVisible(pin, plan)) {
         overlay.addTo(map);
       } else {
@@ -5567,6 +5575,7 @@ function emojiHtml(str) {
       overlay.setOpacity(plan.przezroczystosc || 1);
       overlay._planRef = plan;
       applyPlanRotation(overlay, plan);
+      if (!activePlanPlacement || activePlanPlacement.plan !== plan) setPlanOverlayMapPassthrough(overlay);
       if (shouldPlanBeVisible(pin, plan)) {
         overlay.addTo(map);
       } else {
@@ -5686,6 +5695,7 @@ function emojiHtml(str) {
         overlay._planControls.parentElement.removeChild(overlay._planControls);
       }
       overlay._planControls = null;
+      setPlanOverlayMapPassthrough(overlay);
     }
 
     function destroyPlanTransformControls() {
@@ -5830,6 +5840,7 @@ function emojiHtml(str) {
         overlay._image.addEventListener('mousedown', ev => startPlanMove(ev, overlay));
         overlay._planMoveBound = true;
       }
+      overlay._image.style.pointerEvents = 'auto';
       overlay._image.style.cursor = 'grab';
       syncPlanTransformOverlay(overlay);
     }


### PR DESCRIPTION
### Motivation
- Użytkownicy zgłaszali, że po najechaniu kursorem na wklejony rzut na mapie kursor wygląda jakby element był klikalny, podczas gdy sama mapa powinna przechwytywać zdarzenia myszy; celem jest przywrócenie zachowania kursora tak, jak na czystej mapie. 
- Trzeba jednocześnie zachować możliwość edycji rzutu w trybie transformacji (przeciąganie, skalowanie, obrót), więc zmiana musi być tymczasowa podczas aktywnej edycji.

### Description
- Dodano funkcję `setPlanOverlayMapPassthrough` w `index.html`, która ustawia `pointer-events: none`, czyści kursor i usuwa klasę `leaflet-interactive` z elementu obrazu nakładki. 
- Przy tworzeniu nakładek zmieniono `L.imageOverlay(..., { interactive: true })` na `interactive: false`, aby domyślnie przepuszczać zdarzenia myszy do mapy. 
- Po `applyPlanRotation`/`updatePlanOverlay` nakładka jest ustawiana w tryb „passthrough” kiedy nie trwa aktywne `activePlanPlacement`, a podczas tworzenia/oczyszczania kontrolek transformacji przywracany jest tryb pasywnego przejścia. 
- W `ensurePlanTransformControls` włączane są `pointerEvents = 'auto'` i kursor `grab` tylko podczas aktywnej edycji, a w `cleanupPlanTransformOverlay` przywracane jest zachowanie przepuszczania zdarzeń.

### Testing
- ✅ `git diff --check` run against the modified `index.html` passed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1caea822588330a61d068261b6421f)