### PR TITLE
Ensure pin popup opens from layer list by making layer/marker ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -11147,11 +11147,30 @@ function zaladujPinezkiZFirestore() {
       const layerName = p.warstwa || "Inne";
       const layerData = warstwy[layerName];
       if (layerData && !p.marker) createLeafletMarkerForPin(p, layerName);
-      if (layerData && p.marker && typeof layerData.layer?.hasLayer === 'function' && !layerData.layer.hasLayer(p.marker)) {
-        layerData.layer.addLayer(p.marker);
-      }
+
+      const ensurePinLayerReady = () => {
+        if (!layerData || !p.marker || !layerData.layer) return false;
+        if (layerData.visible === false) {
+          layerData.visible = true;
+          const layerSection = Array.from(document.querySelectorAll('#lista-warstw .warstwa'))
+            .find(section => section.dataset.nazwa === layerName);
+          const layerCheckbox = layerSection ? layerSection.querySelector('input[type="checkbox"]') : null;
+          if (layerCheckbox) layerCheckbox.checked = true;
+          setLayerVisibilityState(layerName, true);
+        }
+        if (!map.hasLayer(layerData.layer) && typeof layerData.layer.addTo === 'function') {
+          layerData.layer.addTo(map);
+        }
+        if (typeof layerData.layer.hasLayer === 'function' && !layerData.layer.hasLayer(p.marker)) {
+          layerData.layer.addLayer(p.marker);
+        }
+        return true;
+      };
+
+      ensurePinLayerReady();
       const openPopupForPin = () => {
         updateMarkerVisibility();
+        ensurePinLayerReady();
         if (!p.marker || !layerData || typeof layerData.layer.zoomToShowLayer !== 'function') {
           if (p.marker) {
             openPinViewPopup(p.marker, p);
@@ -11160,6 +11179,7 @@ function zaladujPinezkiZFirestore() {
           return;
         }
         layerData.layer.zoomToShowLayer(p.marker, () => {
+          ensurePinLayerReady();
           openPinViewPopup(p.marker, p);
           rebindPinPopupAfterOpen(p.marker, p);
         });


### PR DESCRIPTION
### Motivation

- Clicking a pin in the layers sidebar sometimes failed to open the pin popup because the pin's marker or its layer could be hidden/not attached (lazy loading + clustering race). 

### Description

- Modified `index.html` to add an `ensurePinLayerReady` helper inside `openPinFromList` that ensures the target layer and marker are present on the map before attempting to open a popup. 
- The helper makes the layer visible if it was hidden, updates the layer checkbox in the sidebar, persists visibility via `setLayerVisibilityState`, adds the layer to the map, and re-adds the marker to the layer if needed. 
- Calls to `ensurePinLayerReady` were added before and after the marker visibility refresh and immediately before `zoomToShowLayer` to avoid race conditions with lazy marker creation / MarkerCluster. 

### Testing

- Ran `node --check /tmp/index-main-script.js` to verify the extracted non-module script parses correctly, and it succeeded. 
- Ran `node --check /tmp/index-module-script.js` to verify the module script parses correctly, and it succeeded. 
- Ran `git diff --check` to ensure no whitespace/merge issues, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2954d492f8833087a0e3a17bb2d212)