### PR TITLE
Fix layer drag separators and add emoji hue slider + persistence

### DIFF
--- a/firestore-setup.js
+++ b/firestore-setup.js
@@ -36,7 +36,7 @@ auth.onAuthStateChanged(user => {
   }
 });
 
-window.addPinOffline = async function({ lat, lng, name, opis, warstwa, emoji, kategoriaGlowna = 'URBEX' }){
+window.addPinOffline = async function({ lat, lng, name, opis, warstwa, emoji, emojiHue = 0, kategoriaGlowna = 'URBEX' }){
   const payload = {
     lat,
     lng,
@@ -45,6 +45,7 @@ window.addPinOffline = async function({ lat, lng, name, opis, warstwa, emoji, ka
     warstwa,
     kategoriaGlowna: kategoriaGlowna === 'TURYSTYCZNE' ? 'TURYSTYCZNE' : 'URBEX',
     emoji,
+    emojiHue: Number.isFinite(Number(emojiHue)) ? Math.max(0, Math.min(360, Math.round(Number(emojiHue)))) : 0,
     createdAt: firebase.firestore.FieldValue.serverTimestamp(),
     updatedAt: firebase.firestore.FieldValue.serverTimestamp()
   };

--- a/index.html
+++ b/index.html
@@ -537,7 +537,30 @@
     .tool-btn.active { background: #444; }
     .pinezka.active { color: #007bff; font-weight: bold; }
     .pinezka:hover { text-decoration: underline; }
-    .warstwa { margin-bottom: 10px; }
+    .warstwa {
+      margin-bottom: 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+      box-sizing: border-box;
+    }
+    #lista-warstw .warstwa:last-child,
+    #lista-warstw .warstwa:last-of-type {
+      border-bottom: none;
+    }
+    .warstwa.dragging {
+      opacity: 0.5;
+      border-bottom-color: rgba(255, 255, 255, 0.18);
+      box-shadow: none;
+    }
+    .warstwa.sortable-ghost,
+    .warstwa.layer-drop-placeholder {
+      border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+      box-shadow: none;
+    }
+    .warstwa.sortable-chosen,
+    .warstwa.sortable-drag {
+      border-bottom: none;
+      box-shadow: none;
+    }
     .dragging { opacity: 0.5; }
     .warstwa h3 { margin: 1px 0; font-size: 14px; display: flex; align-items: center; justify-content: space-between; cursor: pointer; gap: 6px; }
     .warstwa input[type="checkbox"] { margin-right: 5px; }
@@ -1042,7 +1065,7 @@ body, #sidebar, #basemap-switcher {
 
 
 .emoji-obrys {
-  filter: drop-shadow(0 0 0.1px black)
+  filter: hue-rotate(var(--emoji-hue, 0deg)) drop-shadow(0 0 0.1px black)
           drop-shadow(1px 1px 1px black)
           drop-shadow(-1px -1px 1px black);
   vertical-align: middle;
@@ -1051,7 +1074,7 @@ body, #sidebar, #basemap-switcher {
 }
 
 .emoji-obrys-sztosy {
-  filter: drop-shadow(0 0 0.1px gold)
+  filter: hue-rotate(var(--emoji-hue, 0deg)) drop-shadow(0 0 0.1px gold)
           drop-shadow(1px 1px 1px orange)
           drop-shadow(-1px -1px 1px gold);
   drop-shadow(0 0 2px black)
@@ -1740,6 +1763,28 @@ img.emoji {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
+
+.emoji-hue-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 12px;
+  color: #e8e8e8;
+}
+.emoji-hue-controls label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+.emoji-hue-controls input[type="range"] { flex: 1; min-width: 90px; }
+.emoji-hue-value { min-width: 38px; text-align: right; color: #cfd6e6; }
+.emoji-hue-reset { font-size: 11px; white-space: nowrap; }
+.emoji-inline, .emoji-hue-filter { filter: hue-rotate(var(--emoji-hue, 0deg)); }
 
 .trip-special-point-modal {
   overflow: visible !important;
@@ -3463,6 +3508,60 @@ body.mobile-layout #saveChanges {
     function resolveEmoji(val) {
       if (!val) return val;
       return emojiMap[val] || val;
+    }
+
+    function normalizeEmojiHue(value) {
+      const hue = Number(value);
+      if (!Number.isFinite(hue)) return 0;
+      return Math.max(0, Math.min(360, Math.round(hue)));
+    }
+
+    function getPinEmojiHue(pin = {}) {
+      if (pin && pin.noweEmojiHue !== undefined) return normalizeEmojiHue(pin.noweEmojiHue);
+      return normalizeEmojiHue(pin && pin.emojiHue);
+    }
+
+    function emojiHueStyle(value) {
+      const hue = normalizeEmojiHue(value);
+      return hue ? ` style="--emoji-hue:${hue}deg;"` : '';
+    }
+
+    function createEmojiHueControls({ initialHue = 0, onChange } = {}) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'emoji-hue-controls';
+      const label = document.createElement('label');
+      label.textContent = 'Hue';
+      const slider = document.createElement('input');
+      slider.type = 'range';
+      slider.min = '0';
+      slider.max = '360';
+      slider.step = '1';
+      slider.value = String(normalizeEmojiHue(initialHue));
+      const value = document.createElement('span');
+      value.className = 'emoji-hue-value';
+      const reset = document.createElement('button');
+      reset.type = 'button';
+      reset.className = 'emoji-hue-reset';
+      reset.textContent = 'Reset koloru';
+      const emit = () => {
+        const hue = normalizeEmojiHue(slider.value);
+        slider.value = String(hue);
+        value.textContent = `${hue}°`;
+        if (typeof onChange === 'function') onChange(hue);
+      };
+      slider.addEventListener('input', emit);
+      reset.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        slider.value = '0';
+        emit();
+      });
+      label.appendChild(slider);
+      wrapper.appendChild(label);
+      wrapper.appendChild(value);
+      wrapper.appendChild(reset);
+      emit();
+      return { wrapper, slider, setHue: (hue) => { slider.value = String(normalizeEmojiHue(hue)); emit(); } };
     }
 
     async function addEmojiToList(url, info = '', logger = console.log) {
@@ -5791,7 +5890,7 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
       if (!emojiOrUrl) return '';
       const layerId = pin.warstwaId || layerDocs[layerName] || null;
       const statusOverlay = pinStatusOverlayHtml(pin, layerId, { className: 'pin-list-status-icon', checkSize: 9, includeHighlight: true });
-      return `<span class="pin-list-emoji-wrap"><span class="pin-list-emoji-base">${emojiHtml(emojiOrUrl)}</span>${statusOverlay}</span>`;
+      return `<span class="pin-list-emoji-wrap"><span class="pin-list-emoji-base">${emojiHtml(emojiOrUrl, getPinEmojiHue(pin))}</span>${statusOverlay}</span>`;
     }
 
     function createEmojiIcon(emojiOrUrl, warstwaId, size = 32, status = {}) {
@@ -5830,6 +5929,7 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
 
       const isUrl = emojiOrUrl && emojiOrUrl.startsWith("http");
       const overlay = pinStatusOverlayHtml(status, warstwaId, { className: 'status-icon', checkSize: overlaySize, includeHighlight: true });
+      const hueAttr = emojiHueStyle(getPinEmojiHue(status));
 
       if (isUrl) {
         const cls = isHighlighted ? "emoji-obrys-sztosy" : "emoji-obrys";
@@ -5837,7 +5937,7 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
           className: 'emoji-marker',
           html: `
             <div style="position: relative; display: inline-block;">
-              <img src="${emojiOrUrl}" class="${cls}" width="${imageSize}" height="${imageSize}">
+              <img src="${emojiOrUrl}" class="${cls}" width="${imageSize}" height="${imageSize}"${hueAttr}>
               ${overlay}
             </div>`,
           iconSize: [scaledSize, scaledSize],
@@ -5851,7 +5951,7 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
         className: 'emoji-marker',
         html: `
           <div style="position: relative; display: inline-block;">
-            <span class="${cls}">${emojiOrUrl}</span>
+            <span class="${cls} emoji-hue-filter"${hueAttr}>${emojiOrUrl}</span>
             ${overlay}
           </div>`,
         iconSize: [scaledSize, scaledSize],
@@ -5860,13 +5960,14 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
     }
 
 
-function emojiHtml(str) {
+function emojiHtml(str, hue = 0) {
   if (!str) return '';
   const url = resolveEmoji(str);
+  const hueAttr = emojiHueStyle(hue);
   if (url.startsWith('http')) {
-    return `<span class="hidden-text">${str} </span><img src="${url}" class="emoji-inline">`;
+    return `<span class="hidden-text">${str} </span><img src="${url}" class="emoji-inline"${hueAttr}>`;
   }
-  return url;
+  return normalizeEmojiHue(hue) ? `<span class="emoji-hue-filter"${hueAttr}>${url}</span>` : url;
 }
 
 
@@ -6822,7 +6923,7 @@ function emojiHtml(str) {
         ${p.wyroznione ? `<div style="opacity:0.8;">Wyróżnione ⭐</div>` : ''}`;
       return `
         <div class="photo-gallery" data-slug="${slug}"></div>
-        <b>${p.emoji ? emojiHtml(p.emoji) + ' ' : ''}${p.nazwa}</b>
+        <b>${p.emoji ? emojiHtml(p.emoji, getPinEmojiHue(p)) + ' ' : ''}${p.nazwa}</b>
         ${trudHtml}
         ${statusHtml}
         <div style="border-top:1px solid #444;"></div>
@@ -7107,15 +7208,25 @@ function emojiHtml(str) {
         }
         return resolveEmoji(val);
       }
+      const applyPreviewHue = () => {
+        preview.style.setProperty('--emoji-hue', `${getPinEmojiHue(pin)}deg`);
+        preview.classList.toggle('emoji-hue-filter', getPinEmojiHue(pin) !== 0);
+      };
       preview.src = getCurrent();
+      applyPreviewHue();
       container.appendChild(preview);
+
+      function notifyPickerChange(id, url) {
+        if (typeof options.onChange === 'function') {
+          options.onChange(id, url, pin);
+        }
+      }
 
       function applyEmojiSelection(id, url) {
         preview.src = url || getCurrent();
         pin.noweEmoji = id;
-        if (typeof options.onChange === 'function') {
-          options.onChange(id, url, pin);
-        }
+        applyPreviewHue();
+        notifyPickerChange(id, url);
       }
 
       const grid = document.createElement('div');
@@ -7156,6 +7267,15 @@ function emojiHtml(str) {
       renderGrid();
       subscribeEmojiList(renderGrid);
       container.appendChild(grid);
+      const hueControls = createEmojiHueControls({
+        initialHue: getPinEmojiHue(pin),
+        onChange: (hue) => {
+          pin.noweEmojiHue = hue;
+          applyPreviewHue();
+          notifyPickerChange(pin.noweEmoji !== undefined ? pin.noweEmoji : pin.emoji, getCurrent());
+        }
+      });
+      container.appendChild(hueControls.wrapper);
 
       const useFixedViewportPosition = !!container.closest('.trip-special-point-modal');
       preview.addEventListener('click', e => {
@@ -7168,7 +7288,7 @@ function emojiHtml(str) {
       });
     }
 
-    async function setupEmojiPickerForInput(container, input) {
+    async function setupEmojiPickerForInput(container, input, options = {}) {
       if (!container || !input) return;
       await emojiListReady;
       container.innerHTML = '';
@@ -7187,8 +7307,22 @@ function emojiHtml(str) {
         return resolved || 'https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2_hdpi.png';
       }
 
+      function getInputHue() {
+        if (typeof options.getHue === 'function') return normalizeEmojiHue(options.getHue());
+        return normalizeEmojiHue(input.dataset.emojiHue);
+      }
+
+      function setInputHue(hue) {
+        const normalized = normalizeEmojiHue(hue);
+        input.dataset.emojiHue = String(normalized);
+        if (typeof options.setHue === 'function') options.setHue(normalized);
+      }
+
       function updatePreview() {
         preview.src = currentUrl();
+        const hue = getInputHue();
+        preview.style.setProperty('--emoji-hue', `${hue}deg`);
+        preview.classList.toggle('emoji-hue-filter', hue !== 0);
       }
 
       const addBtn = document.createElement('button');
@@ -7231,6 +7365,15 @@ function emojiHtml(str) {
 
       container.appendChild(preview);
       container.appendChild(grid);
+      const hueControls = createEmojiHueControls({
+        initialHue: getInputHue(),
+        onChange: (hue) => {
+          setInputHue(hue);
+          updatePreview();
+          if (typeof options.onHueChange === 'function') options.onHueChange(hue);
+        }
+      });
+      container.appendChild(hueControls.wrapper);
 
       preview.addEventListener('click', e => {
         e.stopPropagation();
@@ -9119,6 +9262,7 @@ function zaladujPinezkiZFirestore() {
       p.zwiedzone = p.zwiedzone === true;
       p.wyroznione = p.wyroznione === true;
       p.visible = p.visible !== false;
+      p.emojiHue = normalizeEmojiHue(p.emojiHue);
       p.lat = Number(p.lat);
       p.lng = Number(p.lng);
       if (!Number.isFinite(p.lat) || !Number.isFinite(p.lng)) {
@@ -9389,7 +9533,7 @@ function zaladujPinezkiZFirestore() {
 
     const PIN_EDIT_SESSION_FIELDS = [
       'nazwa', 'opis', 'odKogo', 'warstwa', 'warstwaId', 'kategoria', 'kategoriaGlowna',
-      'emoji', 'trudnosc', 'nieaktywne', 'zamkniete', 'tajne', 'doSprawdzenia',
+      'emoji', 'emojiHue', 'trudnosc', 'nieaktywne', 'zamkniete', 'tajne', 'doSprawdzenia',
       'zdewastowane', 'zwiedzone', 'wyroznione', 'slug', 'lat', 'lng'
     ];
 
@@ -9417,6 +9561,7 @@ function zaladujPinezkiZFirestore() {
       delete pin._editOriginalState;
       delete pin._pinEditCommitted;
       delete pin.noweEmoji;
+      delete pin.noweEmojiHue;
     }
 
     function cancelPinEditSession(pin, marker) {
@@ -9672,7 +9817,7 @@ function zaladujPinezkiZFirestore() {
           if (!targetMarker || !targetMarker.setIcon) return;
           const statusSelect = container.querySelector('#estatus');
           const draftStatus = statusSelect ? getPinStatusStateFromSelect(statusSelect) : p;
-          targetMarker.setIcon(createEmojiIcon(emojiVal, p.warstwaId, 32, draftStatus));
+          targetMarker.setIcon(createEmojiIcon(emojiVal, p.warstwaId, 32, { ...p, ...draftStatus, emojiHue: getPinEmojiHue(p) }));
         }
       });
       setupGallery(container.querySelector('.photo-gallery'), { markUnsaved: false });
@@ -9886,6 +10031,7 @@ function zaladujPinezkiZFirestore() {
         kategoria: p.kategoria,
         kategoriaGlowna: getPinMainCategory(p),
         emoji: p.emoji,
+        emojiHue: getPinEmojiHue(p),
         trudnosc: p.trudnosc,
         nieaktywne: p.nieaktywne,
         zamkniete: p.zamkniete,
@@ -9899,6 +10045,7 @@ function zaladujPinezkiZFirestore() {
         lng: editOriginal ? editOriginal.lng : p.lng
       } : null;
       const emojiVal = p && p.noweEmoji !== undefined ? p.noweEmoji : (p ? p.emoji : '');
+      const emojiHueVal = p ? getPinEmojiHue(p) : 0;
       const nowa = {
         nazwa: nameVal,
         opis: document.getElementById("eopis").value.replace(/\n/g, '<br>'),
@@ -9908,6 +10055,7 @@ function zaladujPinezkiZFirestore() {
         kategoria: catVal,
         kategoriaGlowna: mainCatVal,
         emoji: emojiVal,
+        emojiHue: emojiHueVal,
         trudnosc: parseInt(document.getElementById("etrudnosc").value, 10),
         ...getPinStatusStateFromSelect(document.getElementById("estatus"))
       };
@@ -10021,6 +10169,7 @@ function zaladujPinezkiZFirestore() {
         id: newId,
         slug: `tmp-${newId}`,
         emoji: defaultEmoji,
+        emojiHue: 0,
         trudnosc: 0
       };
       const container = document.createElement("div");
@@ -10074,7 +10223,7 @@ function zaladujPinezkiZFirestore() {
           wyroznione: !!container.querySelector('#wyroznioneNew')?.checked
         };
         const emojiVal = tempPin.noweEmoji !== undefined ? tempPin.noweEmoji : tempPin.emoji || defaultEmoji;
-        marker.setIcon(createEmojiIcon(emojiVal, null, 24, status));
+        marker.setIcon(createEmojiIcon(emojiVal, null, 24, { ...status, emojiHue: getPinEmojiHue(tempPin) }));
       };
       setupEmojiPicker(container.querySelector('#emojiPickerNew'), tempPin, { onChange: refreshNewPinIcon });
       const newLayerInput = container.querySelector('#warstwaNew');
@@ -10180,6 +10329,7 @@ function zaladujPinezkiZFirestore() {
             kategoria: catVal,
             kategoriaGlowna: mainCatVal,
             emoji: tempPin.noweEmoji !== undefined ? tempPin.noweEmoji : tempPin.emoji,
+            emojiHue: getPinEmojiHue(tempPin),
             nieaktywne: container.querySelector("#nieaktywneNew").checked,
             zamkniete: container.querySelector("#zamknieteNew").checked,
             tajne: container.querySelector("#tajneNew").checked,
@@ -10461,6 +10611,7 @@ function zaladujPinezkiZFirestore() {
         if (!warstwy[warstwaN]) {
           ensureLocalLayerObject(warstwaN, layerInfo.displayName, localPinMain, { layer: createPinLayer().addTo(map), loaded: true, loading: false });
         }
+        p.emojiHue = normalizeEmojiHue(p.emojiHue);
         const iconEmoji = warstwy[warstwaN].emoji || p.emoji;
         const marker = L.marker([p.lat, p.lng], {icon: createEmojiIcon(iconEmoji, p.warstwaId, 32, p)}).addTo(warstwy[warstwaN].layer);
         marker.__pinRef = p;
@@ -10504,10 +10655,13 @@ function zaladujPinezkiZFirestore() {
       handle.addEventListener('dragstart', () => {
         draggedLayer = div;
         handle.classList.add('dragging');
+        div.classList.add('dragging');
       });
       handle.addEventListener('dragend', () => {
         handle.classList.remove('dragging');
+        div.classList.remove('dragging');
         draggedLayer = null;
+        requestAnimationFrame(() => generujListeWarstw({ deferMarkerVisibilityUpdate: true }));
       });
       div.addEventListener('dragover', e => e.preventDefault());
       div.addEventListener('drop', e => {
@@ -10518,6 +10672,7 @@ function zaladujPinezkiZFirestore() {
           saveLayerOrder({ markChange: false });
           autosaveLayerOrderToFirestore(loadLayerOrder());
           updateLayerNumbers();
+          requestAnimationFrame(() => generujListeWarstw({ deferMarkerVisibilityUpdate: true }));
         }
       });
 
@@ -10539,6 +10694,7 @@ function zaladujPinezkiZFirestore() {
       const endPointerDrag = () => {
         if (!draggedLayer) return;
         handle.classList.remove('dragging');
+        draggedLayer.classList.remove('dragging');
         draggedLayer = null;
         document.body.classList.remove('layer-drag-active');
         document.removeEventListener('pointermove', onPointerMove);
@@ -10547,12 +10703,14 @@ function zaladujPinezkiZFirestore() {
         saveLayerOrder({ markChange: false });
         autosaveLayerOrderToFirestore(loadLayerOrder());
         updateLayerNumbers();
+        requestAnimationFrame(() => generujListeWarstw({ deferMarkerVisibilityUpdate: true }));
       };
       handle.addEventListener('pointerdown', (event) => {
         if (event.button !== 0 && event.pointerType !== 'touch') return;
         event.preventDefault();
         draggedLayer = div;
         handle.classList.add('dragging');
+        div.classList.add('dragging');
         document.body.classList.add('layer-drag-active');
         document.addEventListener('pointermove', onPointerMove);
         document.addEventListener('pointerup', endPointerDrag);
@@ -13944,11 +14102,6 @@ function getTripPointEmoji(p) {
 
         div.appendChild(listaP);
         lista.appendChild(div);
-        if (idx < sectionLayers.length - 1) {
-          const sep = document.createElement('hr');
-          sep.className = 'layer-separator';
-          lista.appendChild(sep);
-        }
       };
       if (tempLayers.length) {
         tempLayers.forEach((nazwa, idx) => renderLayer(nazwa, idx, tempLayers));
@@ -14986,6 +15139,7 @@ function confirmLayerDelete() {
       kategoriaGlowna: getPinMainCategory(p),
       kraj: p.kraj || '',
       emoji: p.emoji,
+      emojiHue: getPinEmojiHue(p),
       nieaktywne: p.nieaktywne || false,
       zamkniete: p.zamkniete || false,
       tajne: p.tajne || false,
@@ -15099,6 +15253,7 @@ function confirmLayerDelete() {
       kategoria: catVal,
       kategoriaGlowna: mainCatVal,
       emoji: form.emoji,
+      emojiHue: normalizeEmojiHue(form.emojiHue),
       trudnosc: parseInt(form.trudnosc, 10),
       nieaktywne: form.nieaktywne,
       zamkniete: form.zamkniete,
@@ -15197,10 +15352,14 @@ function confirmLayerDelete() {
       setupAddPhotoButton(mobileAddPhotoBtn, mobileDraftPhotosSlug, mobilePhotoGallery, { capture: 'environment' });
 
       let mobileEmojiPickerInitialized = false;
+      let mobileEmojiHue = 0;
       function refreshMobileEmojiPicker() {
         if (!emojiPicker || !emojiInput) return;
         if (!mobileEmojiPickerInitialized) {
-          setupEmojiPickerForInput(emojiPicker, emojiInput);
+          setupEmojiPickerForInput(emojiPicker, emojiInput, {
+            getHue: () => mobileEmojiHue,
+            setHue: (hue) => { mobileEmojiHue = normalizeEmojiHue(hue); }
+          });
           mobileEmojiPickerInitialized = true;
         } else {
           const preview = emojiPicker.querySelector('.emoji-picker-preview');
@@ -15224,6 +15383,7 @@ function confirmLayerDelete() {
       mainCatInput.style.display = 'none';
       catInput.style.display = 'none';
       emojiInput.value = '';
+      mobileEmojiHue = 0;
       if (emojiWrapper) emojiWrapper.style.display = 'none';
       if (emojiPicker) {
         const grid = emojiPicker.querySelector('.emoji-picker-grid');
@@ -15253,6 +15413,7 @@ function confirmLayerDelete() {
         layerInput
       });
       emojiInput.value = '';
+      mobileEmojiHue = 0;
       if (emojiWrapper) emojiWrapper.style.display = '';
       inactiveInput.checked = false;
       closedInput.checked = false;
@@ -15340,6 +15501,7 @@ function confirmLayerDelete() {
           kategoriaGlowna: mainCatInput.value,
           kategoria: catInput.value,
           emoji: emojiInput.value,
+          emojiHue: mobileEmojiHue,
           nieaktywne: inactiveInput.checked,
           zamkniete: closedInput.checked,
           tajne: secretInput.checked,


### PR DESCRIPTION
### Motivation
- Layer separators were flickering (missing or duplicated) during drag/drop because separators were added both via DOM <hr> elements and transient drag classes. 
- The layer list should have a single source of truth for separators (CSS on `.warstwa`) and avoid duplicated lines from drag/placeholder classes. 
- Emoji picker lacked a hue control for recoloring emoji previews and markers, and hue needed to be persisted per pin in Firestore as a separate field.

### Description
- Replaced DOM-inserted separators with a single CSS rule: each `.warstwa` renders a `border-bottom` and the last child has no border, and normalized drag/ghost/chosen styles so they do not add extra borders or shadows. 
- Removed insertion of `<hr class="layer-separator">` between layer DOM nodes and instead rely on `.warstwa { border-bottom: ... }`, and force a clean re-render of the layer list (`generujListeWarstw`) after native `dragend` and pointer-drag end to clear temporary classes. 
- Improved `setupDrag` to add/remove `dragging` on the layer element itself and to trigger a `requestAnimationFrame` re-render after drop/end so no temporary separators remain. 
- Added emoji hue support: `normalizeEmojiHue`, `getPinEmojiHue`, `emojiHueStyle`, and `createEmojiHueControls` utilities; hue slider + “Reset koloru” UI appended to emoji pickers (desktop, inline input picker and mobile picker) with live preview. 
- Applied `filter: hue-rotate(...)` to emoji previews and icons where possible (SVG/URL images via `<img>` and text emoji via span) and wired hue into `createEmojiIcon` so map markers, list items and popups respect the selected hue. 
- Persisted hue to Firestore as a separate `emojiHue` field (default `0` if absent) and included it in create/update payloads and offline helpers; editing flows load and preserve `emojiHue` unless user resets to `0`. 
- Ensured all changes preserve existing behavior: emoji URLs unchanged, `emojiHue` is stored separately (not embedded in the emoji link), and KML export/import flow remains compatible (emojiHue is a separate field and not required for KML rendering).

### Testing
- Ran `git diff --check` to ensure no whitespace/conflict markers and it passed. 
- Extracted inline JS and ran `node --check /tmp/index-inline.js` to validate inlined script syntax and it succeeded. 
- Ran `node --check firestore-setup.js` and `node --check offline-uploads.js` to validate the modified Firestore helper and offline code, both checks succeeded. 
- No headless browser UI tests were run in this environment because no browser was available, so visual verification of the picker/drag UI should be done during QA in a browser (changes add non-invasive CSS + re-render call to ensure separators are stable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265f50f2dc833098ea3b0cf22e6ce8)