### PR TITLE
Hide internal layer prefixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4057,12 +4057,21 @@ function slugify(str) {
     const layerDocs = {};
     const layerNamesById = {};
 
+    function stripLayerInternalPrefix(layerName) {
+      let value = (layerName || '').trim();
+      let previous = '';
+      while (value && value !== previous) {
+        previous = value;
+        value = value.replace(/^(urbex|turystyczne)\s*:{1,2}\s*/i, '').trim();
+      }
+      return value;
+    }
+
     function getLayerDisplayName(layerKeyOrName) {
       const value = (layerKeyOrName || '').trim();
       const layer = warstwy[value];
-      if (layer && layer.displayName) return layer.displayName;
-      const separatorIndex = value.indexOf('::');
-      return separatorIndex >= 0 ? value.slice(separatorIndex + 2) : value;
+      if (layer && layer.displayName) return stripLayerInternalPrefix(layer.displayName);
+      return stripLayerInternalPrefix(value);
     }
 
     function makeLayerKey(layerName, mainCategory = MAIN_CATEGORY_URBEX) {
@@ -4987,7 +4996,7 @@ function slugify(str) {
           if (match) visibleCount++;
         });
         const countToShow = query ? visibleCount : info.totalCount;
-        info.label.textContent = `${info.name} (${countToShow})`;
+        info.label.textContent = `${getLayerDisplayName(info.name)} (${countToShow})`;
         if (info.listEl) {
           if (query) {
             const shouldShowList = visibleCount > 0;


### PR DESCRIPTION
### Motivation
- Layer names sometimes include internal main-category prefixes like `TURYSTYCZNE::`, `turystyczne:` or `URBEX::` which were visible in the sidebar and pin UI; those are internal keys and should not be shown to users. 
- The goal is to preserve internal layer keys for uniqueness while displaying only the clean human-readable name to the user.

### Description
- Added `stripLayerInternalPrefix(layerName)` to remove repeated/internal prefixes such as `urbex` / `turystyczne` with either `::` or `:` separators. 
- Changed `getLayerDisplayName` to call the new `stripLayerInternalPrefix` so all places that use `getLayerDisplayName(...)` will show the cleaned name. 
- Ensured the layer counter in search/filter UI uses `getLayerDisplayName(info.name)` instead of the raw internal key so the sidebar label shows the cleaned name and correct count.

### Testing
- Ran a small Node.js validation script (`node - <<'NODE' ... NODE`) that checks several prefix variants against expected cleaned outputs and it succeeded. 
- Ran `git diff --check` to ensure no trailing whitespace/errors and it passed. 
- Attempted to run a headless UI test with Playwright but the environment lacked Playwright/browser, so no browser screenshot test was executed (non-blocking manual/UI verification recommended).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a203044bbac8330be1425e3208ccb92)