### PR TITLE
Fix standard pin emoji display

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,9 +817,12 @@
       pointer-events: none !important;
     }
     .emoji-inline {
-width: 15px;
-    height: 15px;
-    vertical-align: TOP;
+      width: auto;
+      height: auto;
+      max-width: 1.4em;
+      max-height: 1em;
+      object-fit: contain;
+      vertical-align: -0.15em;
     }
     .hidden-text { display: none; }
 
@@ -3654,9 +3657,7 @@ body.mobile-layout #saveChanges {
     function sidebarEmojiForPin(pin = {}, layerName = '') {
       const layerEmoji = layerName && warstwy[layerName] ? warstwy[layerName].emoji : '';
       if (layerEmoji) return layerEmoji;
-      const emoji = pin.noweEmoji !== undefined ? pin.noweEmoji : pin.emoji;
-      if (isImplicitDefaultEmoji(pin) && isStandardEmoji(emoji)) return '';
-      return emoji;
+      return pin.noweEmoji !== undefined ? pin.noweEmoji : pin.emoji;
     }
 
     function normalizeEmojiHue(value) {


### PR DESCRIPTION
### Motivation
- Standard/default pin emoji was hidden in the sidebar for implicit-default pins and the standard emoji image in popups was stretched, so the UI should show the default emoji in the sidebar and preserve image proportions in popups.

### Description
- Adjusted `sidebarEmojiForPin` in `index.html` to return `pin.noweEmoji !== undefined ? pin.noweEmoji : pin.emoji` so the default/standard emoji is shown in the sidebar instead of being suppressed.
- Updated the `.emoji-inline` CSS in `index.html` to `width: auto; height: auto; max-width: 1.4em; max-height: 1em; object-fit: contain; vertical-align: -0.15em;` to stop stretching standard emoji images in popups and pickers.
- Change is limited to `index.html` and preserves existing emoji resolution and marker behavior.

### Testing
- Ran `node --check /tmp/explomapa-main-script.js` to validate the main script syntax and it succeeded.
- Ran `git diff --check` to check for whitespace/syntax diffs and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26807054b48330995257247eea6472)