### PR TITLE
Align map marker status emoji positions with sidebar list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1467,12 +1467,14 @@ body:not(.trip-planner-mode) .trip-planner-panel {
 }
 .sztosy-gwiazda {
   position: absolute;
-  top: -8px;
-  right: 18px;
-  font-size: 18px;
-  padding: 1px;
+  top: auto;
+  right: -5px;
+  bottom: -3px;
+  font-size: 13px;
+  padding: 0;
   line-height: 1;
-  z-index: 10;
+  z-index: 21;
+  pointer-events: none;
 	/*
        filter: drop-shadow(0 0 0.2px red)
           drop-shadow(0 0 1px red)
@@ -1497,7 +1499,8 @@ body:not(.trip-planner-mode) .trip-planner-panel {
 }
 
 .sztosy {
-  top: -1px;
+  top: -4px;
+  right: -5px;
   bottom: auto;
   z-index: 20;
 }
@@ -1513,12 +1516,13 @@ body:not(.trip-planner-mode) .trip-planner-panel {
 
 	  .status-icon {
   position: absolute;
-  top: -6px;
-  right: -8px;
+  top: -4px;
+  right: -5px;
   bottom: auto;
   z-index: 20;
   line-height: 1;
-text-shadow: 0 0 5px rgba(0, 0, 0, 1);
+  pointer-events: none;
+  text-shadow: 0 0 3px rgba(0, 0, 0, 1), 0 0 1px rgba(0, 0, 0, 1);
 }
 
 .checkmark-obrys {
@@ -2792,12 +2796,24 @@ html body .emoji-marker img.emoji-obrys-sztosy {
 }
 
 html body .emoji-marker .status-icon {
+  top: -4px !important;
+  right: -5px !important;
+  bottom: auto !important;
   font-size: 12px !important;
   line-height: 1 !important;
 }
 
+html body .emoji-marker img.status-icon.checkmark-obrys {
+  width: 12px !important;
+  height: 12px !important;
+}
+
 html body .emoji-marker .sztosy-gwiazda {
-  font-size: 15px !important;
+  top: auto !important;
+  right: -5px !important;
+  bottom: -3px !important;
+  font-size: 13px !important;
+  line-height: 1 !important;
 }
 
 /* Trip special point modal: bez podwójnego skalowania */
@@ -6087,7 +6103,7 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
       emojiOrUrl = normalizePinEmojiValue(emojiOrUrl);
       const markerSize = 24;
       const scaledSize = markerSize;
-      const overlaySize = 15;
+      const overlaySize = 12;
       const isSztosy = warstwaId && warstwaId === sztosyId;
       const isHighlighted = isSztosy || status.wyroznione;
       if (warstwaId && warstwaId === orangeLayerId) {


### PR DESCRIPTION
### Motivation
- Sidebar pin list status emojis looked visually better and the map markers' status overlays were misaligned compared to the list. 
- The change aims to make map marker status badges (checkmark, star, other status icons) appear in positions and sizes closer to the sidebar representation for visual consistency.

### Description
- Adjusted CSS for map marker status elements including `.sztosy-gwiazda`, `.sztosy`, and `.status-icon` to move the highlight/star and status badges toward the marker's lower-right area and added `pointer-events: none` to avoid interaction interference. 
- Added explicit marker-scoped overrides under `html body .emoji-marker` to set `top/right/bottom` and normalized `font-size` for `.sztosy-gwiazda` and `.status-icon`, and added a rule to constrain the checkmark image size `html body .emoji-marker img.status-icon.checkmark-obrys`. 
- Reduced the generated overlay icon size used in `createEmojiIcon` from `15` to `12` so the badge scale matches the sidebar status icons better. 

### Testing
- Ran `git diff --check` to ensure no whitespace/diff issues and it passed. 
- Served the site locally and verified `curl -I http://127.0.0.1:8000/index.html` returned a 200 response. 
- Executed a Python presence check that validated the new CSS snippets and constants (`right: -5px;`, `bottom: -3px;`, `const overlaySize = 12;`, and the checkmark selector) and it succeeded. 
- Attempted headless/browser-based visual capture but no browser/runtime (Playwright/Chromium/Firefox) is available in the environment, so visual screenshot tests were not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27b0af19f08330831f08b283ce7a55)