### PR TITLE
Ukryj mobilny zapis pozycji do czasu GPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -15956,7 +15956,7 @@ function confirmLayerDelete() {
       }
 
     if (window.innerWidth <= 800) {
-      btn.style.display = 'block';
+      updateMobileSavePinButton();
       if (typeof map !== 'undefined' && map) {
         initGeolocation();
       } else {


### PR DESCRIPTION
### Motivation
- On mobile the `ZAPISZ POZYCJĘ` button was shown unconditionally before a GPS fix was available; the intended behavior is to show it only when the app has a current GPS position (or when the pin tool is active).

### Description
- Replace the unconditional `btn.style.display = 'block'` with a call to `updateMobileSavePinButton()` so the existing visibility logic (which checks `currentLocation` / `followGps` and `currentTool`) controls when the button appears, while `initGeolocation()` is still invoked for mobile.

### Testing
- Ran a `python3` assertion that verifies the old `btn.style.display = 'block'` string is gone and the GPS-gating expressions (`gpsPositionCentered` / `shouldShow`) remain, which passed. 
- Ran `git diff --check` which reported no problems. 
- Attempted `node --check index.html` but Node cannot syntax-check `.html` files in this repository setup, so this check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a281a29d884833092e3663b5efa6e18)