### PR TITLE
Center default pin marker

### DIFF
--- a/index.html
+++ b/index.html
@@ -5451,10 +5451,11 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
       if (!emojiOrUrl || String(emojiOrUrl).trim() === "" || emojiOrUrl === "undefined") {
         const defaultMarkerWidth = 27 * markerScale;
         const defaultMarkerHeight = 43 * markerScale;
+        const defaultMarkerCenterOffsetX = 2 * markerScale;
         return L.icon({
           iconUrl: 'https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2_hdpi.png',
           iconSize: [defaultMarkerWidth, defaultMarkerHeight],
-          iconAnchor: [defaultMarkerWidth / 2, defaultMarkerHeight]
+          iconAnchor: [(defaultMarkerWidth / 2) - defaultMarkerCenterOffsetX, defaultMarkerHeight]
         });
       }
 

--- a/style.css
+++ b/style.css
@@ -288,7 +288,7 @@
   position: fixed;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -100%);
+  transform: translate(calc(-50% + 2px), -100%);
   pointer-events: none;
   z-index: 1500;
   display: none;


### PR DESCRIPTION
### Motivation
- The default Google-style pin without an emoji was visually shifted to the left of its coordinate; make the default marker and the mobile center preview visually centered over the pin location.

### Description
- Adjusted default marker anchor logic in `createEmojiIcon` in `index.html` to apply a small X offset when using the fallback spotlight icon so the marker is centered over coordinates, and updated `#centerMarker` in `style.css` to shift the mobile preview by the same offset.

### Testing
- Ran a file-readability check with `python3` (`Path(...).read_text()`), which succeeded.
- Extracted inline scripts from `index.html` and ran `node --check` on them, which succeeded.
- Ran `git diff --check` which reported no issues, and started a local static server (`python3 -m http.server`) which started successfully; Playwright-based visual testing was not available in the environment so no screenshot test was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d8b20d5dc8330ace8d3f52707ba28)