### PR TITLE
Ukryj suwak przezroczystości cieniowania Geoportalu, gdy nakładka jest wyłączona

### DIFF
--- a/index.html
+++ b/index.html
@@ -2704,7 +2704,7 @@ body.mobile-layout #saveChanges {
             <button type="button" class="opacity-btn" data-target="shade">⚙</button>
             <button type="button" class="info-btn" data-info="Cieniowanie terenu z Geoportalu">i</button>
           </label><br>
-          <input type="range" min="0" max="100" value="50" class="opacity-slider" id="opacity-shade">
+          <input type="range" min="0" max="100" value="50" class="opacity-slider ukryta" id="opacity-shade">
         </div>
         <div class="overlay-item">
           <label><input type="checkbox" id="overlay-pin-plans" checked> Rzuty pinezek
@@ -8305,11 +8305,14 @@ function emojiHtml(str) {
         const checkbox = document.getElementById(overlayCheckboxIds[key]);
         if (checkbox) {
           checkbox.addEventListener('change', e => {
+            const slider = document.getElementById(`opacity-${key}`);
             if (e.target.checked) {
               overlays[key].addTo(map);
+              if (key === 'shade' && slider) slider.classList.remove('ukryta');
               bringActiveMapOverlaysToFront();
             } else {
               map.removeLayer(overlays[key]);
+              if (key === 'shade' && slider) slider.classList.add('ukryta');
             }
           });
         }
@@ -8324,6 +8327,10 @@ function emojiHtml(str) {
         }
         if (btn && slider) {
           btn.addEventListener('click', () => {
+            if (key === 'shade' && checkbox && !checkbox.checked) {
+              slider.classList.add('ukryta');
+              return;
+            }
             slider.classList.toggle('ukryta');
           });
         }


### PR DESCRIPTION
### Motivation
- Suwak przezroczystości dla nakładki „Cieniowanie (Geoportal)” powinien być widoczny tylko gdy ta nakładka jest włączona, aby uniknąć nieintuicyjnego ustawiania nieaktywnej warstwy.
- Zapobiec sytuacji, w której przycisk konfiguracji (⚙) ujawnia suwak, gdy sama nakładka jest wyłączona.

### Description
- Dodano klasę `ukryta` do elementu suwaka `#opacity-shade`, aby był domyślnie ukryty (`<input ... id="opacity-shade" class="opacity-slider ukryta">`).
- Zmieniono handler checkboxów nakładek tak, by po włączeniu `shade` usuwać klasę `ukryta` z odpowiadającego suwaka, a po wyłączeniu ponownie ją dodawać (logika w pętli `['archStd','archHi','shade'].forEach(...)`).
- Zabezpieczono przycisk `.opacity-btn` tak, żeby nie odkrywał suwaka `shade` gdy checkbox tej nakładki jest niezaznaczony (wcześniej przycisk mógł przełączyć widoczność niezależnie od stanu nakładki).

### Testing
- Uruchomiono `git diff --check`, które zakończyło się pozytywnie (brak problemów z diff). 
- Próba uruchomienia przeglądarkowego testu z użyciem `playwright` nie powiodła się, ponieważ środowisko nie ma zainstalowanego `playwright` (test nie wykonany).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d23a8a3c483308f0ff7657e0cab91)