### PR TITLE
Fix popups: add location icon, equalize edit buttons, and prevent mobile autopan

### DIFF
--- a/icons/location.svg
+++ b/icons/location.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20 10c0 6-8 12-8 12S4 16 4 10a8 8 0 1 1 16 0Z"/>
+  <circle cx="12" cy="10" r="3"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-11-popup-fixes-1" />
+  <link rel="stylesheet" href="style.css?v=2026-06-11-popup-fixes-2" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -8186,6 +8186,13 @@ function emojiHtml(str, hue = 0) {
         // Utrzymuj pełną skalę popupu — CSS zoom potrafi rozjechać hitboxy przycisków
         // (np. edycja/usuwanie) na części przeglądarek i poziomów mapy.
         popupEl.style.zoom = '';
+        if (mobileLayout) {
+          popup._autoPanHandledToken = token;
+          popupAutoPanState.lastRunTs = Date.now();
+          popupAutoPanState.duringAutoPan = false;
+          return;
+        }
+
         const popupRect = popupEl.getBoundingClientRect();
 
         let dx = 0;
@@ -12112,7 +12119,7 @@ function showRoutePopup(pinId, tr, latlng) {
         </a>
         <div class="popup-route-actions">
           <button class="popup-direct-route-btn" id="routeSearchBtn"><span class="popup-action-svg" style="--popup-icon-url: url('icons/route-add.svg')" aria-hidden="true"></span><span>Wyznacz trasę do</span></button>
-          <button class="popup-route-btn" id="addSearchPin">dodaj pinezkę</button>
+          <button class="popup-route-btn" id="addSearchPin"><span class="popup-action-svg" style="--popup-icon-url: url('icons/location.svg')" aria-hidden="true"></span><span>Dodaj pinezkę</span></button>
           <button class="popup-route-btn" id="addSearchToTripBtn"><span class="popup-action-svg" style="--popup-icon-url: url('icons/backpack.svg')" aria-hidden="true"></span><span>+ Do tripa</span></button>
         </div>`;
       searchMarker.bindPopup(container).openPopup();

--- a/style.css
+++ b/style.css
@@ -1311,7 +1311,7 @@ html body .search-result-popup .popup-route-actions {
 
 html body .edit-popup .edit-popup-action-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
   width: 100%;
 }
@@ -1323,8 +1323,10 @@ html body .edit-popup .edit-popup-plan-btn {
   border-radius: 8px;
 }
 
+html body .edit-popup .edit-popup-move-btn,
 html body .edit-popup .edit-popup-delete-btn {
-  min-width: 86px;
+  min-width: 0;
+  width: 100%;
 }
 
 html body .edit-popup .edit-popup-save-btn {


### PR DESCRIPTION
### Motivation
- Ułatwić dodawanie pinezki z wyniku wyszukiwania przez pokazanie czerwonej ikony przy akcji "Dodaj pinezkę". 
- Ujednolicić wygląd popupu edycji tak, aby przyciski „Zmień położenie” i „Usuń” miały tę samą szerokość i odstęp był symetryczny. 
- Naprawić krytyczny problem na urządzeniach mobilnych, gdzie tapnięcie markera powodowało przesunięcie mapy w nieoczekiwane miejsce zamiast otwarcia popupu. 

### Description
- Dodano nowy plik `icons/location.svg` i użyto go w popupie wyszukiwanych adresów, zmieniając przycisk `#addSearchPin` na zawierający ikonę: `<span class="popup-action-svg" style="--popup-icon-url: url('icons/location.svg')"></span>` (w `index.html`).
- W `index.html` w funkcji autopanowania popupu dodano wczesny zwrot dla układu mobilnego (`if (mobileLayout) { ... return; }`) żeby wyłączyć niestandardowe autopanowanie na mobilnych widokach i zapobiec przesuwaniu mapy.
- W `style.css` zmieniono układ akcji edycji popupu na równą siatkę dwóch kolumn (`grid-template-columns: repeat(2, minmax(0, 1fr));`) i ustawiono przyciskom edycyjnym (`.edit-popup-move-btn`, `.edit-popup-delete-btn`) `width: 100%` aby miały tę samą szerokość.
- Zaktualizowano parametr cache w linku do `style.css` (`?v=2026-06-11-popup-fixes-2`) aby wymusić odświeżenie stylów w przeglądarkach.

### Testing
- Uruchomiono `git diff --check` i nie znaleziono problemów (sukces).
- Sprawdzono składnię wyodrębnionych skryptów inline przez `node --check /tmp/explomapa-inline-scripts.js` (sukces).
- Wykonano prosty skrypt Python sprawdzający obecność nowych fragmentów (`icons/location.svg`, zmiana grid-a w `style.css`, blok `if (mobileLayout)` w `index.html`) i plik ikony, wszystkie asercje przeszły (sukces).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a5e0406788330b450be0b45f7faf0)