### PR TITLE
Fix multiple links in pin popups

### DIFF
--- a/index.html
+++ b/index.html
@@ -5233,7 +5233,7 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
     function linkify(text) {
       const cleaned = sanitizeOpis(text);
       if (!cleaned) return '';
-      const urlRegex = /(https?:\/\/[^\s]+|www\.[^\s]+)/g;
+      const urlRegex = /(https?:\/\/[^\s<>"']+|www\.[^\s<>"']+)/gi;
       return cleaned
         .replace(urlRegex, url => {
           const href = url.startsWith('http') ? url : `https://${url}`;
@@ -5243,7 +5243,7 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
           } catch (e) {
             display = url;
           }
-          return `<a href="${href}" target="_blank">${display}</a>`;
+          return `<a href="${href}" target="_blank" rel="noopener noreferrer">${display}</a>`;
         })
         .replace(/\n/g, '<br>');
     }


### PR DESCRIPTION
### Motivation
- Pin descriptions containing multiple URLs separated by HTML (e.g. `<br>`) were being turned into a single link in the popup because the URL regex consumed separators, so multiple links should be detected and rendered separately.
- Links opened in a new tab should include `rel="noopener noreferrer"` for security.

### Description
- Updated the `linkify` function in `index.html` to use the regex `/(https?:\/\/[^\s<>\"']+|www\.[^\s<>\"']+)/gi` so URLs do not swallow HTML separators and multiple links are matched.
- Added `rel="noopener noreferrer"` to the generated `<a>` elements created by `linkify`.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff errors and it succeeded.
- Executed a Node test that calls `linkify` with `https://example.com<br>https://openai.com\nwww.test.pl` and verified the output contains three separate `<a>` links, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d3c72419083309e886f610a0b3df9)