### PR TITLE
Normalizacja i parsowanie współrzędnych DMS w wyszukiwarce i formularzach

### DIFF
--- a/index.html
+++ b/index.html
@@ -10923,23 +10923,37 @@ function showRoutePopup(pinId, tr, latlng) {
       async function executeSearch(q) {
         try {
           let result = null;
-          const topSuggestion = await fetchNominatimSuggestions(q, 1);
-          const firstSuggestion = topSuggestion?.[0];
-
-          if (firstSuggestion) {
+          const coordinateResult = parseCoordinateInput(q);
+          if (coordinateResult) {
             result = {
-              lat: parseFloat(firstSuggestion.lat),
-              lng: parseFloat(firstSuggestion.lon),
-              label: firstSuggestion.display_name
+              lat: coordinateResult[0],
+              lng: coordinateResult[1],
+              label: formatCoordinatePair(coordinateResult[0], coordinateResult[1]),
+              isCoordinateInput: true
             };
+          } else if (isLikelyCoordinateInput(q)) {
+            alert('Nie udało się zinterpretować współrzędnych');
+            return;
           } else {
-            result = await geocodeQuery(q);
+            const topSuggestion = await fetchNominatimSuggestions(q, 1);
+            const firstSuggestion = topSuggestion?.[0];
+
+            if (firstSuggestion) {
+              result = {
+                lat: parseFloat(firstSuggestion.lat),
+                lng: parseFloat(firstSuggestion.lon),
+                label: firstSuggestion.display_name
+              };
+            } else {
+              result = await geocodeQuery(q);
+            }
           }
 
           if (!result) {
             alert('Nie znaleziono adresu');
             return;
           }
+          if (result.isCoordinateInput && shouldNormalizeCoordinateDisplay(q)) input.value = result.label;
           map.setView([result.lat, result.lng], 16);
           showSearchMarker(result.lat, result.lng, result.label || q);
         } catch (err) {
@@ -10978,6 +10992,7 @@ function showRoutePopup(pinId, tr, latlng) {
         if (debounce) clearTimeout(debounce);
         if (!suggestions) return;
         if (!q) { suggestions.style.display = 'none'; return; }
+        if (isLikelyCoordinateInput(q)) { suggestions.style.display = 'none'; return; }
         debounce = setTimeout(() => {
           fetchNominatimSuggestions(q, 5)
             .then(data => {
@@ -11142,7 +11157,11 @@ function showRoutePopup(pinId, tr, latlng) {
 
       const coords = parseCoordinateInput(q);
       if (coords) {
-        return { lat: coords[0], lng: coords[1], label: q };
+        return { lat: coords[0], lng: coords[1], label: formatCoordinatePair(coords[0], coords[1]), isCoordinateInput: true };
+      }
+
+      if (isLikelyCoordinateInput(q)) {
+        return null;
       }
 
       if (isLikelyPlusCode(q)) {
@@ -11215,63 +11234,152 @@ function showRoutePopup(pinId, tr, latlng) {
       };
     }
 
+    function normalizeCoordinateText(value) {
+      return String(value || '')
+        .trim()
+        .replace(/(\d),(\d)/g, '$1.$2')
+        .replace(/[’‘`´′]/g, "'")
+        .replace(/[“”„‟″]/g, '"')
+        .replace(/'{2,}/g, '"')
+        .replace(/[º˚]/g, '°')
+        .replace(/\s+/g, ' ');
+    }
+
+    function formatCoordinatePair(lat, lng) {
+      return `${Number(lat).toFixed(6)}, ${Number(lng).toFixed(6)}`;
+    }
+
+    function shouldNormalizeCoordinateDisplay(value) {
+      const text = String(value || '');
+      return /[°'"′″’‘“”„‟]/.test(text) || /(^|\s)[NSEW](?=\s|\d|$)|\d\s*[NSEW](?=\s|$)/i.test(text) || /(\d),(\d)/.test(text);
+    }
+
+    function isCoordinateInRange(value, dir) {
+      if (!Number.isFinite(value)) return false;
+      if (/[NS]/i.test(dir || '')) return Math.abs(value) <= 90;
+      if (/[EW]/i.test(dir || '')) return Math.abs(value) <= 180;
+      return Math.abs(value) <= 180;
+    }
+
+    function isValidLatLng(lat, lng) {
+      return Number.isFinite(lat) && Number.isFinite(lng) && Math.abs(lat) <= 90 && Math.abs(lng) <= 180;
+    }
+
+    function applyCoordinateDirection(value, dir) {
+      if (!dir) return value;
+      return /[SW]/i.test(dir) ? -Math.abs(value) : Math.abs(value);
+    }
+
+    function dmsToDecimal(degrees, minutes = 0, seconds = 0, dir = '') {
+      const deg = Number(degrees);
+      const min = Number(minutes);
+      const sec = Number(seconds);
+      if (![deg, min, sec].every(Number.isFinite)) return null;
+      if (min < 0 || min >= 60 || sec < 0 || sec >= 60) return null;
+      const sign = deg < 0 ? -1 : 1;
+      const decimal = sign * (Math.abs(deg) + min / 60 + sec / 3600);
+      const directed = applyCoordinateDirection(decimal, dir);
+      if (!isCoordinateInRange(directed, dir)) return null;
+      return directed;
+    }
+
+    function assignCoordinateByDirection(result, value, dir, fallbackIndex) {
+      if (/[NS]/i.test(dir || '')) {
+        if (result.lat !== null) return false;
+        result.lat = value;
+        return true;
+      }
+      if (/[EW]/i.test(dir || '')) {
+        if (result.lng !== null) return false;
+        result.lng = value;
+        return true;
+      }
+      if (fallbackIndex === 0 && result.lat === null) {
+        result.lat = value;
+        return true;
+      }
+      if (fallbackIndex === 1 && result.lng === null) {
+        result.lng = value;
+        return true;
+      }
+      return false;
+    }
+
+    function parseDmsCoordinateInput(value) {
+      const normalized = normalizeCoordinateText(value);
+      const dmsPattern = /([NSEW])?\s*([+-]?\d{1,3}(?:\.\d+)?)\s*(?:°|\s+)\s*(\d{1,2}(?:\.\d+)?)\s*(?:'|\s+)\s*(\d{1,2}(?:\.\d+)?)\s*(?:"|\s)?\s*([NSEW])?/gi;
+      const result = { lat: null, lng: null };
+      const matches = [];
+      let match;
+      while ((match = dmsPattern.exec(normalized)) !== null) {
+        const leadingDir = (match[1] || '').toUpperCase();
+        const trailingDir = (match[5] || '').toUpperCase();
+        if (leadingDir && trailingDir && leadingDir !== trailingDir) {
+          const trailingIndex = match[0].lastIndexOf(match[5]);
+          if (trailingIndex >= 0) dmsPattern.lastIndex = match.index + trailingIndex;
+        }
+        const dir = leadingDir || trailingDir;
+        if (!dir && !/[°'"]/.test(match[0])) continue;
+        const decimal = dmsToDecimal(match[2], match[3], match[4], dir);
+        if (decimal === null) return null;
+        matches.push({ decimal, dir });
+      }
+
+      if (matches.length < 2) return null;
+      for (let i = 0; i < matches.length; i++) {
+        if (!assignCoordinateByDirection(result, matches[i].decimal, matches[i].dir, i)) return null;
+      }
+      if (!isValidLatLng(result.lat, result.lng)) return null;
+      return [result.lat, result.lng];
+    }
+
+    function parseDirectionalDecimalCoordinateInput(value) {
+      const normalized = normalizeCoordinateText(value).replace(/[°'"]/g, ' ');
+      const tokenPattern = /([NSEW])?\s*([+-]?\d{1,3}(?:\.\d+)?)\s*([NSEW])?/gi;
+      const result = { lat: null, lng: null };
+      const matches = [];
+      let match;
+      while ((match = tokenPattern.exec(normalized)) !== null) {
+        const dir = (match[1] || match[3] || '').toUpperCase();
+        if (!dir) continue;
+        const decimal = applyCoordinateDirection(Number(match[2]), dir);
+        if (!isCoordinateInRange(decimal, dir)) return null;
+        matches.push({ decimal, dir });
+      }
+      if (matches.length < 2) return null;
+      for (let i = 0; i < matches.length; i++) {
+        if (!assignCoordinateByDirection(result, matches[i].decimal, matches[i].dir, i)) return null;
+      }
+      if (!isValidLatLng(result.lat, result.lng)) return null;
+      return [result.lat, result.lng];
+    }
+
+    function isLikelyCoordinateInput(value) {
+      const normalized = normalizeCoordinateText(value);
+      if (!/\d/.test(normalized)) return false;
+      if (/[°'"]/.test(normalized)) return true;
+      if (/(^|\s)[NSEW](?=\s|\d|$)|\d\s*[NSEW](?=\s|$)/i.test(normalized)) return true;
+      return /^\s*[+-]?\d{1,3}(?:[.,]\d+)?\s*[,;\s]+\s*[+-]?\d{1,3}(?:[.,]\d+)?\s*$/.test(String(value || ''));
+    }
+
     function parseCoordinateInput(value) {
       if (!value) return null;
-      const simpleMatch = value.match(/^\s*(-?\d+(?:[.,]\d+)?)\s*[,;\s]+\s*(-?\d+(?:[.,]\d+)?)\s*$/);
-      if (simpleMatch && !/[NSEW]/i.test(value) && !/°/.test(value)) {
-        const lat = parseFloat(simpleMatch[1].replace(',', '.'));
-        const lon = parseFloat(simpleMatch[2].replace(',', '.'));
-        if (Number.isNaN(lat) || Number.isNaN(lon)) return null;
+      const normalized = normalizeCoordinateText(value);
+      const simpleMatch = normalized.match(/^\s*([+-]?\d{1,3}(?:\.\d+)?)\s*[,;\s]+\s*([+-]?\d{1,3}(?:\.\d+)?)\s*$/);
+      if (simpleMatch && !/[NSEW]/i.test(normalized) && !/[°'"]/.test(normalized)) {
+        const lat = parseFloat(simpleMatch[1]);
+        const lon = parseFloat(simpleMatch[2]);
+        if (!isValidLatLng(lat, lon)) return null;
         return [lat, lon];
       }
 
-      const hasDirectionalHints = /[NSEW]/i.test(value) || /°/.test(value);
-      if (!hasDirectionalHints) return null;
+      const dmsCoords = parseDmsCoordinateInput(normalized);
+      if (dmsCoords) return dmsCoords;
 
-      const parseDirectionalPart = (part) => {
-        if (!part) return null;
-        let cleaned = part.trim().replace(/[°]/g, '').replace(/\.+$/g, '');
-        let dir = null;
-        const leadingDir = cleaned.match(/^[NSEW]\b/i);
-        if (leadingDir) {
-          dir = leadingDir[0];
-          cleaned = cleaned.replace(/^[NSEW]\b/i, '').trim();
-        }
-        const trailingDir = cleaned.match(/\b[NSEW]\b/i);
-        if (trailingDir) {
-          dir = dir || trailingDir[0];
-          cleaned = cleaned.replace(/\b[NSEW]\b/i, '').trim();
-        }
-        const numberMatch = cleaned.match(/-?\d+(?:[.,]\d+)?/);
-        if (!numberMatch) return null;
-        let num = parseFloat(numberMatch[0].replace(',', '.'));
-        if (Number.isNaN(num)) return null;
-        if (dir) {
-          if (/[SW]/i.test(dir)) {
-            num = -Math.abs(num);
-          } else {
-            num = Math.abs(num);
-          }
-        }
-        return num;
-      };
+      const decimalDirectionalCoords = parseDirectionalDecimalCoordinateInput(normalized);
+      if (decimalDirectionalCoords) return decimalDirectionalCoords;
 
-      const parts = value.split(/[,;]/).map(part => part.trim()).filter(Boolean);
-      let lat = null;
-      let lon = null;
-      if (parts.length >= 2) {
-        lat = parseDirectionalPart(parts[0]);
-        lon = parseDirectionalPart(parts[1]);
-      } else {
-        const tokens = value.match(/[NSEW]?\s*-?\d+(?:[.,]\d+)?\s*°?\s*[NSEW]?/ig);
-        if (tokens && tokens.length >= 2) {
-          lat = parseDirectionalPart(tokens[0]);
-          lon = parseDirectionalPart(tokens[1]);
-        }
-      }
-
-      if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
-      return [lat, lon];
+      return null;
     }
 
     function formatRouteDuration(seconds) {
@@ -11650,6 +11758,9 @@ function getTripPointEmoji(p) {
     async function resolveAddressToCoords(value) {
       const coords = parseCoordinateInput(value);
       if (coords) return coords;
+      if (isLikelyCoordinateInput(value)) {
+        throw new Error('Nie udało się zinterpretować współrzędnych');
+      }
       return geocodeAddress(value);
     }
 
@@ -11682,8 +11793,13 @@ function getTripPointEmoji(p) {
           return;
         }
 
+        const startCoords = parseCoordinateInput(start);
+        const endCoords = parseCoordinateInput(end);
+        if (startCoords && startInput && shouldNormalizeCoordinateDisplay(start)) startInput.value = formatCoordinatePair(startCoords[0], startCoords[1]);
+        if (endCoords && endInput && shouldNormalizeCoordinateDisplay(end)) endInput.value = formatCoordinatePair(endCoords[0], endCoords[1]);
+
         const mode = document.querySelector('input[name="routeMode"]:checked')?.value || 'driving';
-        await showRoute(start, end, mode);
+        await showRoute(startInput?.value.trim() || start, endInput?.value.trim() || end, mode);
         updateRouteClearButton();
       }
 
@@ -12062,7 +12178,7 @@ function getTripPointEmoji(p) {
         return true;
       } catch (err) {
         console.error('Route error', err);
-        alert('Nie udało się wyznaczyć trasy');
+        alert(err?.message === 'Nie udało się zinterpretować współrzędnych' ? err.message : 'Nie udało się wyznaczyć trasy');
         const clearBtn = document.getElementById('routeClear');
         if (clearBtn && routingLayer && routingLayer.getLayers().length === 0) {
           clearBtn.disabled = true;


### PR DESCRIPTION
### Motivation
- Użytkownicy wklejają współrzędne w wielu wariantach DMS i z różnymi znakami, co powoduje, że system nie rozpoznaje lokalizacji poprawnie.
- Należało dodać automatyczne rozpoznawanie i normalizację DMS (apostrofy, cudzysłowy, przecinki dziesiętne itp.), obsługę kierunków N/S/E/W oraz konwersję do Decimal Degrees, przy zachowaniu niezmienionych już podanych współrzędnych dziesiętnych.
- Walidacja i komunikat błędu mają być zwracane tylko gdy tekst rzeczywiście nie da się zinterpretować jako współrzędne.

### Description
- Dodano funkcje pomocnicze: `normalizeCoordinateText`, `formatCoordinatePair`, `shouldNormalizeCoordinateDisplay`, `isLikelyCoordinateInput`, `isCoordinateInRange`, `isValidLatLng`, `applyCoordinateDirection` oraz `dmsToDecimal` do normalizacji tekstu i konwersji DMS → Decimal Degrees.
- Dodano parsery `parseDmsCoordinateInput` i `parseDirectionalDecimalCoordinateInput` oraz zaktualizowano `parseCoordinateInput`, aby najpierw rozpoznawać i obsługiwać liczby dziesiętne, następnie DMS i kierunkowe liczby dziesiętne, zwracając `[lat, lng]` w Decimal Degrees.
- Zmodyfikowano wyszukiwarkę lokalizacji (`executeSearch` / `geocodeQuery`): teraz najpierw sprawdzane są współrzędne lokalnie, sugestie adresowe są ukrywane dla wejść wyglądających jak współrzędne, a w przypadku wejścia wyglądającego jak współrzędne lecz nieparsowalnego wyświetlany jest specyficzny komunikat o błędzie.
- Zintegrowano normalizację z funkcją wyznaczania trasy (`initRouteSearch` / `handleRouteSubmission`) tak, aby poprawnie rozpoznawać i sformatować wpisane współrzędne oraz zwracać czytelny błąd gdy nie da się ich zinterpretować.

### Testing
- Uruchomiono podstawową weryfikację składni i sprawdzenie zmian (`git diff --check` oraz `node --check` na wydobytym skrypcie) i zakończyło się bez błędów.
- Wykonano automatyczny test parsowania przykładowych formatów w Node.js i uzyskano oczekiwane Decimal Degrees: `50°47'35,31''N 18°32'17,61''E`, `50°47'35.31"N 18°32'17.61"E`, `50°47′35,31″N 18°32′17,61″E` oraz `50 47 35.31 N 18 32 17.61 E` → `50.793142, 18.538225`.
- Przetestowano także, że już podane współrzędne dziesiętne (np. `50.793142, 18.538225` lub `50,793142 18,538225`) pozostają poprawnie rozpoznane i nie są niepotrzebnie modyfikowane.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d2d8b48c08330a3411707913ad42d)