### PR TITLE
Add label and styling for UI scale controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,10 @@
       display: none;
     }
 
+    #uiScaleControls .ui-scale-title {
+      font-weight: 700;
+      text-align: left;
+    }
     #uiScaleControls .ui-scale-row {
       display: grid;
       grid-template-columns: auto minmax(0, 1fr) auto;
@@ -2785,6 +2789,7 @@ body.mobile-layout #saveChanges {
     </div>
     <button id="syncBtn">Synchronizuj (<span id="syncCountBtn">0</span>)</button>
     <div id="uiScaleControls" aria-label="Skalowanie interfejsu">
+      <div class="ui-scale-title">Skala UI</div>
       <div class="ui-scale-row">
         <div class="ui-scale-buttons">
           <button id="uiScaleMinus" type="button" aria-label="Zmniejsz skalę UI">−</button>


### PR DESCRIPTION
### Motivation

- Add a visible, left-aligned title for the UI scaling controls to improve discoverability and clarify purpose.

### Description

- Inserted a `div` with class `ui-scale-title` containing the text `Skala UI` into `#uiScaleControls` and added CSS rule `#uiScaleControls .ui-scale-title` to set `font-weight: 700` and `text-align: left`.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d209e176883308eff1a73d49d12ec)