### PR TITLE
Fix marker popup opening handler scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -7256,6 +7256,59 @@ function emojiHtml(str, hue = 0) {
       bindCurrentPopupButtons(marker, p);
     }
 
+    function ensureViewPopup(marker, pin, options = {}) {
+      if (!marker || !pin || typeof createPopupHtml !== 'function') return;
+      if (pin._isEditing === true) return;
+      delete pin._editDraft;
+
+      if (marker._editCloseHandler) {
+        marker.off('popupclose', marker._editCloseHandler);
+        if (map) map.off('popupclose', marker._editCloseHandler);
+        marker._editCloseHandler = null;
+      }
+      if (marker._editPopupRemoveHandler && marker._editPopup) {
+        marker._editPopup.off('remove', marker._editPopupRemoveHandler);
+        marker._editPopupRemoveHandler = null;
+      }
+      if (marker._editPopup) {
+        if (map && typeof map.closePopup === 'function') map.closePopup(marker._editPopup);
+        marker._editPopup = null;
+      }
+
+      const popupDiv = document.createElement('div');
+      popupDiv.className = 'popup-container';
+      popupDiv.innerHTML = createPopupHtml(pin);
+
+      if (typeof marker.unbindPopup === 'function') marker.unbindPopup();
+      if (typeof marker.bindPopup === 'function') {
+        marker.bindPopup(popupDiv, {
+          maxWidth: 300,
+          autoPan: false,
+          keepInView: false
+        });
+      }
+    }
+
+    function handlePinOpen(marker, pin) {
+      if (!marker || drawingRoute) return null;
+      const resolvedPin = pin || marker.__pinRef || wszystkiePinezki.find(item => item && item.marker === marker) || null;
+      if (resolvedPin) {
+        marker.__pinRef = resolvedPin;
+        resolvedPin._isEditing = false;
+      }
+
+      if (resolvedPin) {
+        ensureViewPopup(marker, resolvedPin);
+        attachPopupHandlers(marker, resolvedPin);
+        if (typeof attachMarkerLongPress === 'function') attachMarkerLongPress(marker, resolvedPin);
+      }
+
+      if (typeof marker.openPopup === 'function') {
+        marker.openPopup();
+      }
+      return resolvedPin;
+    }
+
     function getPointerClientPoint(event) {
       const source = event?.originalEvent || event;
       const touch = source?.changedTouches?.[0] || source?.touches?.[0];


### PR DESCRIPTION
### Motivation
- Mobile taps and marker highlight handlers called `handlePinOpen(...)` but the function was not available in the same scope, causing `ReferenceError` on marker clicks. 
- Popup creation and binding logic already exists around `attachPopupHandlers()`/`attachHighlight()`, so `handlePinOpen` must live in that scope and reuse existing popup HTML plumbing. 
- The goal is to open pin popups on desktop and mobile without adding new mobile logic or changing existing popup behaviors.

### Description
- Added `ensureViewPopup(marker, pin, options = {})` adjacent to the existing popup/highlight handlers that prepares a marker popup using `createPopupHtml()`, clears edit state, unbinds any edit-popup, and (re)binds the prepared popup to the marker. 
- Added a globally scoped `handlePinOpen(marker, pin)` that resolves the pin reference, marks it not-editing, calls `ensureViewPopup(...)`, re-attaches `attachPopupHandlers(...)` and `attachMarkerLongPress(...)` when applicable, then calls `marker.openPopup()` if available, and returns the resolved pin. 
- Kept mobile tap/highlight code unchanged; handlers now call the new `handlePinOpen(...)` so popups open and no ReferenceError is thrown.

### Testing
- Ran `node --check /tmp/explomapa-inline.js` to validate inline script syntax, which succeeded. 
- Ran `git diff --check` to ensure no whitespace/syntax diffs remain, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a96a62c1c8330a147f0bf1eba5fff)