### PR TITLE
Allow saving moving-mode pins without a manual name

### DIFF
--- a/index.html
+++ b/index.html
@@ -15642,12 +15642,23 @@ function confirmLayerDelete() {
     return true;
   }
 
+  async function resolveMovingPinName(name, location) {
+    const typedName = (name || '').trim();
+    if (typedName) return typedName;
+
+    const address = await resolveAddress(location.lat, location.lng);
+    if (address) return address;
+
+    return `Lokalizacja ${formatCoords(location.lat, location.lng)}`;
+  }
+
   async function saveMovingPin(name) {
     const capturedLocation = pendingMovingPinLocation;
     if (!capturedLocation) {
       alert('Brak aktualnej lokalizacji');
       return;
     }
+    const pinName = await resolveMovingPinName(name, capturedLocation);
     await ensureMovingLayer();
     if (warstwy['Tryb w ruchu']) {
       warstwy['Tryb w ruchu'].visible = true;
@@ -15658,7 +15669,7 @@ function confirmLayerDelete() {
         id: IDpinezki,
         IDpinezki,
         firebaseId: null,
-        nazwa: name,
+        nazwa: pinName,
         opis: '',
         warstwa: makeLayerKey('Tryb w ruchu', MAIN_CATEGORY_URBEX),
         warstwaId: movingLayerId,
@@ -15670,7 +15681,7 @@ function confirmLayerDelete() {
         lat: capturedLocation.lat,
         lng: capturedLocation.lng,
         dataDodania: Date.now(),
-        slug: slugify(name)
+        slug: slugify(pinName)
       };
     const markerLocation = [capturedLocation.lat, capturedLocation.lng];
     const marker = L.marker(markerLocation, {icon: createEmojiIcon('emoji39', movingLayerId)}).addTo(warstwy['Tryb w ruchu'].layer);
@@ -15958,7 +15969,7 @@ function confirmLayerDelete() {
       const name = nameInput.value.trim();
       const layer = layerInput.value.trim();
       const missing = [];
-      if (!name) missing.push('Wpisz nazwę pinezki');
+      if (currentTool === 'pin' && !name) missing.push('Wpisz nazwę pinezki');
       if (currentTool === 'pin' && !layer) missing.push('Wybierz warstwę');
       if (missing.length) { alert(missing.join('\n')); return; }
       if (currentTool === 'pin') {


### PR DESCRIPTION
### Motivation
- Mobile "Tryb w ruchu" flow should allow quickly saving a pin centered on the user's GPS without forcing manual name entry. 
- When name is omitted, the app should still populate a meaningful title so pins remain identifiable and slugs remain stable.

### Description
- Added `resolveMovingPinName(name, location)` which returns the typed name or falls back to `resolveAddress(lat,lng)` and finally to a coordinate label via `formatCoords` if no address is available.
- `saveMovingPin` now awaits `resolveMovingPinName(...)` and uses the resulting `pinName` for the `nazwa` and `slug` fields when creating the moving pin.
- Relaxed mobile modal validation so the empty-name check runs only when `currentTool === 'pin'` (center-pin mode), allowing the moving-mode save button to be clicked with an empty name.

### Testing
- Ran `git diff --check` to ensure no whitespace/format issues and it completed successfully.
- Changes were committed to the branch (commit message: `Allow moving pins without manual names`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a281027a3408330a23c3fe659e35b3b)