### PR TITLE
Zachowaj proporcje zdjęć pinezek

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-05-31 v.0.546';
+    const BUILD_VERSION = '2026-06-01 v.0.547';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
@@ -1084,13 +1084,16 @@ body:not(.trip-planner-mode) .trip-planner-panel {
   font-weight: 600;
 }
 .popup-photo {
+  display: block;
   width: 100%;
-  max-height: 150px;
-  object-fit: cover;
+  height: 150px;
+  object-fit: contain;
+  background: #111;
   cursor: pointer;
 }
 .photo-gallery {
   display: flex;
+  align-items: flex-start;
   overflow-x: auto;
   gap: 2px;
   margin-bottom: 4px;
@@ -1132,6 +1135,9 @@ body:not(.trip-planner-mode) .trip-planner-panel {
 #photoModal img {
   max-width: 90%;
   max-height: 90%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
 }
 #photoModalClose {
   position: absolute;


### PR DESCRIPTION
### Motivation
- Miniatury i pełnoekranowy podgląd zdjęć pinezek były przycinane/rozciągane i trzeba je wyświetlać zgodnie z oryginalnymi proporcjami obrazu.

### Description
- Zmieniono styl miniatur w popupie: `.popup-photo` ma teraz stałą wysokość i `object-fit: contain` aby zachować proporcje i zapobiec przycinaniu; dodano tło dla spójnego obszaru podglądu.
- Ustawiono wyrównanie galerii zdjęć (`.photo-gallery { align-items: flex-start; }`) by zachować stabilny układ miniatur.
- Dla pełnoekranowego modalu zdjęć dodano `width: auto; height: auto; object-fit: contain;` aby również tam zachować oryginalne proporcje.
- Podbito wartość `BUILD_VERSION` aby wymusić odświeżenie cache'u service workera.

### Testing
- Uruchomiono skrypt z asercjami w `python3` sprawdzający obecność nowych reguł CSS i numeru wersji, który zakończył się sukcesem.
- Uruchomiono `git diff --check` w celu wykrycia problemów z diffem i nie wykryto błędów.
- Próba uruchomienia zrzutu ekranu przy użyciu Playwright nie powiodła się z powodu błędu pobierania pakietu (`npm 403`), więc wizualne testy E2E nie zostały uruchomione w tym środowisku.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d265f3c3c833095bf9183dd1d5d45)