### PR TITLE
Ujednolicenie loadera doczytywania pinezek

### DIFF
--- a/index.html
+++ b/index.html
@@ -1530,37 +1530,30 @@ text-shadow: 0 0 5px rgba(0, 0, 0, 1);
       position: fixed;
       left: 50%;
       top: 50%;
+      width: 58px;
+      height: 58px;
       transform: translate(-50%, -50%);
       z-index: 2147483590;
       align-items: center;
-      flex-direction: column;
-      gap: 6px;
-      padding: 12px 14px;
-      border: 1px solid rgba(255,255,255,0.22);
-      border-radius: 12px;
-      background: rgba(18, 20, 27, 0.84);
+      justify-content: center;
       color: #fff;
-      box-shadow: 0 10px 28px rgba(0,0,0,0.38);
-      backdrop-filter: blur(4px);
       pointer-events: none;
-      font-weight: 700;
+      font-weight: 800;
+      text-shadow: 0 1px 4px rgba(0, 0, 0, 0.9);
     }
     #pinViewportLoading .pin-loader {
-      width: 34px;
-      height: 34px;
-      border: 4px solid rgba(255,255,255,0.2);
+      position: absolute;
+      inset: 0;
+      border: 5px solid rgba(255,255,255,0.28);
       border-top-color: #58a1ff;
       border-radius: 50%;
       animation: spin 0.8s linear infinite;
     }
     #pinViewportLoadingPercent {
-      font-size: 14px;
+      position: relative;
+      z-index: 1;
+      font-size: 13px;
       line-height: 1;
-    }
-    #pinViewportLoading .pin-loading-label {
-      font-size: 11px;
-      opacity: 0.85;
-      white-space: nowrap;
     }
 #loading {
   position: fixed;
@@ -2881,7 +2874,7 @@ body.mobile-layout #saveChanges {
   <div id="toast"></div>
   <div id="ekran-logowania"><button id="loginBtn">Zaloguj się przez Google</button></div>
   <div id="loading"><div class="loader"></div></div>
-  <div id="pinViewportLoading" aria-live="polite"><div class="pin-loader"></div><div id="pinViewportLoadingPercent">0%</div><div class="pin-loading-label">Doczytywanie pinezek…</div></div>
+  <div id="pinViewportLoading" aria-live="polite"><div class="pin-loader"></div><div id="pinViewportLoadingPercent">0%</div></div>
   <div id="sidebar">
     <div id="sidebar-inner">
       <div class="sidebar-header">
@@ -4322,17 +4315,22 @@ function slugify(str) {
     let baseLayerLoadingCount = 0;
     let baseLayerLoadingHandler = null;
     let baseLayerLoadedHandler = null;
-    function showLoading() {
+    function isPinViewportLoadingVisible() {
+      const el = document.getElementById('pinViewportLoading');
+      return !!el && window.getComputedStyle(el).display !== 'none';
+    }
+    function syncMainLoadingVisibility() {
       const el = document.getElementById('loading');
-      if (loadingCount === 0 && el) el.style.display = 'block';
+      if (!el) return;
+      el.style.display = loadingCount > 0 && !isPinViewportLoadingVisible() ? 'block' : 'none';
+    }
+    function showLoading() {
       loadingCount++;
+      syncMainLoadingVisibility();
     }
     function hideLoading() {
       if (loadingCount > 0) loadingCount--;
-      if (loadingCount === 0) {
-        const el = document.getElementById('loading');
-        if (el) el.style.display = 'none';
-      }
+      syncMainLoadingVisibility();
     }
     function resetBaseLayerLoading() {
       if (baseLayerLoadingCount > 0) {
@@ -13932,6 +13930,7 @@ function getTripPointEmoji(p) {
         percentEl.textContent = `${Math.max(0, Math.min(100, Math.round(percent)))}%`;
       }
       el.style.display = 'flex';
+      syncMainLoadingVisibility();
     }
 
     function updatePinViewportLoadingProgress(processed, total) {
@@ -13947,6 +13946,7 @@ function getTripPointEmoji(p) {
       pinViewportLoadingHideTimer = setTimeout(() => {
         el.style.display = 'none';
         pinViewportLoadingHideTimer = null;
+        syncMainLoadingVisibility();
       }, delay);
     }
 


### PR DESCRIPTION
### Motivation
- Naprawić wyświetlanie dwóch kółek ładowania podczas przesuwania/zoomowania mapy przez ujednolicenie wskaźnika doczytywania pinezek.
- Usunąć panel tła i podpis „Doczytywanie pinezek…”, zostawić prosty spinner z procentami wyśrodkowanymi w środku kółka.
- Zapobiec jednoczesnemu pokazywaniu głównego loadera mapy i loadera pinezek, aby na ekranie był widoczny tylko jeden wskaźnik.

### Description
- Zmieniono styl `#pinViewportLoading` i `.pin-loader` w `index.html`, zmniejszono do jednego okrągłego spinnera bez tła/ramki i ustawiono procent w środku (usunięto `.pin-loading-label`).
- Usunięto tekstowy element loadera z markup’u i pozostawiono tylko spinner oraz element `#pinViewportLoadingPercent` w środku.
- Dodano funkcje `isPinViewportLoadingVisible` i `syncMainLoadingVisibility` oraz zintegrowano je ze `showLoading`/`hideLoading`, tak aby główny loader (`#loading`) nie był widoczny jednocześnie z loaderem pinezek.
- Wywołania `syncMainLoadingVisibility` dodano także w `showPinViewportLoading` i `hidePinViewportLoading`, aby synchronizacja była wykonywana przy pokazaniu/ukryciu loadera pinezek.

### Testing
- Uruchomiono `git diff --check` i sprawdzono brak problemów (sukces).
- Wykonano skrypty sprawdzające obecność/nieobecność elementów w `index.html` (sprawdzające usunięcie `pin-loading-label`, obecność `id="pinViewportLoadingPercent"` oraz `syncMainLoadingVisibility`) i wszystkie testy przeszły (PASS).
- Wykonano prosty smoke-test parsera HTML przy pomocy `html.parser` w Pythonie i zakończył się poprawnie.
- Nie wykonano screenshotów end-to-end, ponieważ w kontenerze nie ma zainstalowanej przeglądarki/narzędzi do zrzutów ekranu.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26af92d8ac833087e34321146fbcd0)