### PR TITLE
Poprawki popupów pinezek — układ, ikony i styl

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-05-31-zoom-1" />
+  <link rel="stylesheet" href="style.css?v=2026-06-11-popup-fixes-1" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -7145,8 +7145,21 @@ function emojiHtml(str, hue = 0) {
     function createPopupHtml(p) {
       const slug = p.slug || slugify(p.nazwa || '');
       const layerLabel = resolveLayerInfo(p.warstwa, p.warstwaId, getPinMainCategory(p)).displayName || 'Inne';
+      const pinName = String(p.nazwa || 'Bez nazwy');
+      const escapedPinName = escapeHtml(pinName);
+      const longTitleClass = pinName.length > 34 ? ' popup-card-title-long' : '';
+      const sanitizedDescription = sanitizeOpis(p.opis);
+      const descriptionHtml = sanitizedDescription ? (() => {
+        const shouldScroll = sanitizedDescription.length > 100;
+        return `
+        <section class="popup-description-section">
+          <div class="popup-section-label">Opis</div>
+          <div class="popup-description${shouldScroll ? ' scrollable' : ''}">${linkify(p.opis)}</div>
+        </section>`;
+      })() : '';
+      const popupIcon = (path) => `<span class="popup-action-svg" style="--popup-icon-url: url('${path}')" aria-hidden="true"></span>`;
       const trudHtml = p.trudnosc !== undefined ?
-        `<span class="trudnosc-text" id="trudnoscLabel-${p.id}" style="color:${trudnoscColor(p.trudnosc)}">Poziom trudności: ${trudnoscText(p.trudnosc)}</span>` : '';
+        `<span class="trudnosc-text" id="trudnoscLabel-${p.id}">Poziom trudności: ${trudnoscText(p.trudnosc)}</span>` : '';
       const statusItems = [
         (p.niedostepne || p.nieaktywne) ? 'Niedostępne ⛔' : '',
         p.zamkniete ? 'Zamknięte 🔐' : '',
@@ -7156,27 +7169,19 @@ function emojiHtml(str, hue = 0) {
         p.zwiedzone ? 'Zwiedzone <img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Green_check.svg" width="16" height="16" class="checkmark-obrys">' : '',
         p.wyroznione ? 'Wyróżnione ⭐' : ''
       ].filter(Boolean);
-      const statusHtml = statusItems.map(item => `<span class="popup-status-item">${item}</span>`).join('<span class="popup-status-separator">•</span>');
-      const statusLineHtml = [trudHtml, statusHtml].filter(Boolean).join('<span class="popup-status-separator">•</span>');
+      const statusHtml = statusItems.length ? `<span class="popup-status-row">${statusItems.map(item => `<span class="popup-status-item">${item}</span>`).join('')}</span>` : '';
+      const statusLineHtml = [trudHtml, statusHtml].filter(Boolean).join('');
       return `
         <div class="photo-gallery" data-slug="${slug}"></div>
         <div class="popup-card-header">
-          <div class="popup-card-title">${p.emoji ? emojiHtml(p.emoji, getPinEmojiHue(p)) + ' ' : ''}<b>${p.nazwa}</b></div>
+          <div class="popup-card-title${longTitleClass}" title="${escapedPinName}">${p.emoji ? emojiHtml(p.emoji, getPinEmojiHue(p)) + ' ' : ''}<b>${escapedPinName}</b></div>
           <div class="popup-edit-row">
             <button class="popup-edit-btn popup-edit-pin-btn" title="Edytuj pinezkę">✏️</button>
             <button class="popup-edit-btn popup-delete-btn" title="Usuń pinezkę">🗑️</button>
           </div>
         </div>
         <div class="popup-status-line">${statusLineHtml}</div>
-        <div class="popup-soft-separator"></div>
-        <section class="popup-description-section">
-          <div class="popup-section-label">Opis</div>
-          ${(() => {
-            const sanitized = sanitizeOpis(p.opis);
-            const shouldScroll = sanitized && sanitized.length > 100;
-            return `<div class="popup-description${shouldScroll ? ' scrollable' : ''}">${linkify(p.opis)}</div>`;
-          })()}
-        </section>
+        <div class="popup-soft-separator"></div>${descriptionHtml}
         <a class="popup-google-card" href="https://maps.google.com/?q=${p.lat},${p.lng}" target="_blank" rel="noopener noreferrer">
           <span class="popup-action-icon">📍</span>
           <span>Google Maps</span>
@@ -7196,10 +7201,10 @@ function emojiHtml(str, hue = 0) {
           </div>
         </details>
         <div class="popup-route-actions">
-          <button class="popup-route-btn popup-route-add-btn">Dodaj trasę</button>
-          <button class="popup-direct-route-btn popup-route-direct-btn">Wyznacz trasę do</button>
-          <button class="popup-route-btn popup-plan-btn">Dodaj plan</button>
-          <button class="popup-route-btn popup-trip-add-btn">+ Do tripa</button>
+          <button class="popup-route-btn popup-route-add-btn">${popupIcon('icons/route.svg')}<span>Dodaj trasę</span></button>
+          <button class="popup-direct-route-btn popup-route-direct-btn">${popupIcon('icons/route-add.svg')}<span>Wyznacz trasę do</span></button>
+          <button class="popup-route-btn popup-plan-btn">${popupIcon('icons/blueprint-grid.svg')}<span>Dodaj plan</span></button>
+          <button class="popup-route-btn popup-trip-add-btn">${popupIcon('icons/backpack.svg')}<span>+ Do tripa</span></button>
         </div>
       `;
     }
@@ -10186,10 +10191,12 @@ function zaladujPinezkiZFirestore() {
           </div>
           <div class="trudnosc-value" id="etrudnoscLabel" style="color:${trudnoscColor(p.trudnosc ?? 0)}">${trudnoscText(p.trudnosc ?? 0)}</div>
         </div>
-        <button id="movePinBtn-${id}">📍 Zmień położenie</button>
-        ${hasEditablePinPlans(p) ? `<button id="editPinPlanBtn-${id}" type="button">🗺️ Edytuj plan</button>` : ''}
-        <button onclick="zapiszLokalnie('${id}')">💾 Zapisz</button>
-        <button id="deleteBtn-${id}">🗑️</button>
+        ${hasEditablePinPlans(p) ? `<button id="editPinPlanBtn-${id}" type="button" class="edit-popup-plan-btn">🗺️ Edytuj plan</button>` : ''}
+        <div class="edit-popup-action-row">
+          <button id="movePinBtn-${id}" type="button" class="edit-popup-move-btn">📍 Zmień położenie</button>
+          <button id="deleteBtn-${id}" type="button" class="edit-popup-delete-btn">🗑️ Usuń</button>
+        </div>
+        <button class="edit-popup-save-btn" onclick="zapiszLokalnie('${id}')">💾 Zapisz</button>
       `;
       L.DomEvent.disableClickPropagation(container);
       const eOpisInput = container.querySelector('#eopis');
@@ -12092,14 +12099,21 @@ function showRoutePopup(pinId, tr, latlng) {
       searchMarker = L.marker(latlng, {icon: greenIcon}).addTo(searchLayer.layer);
       const coordsDisplay = formatCoords(latNum, lngNum);
       const container = document.createElement('div');
+      container.className = 'popup-container search-result-popup';
       container.innerHTML = `
-        <div>${label}</div>
-        <div>${coordsDisplay}</div>
-        <div class="popup-info-item"><a href="https://maps.google.com/?q=${latNum},${lngNum}" target="_blank" rel="noopener noreferrer">📍 Google Maps</a></div>
+        <div class="popup-card-header">
+          <div class="popup-card-title search-result-title" title="${escapeHtml(label)}"><b>${escapeHtml(label)}</b></div>
+        </div>
+        <div class="popup-status-line"><span class="popup-status-item">${coordsDisplay}</span></div>
+        <a class="popup-google-card" href="https://maps.google.com/?q=${latNum},${lngNum}" target="_blank" rel="noopener noreferrer">
+          <span class="popup-action-icon">📍</span>
+          <span>Google Maps</span>
+          <span class="popup-external-icon">↗</span>
+        </a>
         <div class="popup-route-actions">
-          <button class="popup-direct-route-btn" id="routeSearchBtn">Wyznacz trasę do</button>
+          <button class="popup-direct-route-btn" id="routeSearchBtn"><span class="popup-action-svg" style="--popup-icon-url: url('icons/route-add.svg')" aria-hidden="true"></span><span>Wyznacz trasę do</span></button>
           <button class="popup-route-btn" id="addSearchPin">dodaj pinezkę</button>
-          <button class="popup-route-btn" id="addSearchToTripBtn">+ Do tripa</button>
+          <button class="popup-route-btn" id="addSearchToTripBtn"><span class="popup-action-svg" style="--popup-icon-url: url('icons/backpack.svg')" aria-hidden="true"></span><span>+ Do tripa</span></button>
         </div>`;
       searchMarker.bindPopup(container).openPopup();
       container.querySelector('#addSearchPin').addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -1210,3 +1210,146 @@ html body .popup-container .popup-route-actions .popup-direct-route-btn:hover {
     font-size: 15px !important;
   }
 }
+
+/* Popup pinezki: kompaktowy nagłówek, statusy i akcje */
+html body .popup-card-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 15px !important;
+  line-height: 1.18 !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+html body .popup-card-title.popup-card-title-long {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+  overflow-wrap: anywhere;
+}
+
+html body .popup-status-line {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  color: rgba(226, 232, 240, 0.88) !important;
+}
+
+html body .popup-status-line .trudnosc-text {
+  color: inherit !important;
+  font-weight: 700;
+}
+
+html body .popup-status-item {
+  margin-right: 8px;
+}
+
+html body .popup-status-separator {
+  display: none !important;
+}
+
+html body .popup-details summary,
+html body .popup-container .popup-details summary {
+  min-height: 28px !important;
+  height: 28px !important;
+  padding: 4px 9px !important;
+  font-size: 12px !important;
+  line-height: 1.1 !important;
+}
+
+html body .popup-details-count {
+  min-width: 17px;
+  height: 17px;
+  font-size: 10px;
+}
+
+html body .popup-action-svg {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  display: inline-block;
+  background: #ff3b3b;
+  -webkit-mask: var(--popup-icon-url) center / contain no-repeat;
+  mask: var(--popup-icon-url) center / contain no-repeat;
+}
+
+html body .popup-route-actions button,
+html body .popup-route-actions .popup-route-btn,
+html body .popup-route-actions .popup-direct-route-btn,
+html body .popup-container .popup-route-actions button,
+html body .popup-container .popup-route-actions .popup-route-btn,
+html body .popup-container .popup-route-actions .popup-direct-route-btn {
+  gap: 5px;
+  min-height: 38px !important;
+  height: 38px !important;
+  padding: 5px 7px !important;
+  font-size: 12px !important;
+  line-height: 1.05 !important;
+  vertical-align: middle;
+}
+
+html body .popup-route-actions button span:not(.popup-action-svg) {
+  min-width: 0;
+}
+
+html body .search-result-popup .popup-card-header {
+  align-items: center;
+}
+
+html body .search-result-popup .search-result-title {
+  white-space: normal;
+  overflow-wrap: normal;
+}
+
+html body .search-result-popup .popup-route-actions {
+  grid-template-columns: 1fr;
+}
+
+html body .edit-popup .edit-popup-action-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  width: 100%;
+}
+
+html body .edit-popup .edit-popup-action-row button,
+html body .edit-popup .edit-popup-save-btn,
+html body .edit-popup .edit-popup-plan-btn {
+  min-height: 34px;
+  border-radius: 8px;
+}
+
+html body .edit-popup .edit-popup-delete-btn {
+  min-width: 86px;
+}
+
+html body .edit-popup .edit-popup-save-btn {
+  width: 100%;
+}
+
+@media (max-width: 700px) {
+  html body .popup-card-title {
+    font-size: 14px !important;
+  }
+
+  html body .popup-route-actions button,
+  html body .popup-route-actions .popup-route-btn,
+  html body .popup-route-actions .popup-direct-route-btn,
+  html body .popup-container .popup-route-actions button,
+  html body .popup-container .popup-route-actions .popup-route-btn,
+  html body .popup-container .popup-route-actions .popup-direct-route-btn {
+    min-height: 40px !important;
+    height: 40px !important;
+    font-size: 12px !important;
+  }
+}
+
+html body .popup-status-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px 8px;
+}


### PR DESCRIPTION
### Motivation
- Uporządkować i uprościć wygląd popupu pinezki: tytuł ma być bardziej kompaktowy, status ma być pod poziomem trudności, a nagłówek „Opis” nie powinien się pojawiać gdy brak treści.
- Dostosować wygląd przycisków akcji (mniej „zapchane”), dodać ikony i poprawić popup wyszukanego adresu, aby był spójny ze stylem pinezki.
- Ułatwić edycję pinezki przez przegrupowanie przycisków w popupie edycji (przenieść „Zmień położenie” i dodać etykietę „Usuń”).

### Description
- Zmieniono tworzenie HTML popupu w `createPopupHtml(p)` tak, że tytuł jest skrócony/niezłamywany (z klasą `popup-card-title-long` dla bardzo długich nazw), statusy są renderowane pod poziomem trudności i separator-kropka między nimi usunięto; nagłówek „Opis” dołączany jest tylko gdy `sanitizeOpis(p.opis)` zwraca treść. (`index.html`)
- Dodano czerwone ikony SVG przy akcjach: `icons/route.svg`, `icons/route-add.svg`, `icons/blueprint-grid.svg`, `icons/backpack.svg` oraz mały wrapper `popup-action-svg` i dopasowany HTML (ikonka + tekst). (`index.html`, dod. CSS)
- Przebudowano popup edycji: przyciski zostały ułożone w rząd `edit-popup-action-row` z `move` po lewej i `Usuń` (z napisem) po prawej oraz szeroki przycisk `Zapisz` pod nimi; `Zmień położenie` ma teraz klasę `edit-popup-move-btn`. (`index.html`, dod. CSS)
- Odświeżono popup wyszukanego adresu, aby używał `popup-card-header`, pokazywał nazwę, współrzędne i link do Google Maps w tym samym stylu co pinezka oraz dodał ikony akcji. (`index.html`)
- Dodano nowe reguły CSS w `style.css` dla: kompaktowego tytułu (`.popup-card-title`), statusów (`.popup-status-line`, `.popup-status-row`), ikon akcji (`.popup-action-svg`), mniejszych/ciaśniejszych przycisków akcji i układu przycisków edycyjnych; zwiększono responsywność i zachowano dotychczasowe breakpointy.
- Zaktualizowano cache-buster stylów w `index.html` na `style.css?v=2026-06-11-popup-fixes-1` by wymusić odświeżenie stylów.

### Testing
- `node --check /tmp/explomapa-script-12.js && node --check /tmp/explomapa-script-13.js` — sprawdzono poprawność składni osadzonych skryptów JavaScript i zakończono sukcesem.
- Sprawdzono istnienie ikon poleceniem Python (lista plików `icons/route.svg`, `icons/route-add.svg`, `icons/blueprint-grid.svg`, `icons/backpack.svg`) — wszystkie pliki istnieją i test przeszedł pomyślnie.
- Próba uruchomienia przeglądarkowych testów/screenshotu z `playwright` nie była możliwa, ponieważ `playwright`/przeglądarka są niedostępne w środowisku (brak testu wizualnego).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a5a533a748330abc3cb2e652e85f0)