### PR TITLE
Remove duplicate status checkboxes from edit popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -9302,7 +9302,6 @@ function zaladujPinezkiZFirestore() {
           </div>
           <div class="trudnosc-value" id="etrudnoscLabel" style="color:${trudnoscColor(p.trudnosc ?? 0)}">${trudnoscText(p.trudnosc ?? 0)}</div>
         </div>
-        ${buildStatusGrid('e', '', p)}
         <button id="movePinBtn-${id}">📍 Zmień położenie</button>
         ${hasEditablePinPlans(p) ? `<button id="editPinPlanBtn-${id}" type="button">🗺️ Edytuj plan</button>` : ''}
         <button onclick="zapiszLokalnie('${id}')">💾 Zapisz</button>


### PR DESCRIPTION
### Motivation
- The edit popup contained both a status dropdown and a redundant grid of status checkboxes, which is confusing and unnecessary; keep a single status control in the edit flow.

### Description
- Removed the `buildStatusGrid('e', '', p)` rendering from the pin edit popup in `index.html`, leaving the `estatus` dropdown (`buildStatusSelect`) as the sole status selector.

### Testing
- Verified with a small script that the checkbox grid string is no longer present and the status `select` remains (`python3` assertion), and ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d62f974b88330834eb51022456a71)