### PR TITLE
Fix uneven UI button sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2582,6 +2582,97 @@ body.mobile-layout #saveChanges {
   min-width: 170px !important;
   z-index: 2147483646 !important;
 }
+
+/* Button alignment overrides: keep neighboring controls visually equal without changing JS logic. */
+#uiScaleControls button {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(30px * var(--ui-scale));
+  height: calc(30px * var(--ui-scale));
+  padding: 0 calc(8px * var(--ui-scale));
+  line-height: 1;
+  white-space: nowrap;
+  overflow: visible;
+  max-width: none;
+}
+
+#uiScaleMinus,
+#uiScalePlus {
+  flex: 0 0 calc(30px * var(--ui-scale));
+  width: calc(30px * var(--ui-scale));
+  min-width: calc(30px * var(--ui-scale));
+  padding: 0;
+}
+
+#uiScaleReset {
+  align-self: flex-start;
+  width: auto;
+  min-width: calc(58px * var(--ui-scale));
+  max-width: 100%;
+  padding-inline: calc(10px * var(--ui-scale));
+}
+
+.trip-mode-toggle button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(36px * var(--ui-scale));
+  height: calc(36px * var(--ui-scale));
+  padding: 0 calc(8px * var(--ui-scale));
+  border-width: 1px;
+  line-height: 1;
+}
+
+.popup-edit-row {
+  display: flex;
+  align-items: center;
+}
+
+.popup-edit-btn {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 calc(28px * var(--ui-scale));
+  width: calc(28px * var(--ui-scale));
+  min-width: calc(28px * var(--ui-scale));
+  height: calc(28px * var(--ui-scale));
+  min-height: calc(28px * var(--ui-scale));
+  padding: 0;
+  line-height: 1;
+  text-align: center;
+}
+
+.popup-route-actions {
+  display: flex;
+  align-items: stretch;
+}
+
+.popup-route-btn,
+.popup-direct-route-btn,
+.popup-chatgpt-btn {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(34px * var(--ui-scale));
+  height: auto;
+  padding: calc(6px * var(--ui-scale)) calc(8px * var(--ui-scale));
+  line-height: 1.15;
+  text-align: center;
+  white-space: normal;
+}
+
+.popup-route-actions .popup-route-btn,
+.popup-route-actions .popup-direct-route-btn,
+.popup-route-actions .popup-chatgpt-btn {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
 </style>
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Normalize inconsistent button heights and alignment across several UI controls so neighboring buttons visually match without altering page logic.
- Ensure Fix keeps compatibility with the `--ui-scale` scaling variable and does not change JS handlers or panel layout.

### Description
- Add a centralized CSS override block at the end of the main `<style>` that targets `#uiScaleControls button`, `#uiScaleMinus`, `#uiScalePlus`, and `#uiScaleReset` to unify `box-sizing`, `display`, scaled `height/min-height`, `padding`, and `line-height` while preventing Reset text clipping.
- Normalize `.trip-mode-toggle button` box model and centering so both toggle buttons share identical height, padding, border width and vertical alignment.
- Make `.popup-edit-row` a centered flex container and give `.popup-edit-btn` a fixed scaled width/height with flex centering and `line-height: 1` so emoji buttons (✏️/🗑️) align in one row and remain identical in size.
- Standardize `.popup-route-actions` and route buttons by applying flex/stretch layout and shared scaled `min-height`, `padding`, `line-height`, `display:flex`, `align-items:center` and `justify-content:center` to keep all route/action buttons visually equal while allowing wrapped text without increasing only one button's height.

### Testing
- Parsed `index.html` using Python's `HTMLParser` which completed successfully indicating the file remains valid HTML.
- Performed a CSS brace-balance check on the `<style>` block which returned balanced braces (no syntax corruption). 
- Ran `git diff --check` / basic repo checks with no reported style/blocking errors; headless browser screenshot tests were not executed because no browser/playwright was available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e7ec3c8248330b5093ffd4f2ba68d)