### PR TITLE
Fix inline labels/placeholders for pin edit selects

### DIFF
--- a/index.html
+++ b/index.html
@@ -1007,12 +1007,9 @@ body, #sidebar, #basemap-switcher {
 .edit-popup .inline-labeled-input.has-value::before {
   display: block;
 }
-.edit-popup .inline-labeled-input.has-value input {
+.edit-popup .inline-labeled-input.has-value input,
+.edit-popup .inline-labeled-input.has-value select {
   padding-left: var(--inline-label-offset, 82px);
-}
-.edit-popup .inline-labeled-input[data-label="Kategoria główna"].has-value input,
-.edit-popup .inline-labeled-input[data-label="Kategoria główna"].has-value select {
-  padding-left: 132px;
 }
 .edit-popup .edit-form-field input,
 .edit-popup .edit-form-field textarea,
@@ -8992,7 +8989,7 @@ function zaladujPinezkiZFirestore() {
 
     const pinStatusFieldKeys = ['nieaktywne', 'zamkniete', 'tajne', 'doSprawdzenia', 'zdewastowane', 'zwiedzone', 'wyroznione'];
     const pinStatusSelectOptions = [
-      { value: '', label: 'Brak statusu' },
+      { value: '', label: 'Status' },
       { value: 'nieaktywne', label: 'Niedostępne ⛔' },
       { value: 'zamkniete', label: 'Zamknięte 🔐' },
       { value: 'tajne', label: 'Tajne 🤫' },
@@ -9014,14 +9011,9 @@ function zaladujPinezkiZFirestore() {
       }, {});
     }
 
-    function formatInlineSelectLabel(label, valueLabel) {
-      return valueLabel ? `${label}: ${valueLabel}` : label;
-    }
-
-    function buildInlineLabeledSelectOptions(label, options, selected) {
+    function buildInlineSelectOptions(options, selected) {
       return options.map(option => {
-        const optionLabel = formatInlineSelectLabel(label, option.value ? option.label : '');
-        return `<option value="${option.value}" ${option.value === selected ? 'selected' : ''}>${optionLabel}</option>`;
+        return `<option value="${option.value}" ${option.value === selected ? 'selected' : ''}>${option.label}</option>`;
       }).join('');
     }
 
@@ -9041,8 +9033,12 @@ function zaladujPinezkiZFirestore() {
 
     function buildStatusSelect(id, status = {}) {
       const selected = getSelectedPinStatusKey(status);
-      const options = buildInlineLabeledSelectOptions('Status', pinStatusSelectOptions, selected);
-      return `<select id="${id}">${options}</select>`;
+      const options = buildInlineSelectOptions(pinStatusSelectOptions, selected);
+      return `
+        <span class="inline-labeled-input" data-label="Status" style="--inline-label-offset: 64px;">
+          <select id="${id}">${options}</select>
+        </span>
+      `;
     }
 
     function captureEditDraft(pin, container) {
@@ -9321,12 +9317,14 @@ function zaladujPinezkiZFirestore() {
           </span>
         </div>
         <div class="edit-form-field">
-          <select id="ekategoriaGlowna">
-            ${buildInlineLabeledSelectOptions('Kategoria główna', [
-              { value: MAIN_CATEGORY_URBEX, label: MAIN_CATEGORY_URBEX },
-              { value: MAIN_CATEGORY_TURYSTYCZNE, label: MAIN_CATEGORY_TURYSTYCZNE }
-            ], getPinMainCategory(p))}
-          </select>
+          <span class="inline-labeled-input" data-label="Kategoria główna" style="--inline-label-offset: 132px;">
+            <select id="ekategoriaGlowna">
+              ${buildInlineSelectOptions([
+                { value: MAIN_CATEGORY_URBEX, label: MAIN_CATEGORY_URBEX },
+                { value: MAIN_CATEGORY_TURYSTYCZNE, label: MAIN_CATEGORY_TURYSTYCZNE }
+              ], getPinMainCategory(p))}
+            </select>
+          </span>
         </div>
         <div class="edit-form-field">
           <span class="inline-labeled-input" data-label="Podkategoria" style="--inline-label-offset: 108px;">
@@ -9366,8 +9364,10 @@ function zaladujPinezkiZFirestore() {
       setupEmojiPicker(container.querySelector(`#emojiPicker-${id}`), p);
       setupGallery(container.querySelector('.photo-gallery'), { markUnsaved: false });
       setupInlineFieldLabel(container.querySelector('#eodKogo'), 'Od kogo');
+      setupInlineFieldLabel(container.querySelector('#ekategoriaGlowna'), 'Kategoria główna');
       setupInlineFieldLabel(container.querySelector('#ekategoria'), 'Podkategoria');
       setupInlineFieldLabel(container.querySelector('#ewarstwa'), 'Warstwa');
+      setupInlineFieldLabel(container.querySelector('#estatus'), 'Status');
       setupLayerDropdownByMainCategory(container.querySelector('#ewarstwa'), container.querySelector('#ekategoriaGlowna'));
       const editMainCategoryInput = container.querySelector('#ekategoriaGlowna');
       const editCategoryInput = container.querySelector('#ekategoria');


### PR DESCRIPTION
### Motivation
- The edit-pin popup showed inline prefixes and repeated labels inside select options for `Status` and `Kategoria główna`, instead of showing the field label only when a value is selected like `Warstwa` and `Podkategoria`.

### Description
- Replaced per-option inline-label construction with `buildInlineSelectOptions` so option text is rendered normally without prefixed labels. 
- Wrapped `#ekategoriaGlowna` and `#estatus` selects in `<span class="inline-labeled-input" data-label="...">` so the inline label appears only when the field has a value. 
- Updated inline-label CSS so `.inline-labeled-input.has-value select` receives the same left padding as inputs. 
- Changed the empty status option label to `Status` to act as a placeholder and added `setupInlineFieldLabel` calls for `#ekategoriaGlowna` and `#estatus`.

### Testing
- Ran static checks with `git diff --check` and ran syntax checks with `node --check` on the extracted inline scripts, which passed. 
- Served the app locally and validated the page responded with `curl -I http://127.0.0.1:8000/index.html` (HTTP 200). 
- Attempted headless browser testing but Playwright / a headless browser was not available in the environment, so no visual E2E screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d72424498833082baa126fb88ee6f)