### PR TITLE
Preserve layer collapse state when reordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -4221,6 +4221,7 @@ function slugify(str) {
     const warstwy = {};
     let wszystkiePinezki = [];
     let draggedLayer = null;
+    let layerDragCollapseStates = null;
     let highlightedItem = null;
     let highlightedMarker = null;
     let pinHighlightCircle = null;
@@ -10650,9 +10651,35 @@ function zaladujPinezkiZFirestore() {
       refreshCountriesFromPins();
     }
 
+    function getCurrentLayerCollapseStates() {
+      const states = {};
+      Object.entries(warstwy).forEach(([name, layerData]) => {
+        states[name] = !!layerData.collapsed;
+      });
+      return states;
+    }
+
+    function preserveLayerCollapseStatesForReorder() {
+      layerDragCollapseStates = getCurrentLayerCollapseStates();
+      saveLayerCollapseStates(layerDragCollapseStates);
+      return { ...layerDragCollapseStates };
+    }
+
+    function rerenderLayersAfterReorder() {
+      const collapseStates = layerDragCollapseStates ? { ...layerDragCollapseStates } : preserveLayerCollapseStatesForReorder();
+      requestAnimationFrame(() => {
+        generujListeWarstw({
+          deferMarkerVisibilityUpdate: true,
+          collapseStatesOverride: collapseStates
+        });
+        layerDragCollapseStates = null;
+      });
+    }
+
     function setupDrag(div, handle) {
       handle.draggable = true;
       handle.addEventListener('dragstart', () => {
+        layerDragCollapseStates = preserveLayerCollapseStatesForReorder();
         draggedLayer = div;
         handle.classList.add('dragging');
         div.classList.add('dragging');
@@ -10661,7 +10688,7 @@ function zaladujPinezkiZFirestore() {
         handle.classList.remove('dragging');
         div.classList.remove('dragging');
         draggedLayer = null;
-        requestAnimationFrame(() => generujListeWarstw({ deferMarkerVisibilityUpdate: true }));
+        rerenderLayersAfterReorder();
       });
       div.addEventListener('dragover', e => e.preventDefault());
       div.addEventListener('drop', e => {
@@ -10672,7 +10699,7 @@ function zaladujPinezkiZFirestore() {
           saveLayerOrder({ markChange: false });
           autosaveLayerOrderToFirestore(loadLayerOrder());
           updateLayerNumbers();
-          requestAnimationFrame(() => generujListeWarstw({ deferMarkerVisibilityUpdate: true }));
+          rerenderLayersAfterReorder();
         }
       });
 
@@ -10703,11 +10730,12 @@ function zaladujPinezkiZFirestore() {
         saveLayerOrder({ markChange: false });
         autosaveLayerOrderToFirestore(loadLayerOrder());
         updateLayerNumbers();
-        requestAnimationFrame(() => generujListeWarstw({ deferMarkerVisibilityUpdate: true }));
+        rerenderLayersAfterReorder();
       };
       handle.addEventListener('pointerdown', (event) => {
         if (event.button !== 0 && event.pointerType !== 'touch') return;
         event.preventDefault();
+        layerDragCollapseStates = preserveLayerCollapseStatesForReorder();
         draggedLayer = div;
         handle.classList.add('dragging');
         div.classList.add('dragging');
@@ -11490,8 +11518,10 @@ function zaladujPinezkiZFirestore() {
       orderInput.addEventListener('change', e => {
         const val = parseInt(orderInput.value, 10);
         if (!isNaN(val) && editedLayer) {
+          const collapseStates = getCurrentLayerCollapseStates();
           reorderLayer(editedLayer, val);
-          generujListeWarstw();
+          saveLayerCollapseStates(collapseStates);
+          generujListeWarstw({ collapseStatesOverride: collapseStates });
           orderInput.value = val;
         }
       });
@@ -13865,14 +13895,14 @@ function getTripPointEmoji(p) {
     }
 
     function generujListeWarstw(options = {}) {
-      const { deferMarkerVisibilityUpdate = false } = options;
+      const { deferMarkerVisibilityUpdate = false, collapseStatesOverride = null } = options;
       const sidebarRenderStartTs = performance.now();
       layerDomRefs = {};
       const lista = document.getElementById("lista-warstw");
       const pinTotalCounter = document.getElementById("pinTotalCounter");
       lista.innerHTML = "";
       const saved = loadLayerOrder();
-      const collapseStates = shouldIgnoreStoredLayerState ? {} : loadLayerCollapseStates();
+      const collapseStates = collapseStatesOverride || (shouldIgnoreStoredLayerState ? {} : loadLayerCollapseStates());
       const visibilityStates = shouldIgnoreStoredLayerState ? {} : loadLayerVisibilityStates();
       const nazwy = [...saved.filter(n => warstwy[n]), ...Object.keys(warstwy).filter(n => !saved.includes(n))];
       const tempLayers = nazwy.filter(n => warstwy[n].temporary);


### PR DESCRIPTION
### Motivation
- Przy zmianie kolejności warstw sidebar był przebudowywany i tracił aktualny stan zwinięcia/rozwinięcia, przez co zwinięte warstwy stawały się rozwinięte i odwrotnie.

### Description
- Dodano przechwycenie stanu zwinięcia warstw w zmiennej `layerDragCollapseStates` oraz funkcje pomocnicze `getCurrentLayerCollapseStates`, `preserveLayerCollapseStatesForReorder` i `rerenderLayersAfterReorder` w `index.html`.
- Zmieniono logikę drag&drop w `setupDrag` tak, by przed rozpoczęciem przeciągania zapisywać bieżące stany zwinięcia i po zakończeniu reorderu ponownie renderować listę warstw z wymuszonym `collapseStatesOverride` (zachowując wcześniej zapisany stan).
- `generujListeWarstw` otrzymuje teraz opcjonalny parametr `collapseStatesOverride` i używa go zamiast wczytywać domyślnie stany z `localStorage`, co pozwala przywrócić dokładny widok po reorderze.
- Zmiana kolejności z pola edycji (`layer editor` order input) również robi snapshot stanów i renderuje listę z `collapseStatesOverride`, a stany są zapisywane przez wywołanie `saveLayerCollapseStates`.

### Testing
- Uruchomiono statyczne sprawdzenie składni skryptów: `node --check /tmp/explomapa-scripts.js`, które zakończyło się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a266205cdc8833088f6c6c2e30eedf5)