### PR TITLE
Fix plan overlay rotation during zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -5516,7 +5516,7 @@ function emojiHtml(str) {
       if (!overlay || !overlay._image) return;
       const img = overlay._image;
       const base = img.style.transform || '';
-      const cleaned = base.replace(/ rotate\([^)]*\)/, '');
+      const cleaned = base.replace(/\s*rotate\([^)]*\)/g, '');
       img.style.transform = `${cleaned} rotate(${(plan && plan.obrot) || 0}deg)`;
       img.style.transformOrigin = 'center center';
       syncPlanTransformOverlay(overlay);
@@ -5549,6 +5549,13 @@ function emojiHtml(str) {
           overlay._originalReset = overlay._reset.bind(overlay);
           overlay._reset = function() {
             overlay._originalReset();
+            applyPlanRotation(overlay, overlay._planRef || plan);
+          };
+        }
+        if (!overlay._originalAnimateZoom && overlay._animateZoom) {
+          overlay._originalAnimateZoom = overlay._animateZoom.bind(overlay);
+          overlay._animateZoom = function(e) {
+            overlay._originalAnimateZoom(e);
             applyPlanRotation(overlay, overlay._planRef || plan);
           };
         }


### PR DESCRIPTION
### Motivation
- Rzuty (image overlays) chwilowo tracą ustawiony kąt podczas animowanego zoomu mapy, co powoduje, że obraz na czas zoomowania wygląda „prościej/obraca się” (niezgodnie z zapisaną wartością `obrot`).

### Description
- W `applyPlanRotation` oczyszczono transformację tak, by usuwać wszystkie wystąpienia `rotate(...)` używając wyrażenia regularnego `/\s*rotate\([^)]*\)/g`, aby nie kumulować starych fragmentów `rotate()` w `style.transform`.
- Dla nowych nakładek nadpisano (jeśli dostępne) `overlay._animateZoom`, wiążąc oryginalną funkcję i wywołując `applyPlanRotation` po każdym wewnętrznym animowanym kroku zoomu, dzięki czemu zapisany obrót jest przywracany w trakcie zoomu.
- Zmiany zostały wprowadzone w `index.html` obok istniejącej logiki tworzenia `L.imageOverlay` i synchronizacji kontrolek transformacji.

### Testing
- Uruchomiono `node --check /tmp/index-classic.js` i sprawdzenie zakończyło się pomyślnie. 
- Uruchomiono `node --check /tmp/index-module.js` i sprawdzenie zakończyło się pomyślnie. 
- Uruchomiono `git diff --check` i nie wykryto problemów.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cc7a7bf9c8330aa8b79e39635dc66)