### PR TITLE
Update mobile save pin button behavior and labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -5930,6 +5930,7 @@ function slugify(str) {
           cm.style.display = 'none';
         }
       }
+      if (typeof window.updateMobileSavePinButton === 'function') window.updateMobileSavePinButton();
     }
     if (handBtn) handBtn.addEventListener("click", () => selectTool("hand"));
 if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
@@ -15521,6 +15522,7 @@ function confirmLayerDelete() {
     followGps = false;
     const gpsBtn = document.getElementById('gpsFollowBtn');
     if (gpsBtn) gpsBtn.style.display = 'block';
+    if (typeof window.updateMobileSavePinButton === 'function') window.updateMobileSavePinButton();
     if (reason) console.log('GPS follow disabled:', reason);
   }
 
@@ -15566,6 +15568,7 @@ function confirmLayerDelete() {
       if (followGps) {
         map.setView(currentLocation, map.getZoom());
       }
+      if (typeof window.updateMobileSavePinButton === 'function') window.updateMobileSavePinButton();
       if (isMobile && gpsLoading) {
         gpsLoading.style.display = 'none';
       }
@@ -15830,6 +15833,20 @@ function confirmLayerDelete() {
       const mobilePhotoGallery = document.getElementById('mobilePinPhotoGallery');
       const mobileAddPhotoBtn = document.getElementById('mobilePinAddPhotoBtn');
       if (!btn || !modal || !ok || !cancel || !nameInput || !trudInput || !trudLabel || !trudWrapper) return;
+
+      function updateMobileSavePinButton() {
+        if (!btn) return;
+        const isMobileViewport = window.innerWidth <= 800;
+        const pinToolActive = currentTool === 'pin';
+        const gpsPositionCentered = followGps && Array.isArray(currentLocation);
+        const shouldShow = isMobileViewport && (pinToolActive || gpsPositionCentered);
+        btn.style.display = shouldShow ? 'block' : 'none';
+        btn.textContent = pinToolActive ? 'ZAPISZ PINEZKĘ' : 'ZAPISZ POZYCJĘ';
+      }
+      window.updateMobileSavePinButton = updateMobileSavePinButton;
+      window.addEventListener('resize', updateMobileSavePinButton);
+      updateMobileSavePinButton();
+
       setupTrudnoscInput(trudInput, trudLabel);
       const mobileDraftPhotosSlug = '__mobile_pin_draft__';
       if (mobilePhotoGallery) {
@@ -16026,6 +16043,7 @@ function confirmLayerDelete() {
         if (currentLocation) {
           map.setView(currentLocation, map.getZoom());
         }
+        updateMobileSavePinButton();
       });
     }
   }
@@ -16069,7 +16087,7 @@ function confirmLayerDelete() {
     <img id="photoModalImg" src="">
   </div>
   <img id="centerMarker" src="https://maps.gstatic.com/mapfiles/api-3/images/spotlight-poi2.png" alt="center marker">
-  <button id="savePinBtn">ZAPISZ PIN</button>
+  <button id="savePinBtn">ZAPISZ POZYCJĘ</button>
   <div id="pinSavedMessage">Zapisano pinezkę</div>
   <div id="gpsLoadingMessage">Wczytuję lokalizację GPS...</div>
   <div id="osmOverlayStatus" class="osm-status-loading">Wczytywanie miejsc OSM dla aktualnego obszaru…</div>

--- a/style.css
+++ b/style.css
@@ -281,7 +281,7 @@
 }
 
 @media (max-width: 800px) {
-  #savePinBtn { display: block; z-index: 250; }
+  #savePinBtn { z-index: 250; }
 }
 
 #centerMarker {


### PR DESCRIPTION
### Motivation
- Improve mobile UX by showing the save button only when it is meaningful (GPS is centered or the pin-adding tool is active) and by using clearer, context-aware labels.
- Avoid CSS forcing visibility so JavaScript can fully control when the button is shown and its text.

### Description
- Added `updateMobileSavePinButton()` and exposed it as `window.updateMobileSavePinButton` to centralize mobile save button state and text logic in `index.html`.
- Button is now visible on mobile only when `window.innerWidth <= 800` and either `currentTool === 'pin'` or GPS is centered (`followGps && currentLocation`), and the label switches between `ZAPISZ PINEZKĘ` (pin tool active) and `ZAPISZ POZYCJĘ` (GPS mode).
- Hooked the update function into relevant places: `selectTool(...)`, `stopGpsFollow(...)`, `initGeolocation()` position updates, GPS follow button handler, and `resize` events so the UI stays synchronized with tool and location changes.
- Renamed the default button text in the markup from `ZAPISZ PIN` to `ZAPISZ POZYCJĘ` and removed the CSS rule that forcibly displayed the button on mobile in `style.css` so visibility is JS-driven.
- Modified files: `index.html`, `style.css`.

### Testing
- Ran `git diff --check` to ensure no whitespace errors and it passed.
- Changes were committed (`Update mobile save pin button behavior`).
- No automated unit/integration test suite was available or executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28150d75b483308cfc237eb0b7fc58)