### PR TITLE
Zmniejsz standardowy pin markera do 22.4px

### DIFF
--- a/index.html
+++ b/index.html
@@ -5449,9 +5449,9 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
       }
 
       if (!emojiOrUrl || String(emojiOrUrl).trim() === "" || emojiOrUrl === "undefined") {
-        const defaultMarkerWidth = 27 * markerScale;
-        const defaultMarkerHeight = 43 * markerScale;
-        const defaultMarkerCenterOffsetX = 2 * markerScale;
+        const defaultMarkerHeight = 22.4;
+        const defaultMarkerWidth = defaultMarkerHeight * (27 / 43);
+        const defaultMarkerCenterOffsetX = defaultMarkerHeight * (2 / 43);
         return L.icon({
           iconUrl: 'https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2_hdpi.png',
           iconSize: [defaultMarkerWidth, defaultMarkerHeight],


### PR DESCRIPTION
### Motivation
- Standardowy pin markera był za duży; potrzebna jest wysokość `22.4px` przy zachowaniu proporcji oryginalnej ikony.

### Description
- W `createEmojiIcon` w `index.html` zastąpiono skalowane wartości domyślnego pinu stałą wysokością `22.4` oraz obliczono szerokość i przesunięcie kotwicy proporcjonalnie (`defaultMarkerWidth = defaultMarkerHeight * (27/43)` i `defaultMarkerCenterOffsetX = defaultMarkerHeight * (2/43)`).

### Testing
- Uruchomiono `git diff --check` oraz krótkie sprawdzenie przez skrypt Pythona, który asercjami potwierdził obecność nowych stałych (`const defaultMarkerHeight = 22.4;`, `const defaultMarkerWidth = defaultMarkerHeight * (27 / 43);`, `const defaultMarkerCenterOffsetX = defaultMarkerHeight * (2 / 43);`) i zakończył się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d8ee0e1188330aef606c12df10ed0)