### PR TITLE
Fix local pin photo previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -3615,13 +3615,18 @@ function slugify(str) {
       return out;
     }
 
+    function isLocalPreviewPhotoUrl(url) {
+      return /^(data:image\/|blob:)/i.test(String(url || ''));
+    }
+
     function getPhotoEntryUrl(entry) {
       if (!entry) return null;
       if (typeof entry === 'string') {
-        return normalizePhotoUrls({ photo: entry })[0] || null;
+        return isLocalPreviewPhotoUrl(entry) ? entry : (normalizePhotoUrls({ photo: entry })[0] || null);
       }
       if (typeof entry === 'object') {
-        return normalizePhotoUrls({ photo: [entry.url, entry.src, entry.href, entry.photo] })[0] || null;
+        const rawUrl = entry.url || entry.src || entry.href || entry.photo;
+        return isLocalPreviewPhotoUrl(rawUrl) ? rawUrl : (normalizePhotoUrls({ photo: [rawUrl] })[0] || null);
       }
       return null;
     }
@@ -3632,7 +3637,7 @@ function slugify(str) {
       img.decoding = 'async';
       img.src = normalizePhotoUrl(url);
       img.onerror = function () {
-        if (!img.dataset.fallback) {
+        if (!img.dataset.fallback && !isLocalPreviewPhotoUrl(url)) {
           img.dataset.fallback = '1';
           img.src = proxyImage(url);
         }
@@ -10172,7 +10177,9 @@ function zaladujPinezkiZFirestore() {
         <button id="cancelNew">Anuluj</button>`;
 
       setupGallery(container.querySelector('.photo-gallery'), { markUnsaved: false });
-      setupAddPhotoButton(container.querySelector('.popup-add-photo'), tempPin.slug, container.querySelector('.photo-gallery'));
+      setupAddPhotoButton(container.querySelector('.popup-add-photo'), tempPin.slug, container.querySelector('.photo-gallery'), {
+        markUnsaved: false
+      });
       setupEmojiPicker(container.querySelector('#emojiPickerNew'), tempPin);
       const newLayerInput = container.querySelector('#warstwaNew');
       const newMainCategoryInput = container.querySelector('#kategoriaGlownaNew');


### PR DESCRIPTION
### Motivation
- Umożliwić natychmiastowy podgląd lokalnie wybranego zdjęcia (data: / blob:) w popupie nowej lub edycji pinezki przed zapisaniem do Firestore/Storage.
- Zapobiec niepotrzebnemu oznaczaniu mapy jako „niezapisanej” po dodaniu zdjęcia przez ikonę dodawania w popupie nowej pinezki; zapis powinien być wymuszony dopiero po kliknięciu `Zapisz` w popupie.
- Uniemożliwić próbę fallbacku przez zewnętrzne proxy dla lokalnych podglądów zdjęć, co powodowało błędne żądania dla `data:`/`blob:` URL-i.

### Description
- Dodano funkcję pomocniczą `isLocalPreviewPhotoUrl` rozpoznającą `data:image/...` i `blob:` URL-e oraz wykorzystano ją w `getPhotoEntryUrl` by zwracać lokalny URL gdy istnieje.
- Zmieniono `imgWithFallback` tak, aby nie próbował proxy/fallbacku dla lokalnych podglądów (`data:`/`blob:`).
- Przy wyświetlaniu formularza tworzenia nowej pinezki przekazano `markUnsaved: false` do `setupAddPhotoButton` dla przycisku dodawania zdjęć w popupie, żeby samo dodanie zdjęcia nie wywoływało globalnego przycisku `#saveChanges`.
- Zmiany wprowadzono w `index.html` (dodane ~11 wierszy, zmodyfikowane fragmenty związane z galerią i fallbackiem obrazków).

### Testing
- Uruchomiono prosty skrypt `python3` sprawdzający obecność nowych symboli (`function isLocalPreviewPhotoUrl`, sprawdzenia użycia) i test zakończył się pomyślnie.
- Uruchomiono `git diff --check` w celu wykrycia problemów z formatowaniem i konfliktami, bez błędów zwrócono sukces.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25da5afae88330bd2a35abdf12754e)