### PR TITLE
Compact desktop map popups (style.css overrides)

### DIFF
--- a/style.css
+++ b/style.css
@@ -1108,3 +1108,105 @@ html body .popup-container .popup-route-actions .popup-direct-route-btn:hover {
     grid-template-columns: 1fr;
   }
 }
+
+/* Compact desktop pin popup sizing overrides */
+@media (min-width: 701px) {
+  html body .leaflet-popup-content {
+    width: 340px !important;
+    max-width: 340px !important;
+  }
+
+  html body .popup-container {
+    padding: 12px !important;
+    gap: 7px !important;
+  }
+
+  html body .popup-title,
+  html body .popup-card-title,
+  html body .popup-pin-title {
+    font-size: 18px !important;
+    line-height: 1.2 !important;
+  }
+
+  html body .popup-status-line {
+    font-size: 12px !important;
+    line-height: 1.25 !important;
+    margin-bottom: 4px !important;
+  }
+
+  html body .popup-section-label {
+    font-size: 10px !important;
+    margin-bottom: 4px !important;
+  }
+
+  html body .popup-description {
+    font-size: 13px !important;
+    line-height: 1.35 !important;
+  }
+
+  html body .popup-google-card,
+  html body .popup-chatgpt-btn {
+    min-height: 34px !important;
+    height: 34px !important;
+    padding: 6px 10px !important;
+    font-size: 13px !important;
+    border-radius: 8px !important;
+  }
+
+  html body .popup-details summary {
+    min-height: 34px !important;
+    height: 34px !important;
+    padding: 6px 10px !important;
+    font-size: 13px !important;
+  }
+
+  html body .popup-details {
+    border-radius: 8px !important;
+  }
+
+  html body .popup-route-actions {
+    gap: 8px !important;
+  }
+
+  html body .popup-route-actions button,
+  html body .popup-route-actions .popup-route-btn,
+  html body .popup-route-actions .popup-direct-route-btn {
+    height: 38px !important;
+    min-height: 38px !important;
+    padding: 5px 8px !important;
+    font-size: 13px !important;
+    border-radius: 8px !important;
+  }
+
+  html body .popup-edit-btn,
+  html body .popup-delete-btn {
+    width: 34px !important;
+    height: 34px !important;
+    min-height: 34px !important;
+    padding: 0 !important;
+    border-radius: 8px !important;
+  }
+
+  html body .popup-soft-separator {
+    margin: 4px 0 !important;
+  }
+}
+
+@media (max-width: 700px) {
+  html body .leaflet-popup-content {
+    width: min(92vw, 430px) !important;
+    max-width: min(92vw, 430px) !important;
+  }
+
+  html body .popup-container {
+    padding: 16px !important;
+    gap: 10px !important;
+  }
+
+  html body .popup-route-actions button,
+  html body .popup-route-actions .popup-route-btn,
+  html body .popup-route-actions .popup-direct-route-btn {
+    min-height: 46px !important;
+    font-size: 15px !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- Desktop popups were rendering at mobile/modal scale instead of a compact sidebar size, so responsive CSS overrides were needed to force a compact layout on larger viewports.
- The change ensures desktop popups use tighter spacing, smaller typography and smaller controls while preserving larger, touch-friendly sizing on mobile.

### Description
- Appended a responsive override block to `style.css` that adds `@media (min-width: 701px)` rules forcing `.leaflet-popup-content` to `width: 340px` and `max-width: 340px` for compact desktop popups.
- Reduced padding/gap on the popup container and adjusted typography: `.popup-title`/`.popup-card-title`/`.popup-pin-title` to `18px`, `.popup-status-line` to `12px`, `.popup-section-label` to `10px`, and `.popup-description` to `13px` with specified line-heights.
- Made controls more compact by sizing `.popup-google-card` and `.popup-chatgpt-btn` to `34px` height with `6px 10px` padding, `.popup-details summary` to `34px`, route action buttons to `38px` height in a 2x2 grid, and limiting edit/delete icon buttons to `34x34`.
- Kept mobile rules under `@media (max-width: 700px)` intact and explicit, setting popup width to `min(92vw, 430px)` and keeping larger padding and tap targets for mobile.

### Testing
- Ran `git diff --check` which completed without errors.
- Ran an inline Python check that validated presence of the expected responsive rules (strings like `width: 340px !important;`, `@media (min-width: 701px)`, `@media (max-width: 700px)`, and `width: min(92vw, 430px) !important;`) and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29617792fc83309240999f80f35e5a)