### PR TITLE
Remove custom mobile marker tap popup handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -7319,68 +7319,7 @@ function emojiHtml(str, hue = 0) {
       return null;
     }
 
-    function attachMarkerMobileTapOpen(marker, p) {
-      if (!marker || !p) return;
-      if (marker._mobileTapOpenHandlers) {
-        const { start, move, end } = marker._mobileTapOpenHandlers;
-        marker.off('touchstart', start);
-        marker.off('touchmove', move);
-        marker.off('touchend', end);
-        marker.off('pointerdown', start);
-        marker.off('pointermove', move);
-        marker.off('pointerup', end);
-      }
-
-      const state = { x: 0, y: 0, startedAt: 0, moved: false };
-      const maxTapMovePx = 14;
-      const maxTapDurationMs = 1200;
-
-      const start = event => {
-        const point = getPointerClientPoint(event);
-        if (!point) return;
-        state.x = point.x;
-        state.y = point.y;
-        state.startedAt = Date.now();
-        state.moved = false;
-      };
-
-      const move = event => {
-        if (!state.startedAt) return;
-        const point = getPointerClientPoint(event);
-        if (!point) return;
-        if (Math.hypot(point.x - state.x, point.y - state.y) > maxTapMovePx) {
-          state.moved = true;
-        }
-      };
-
-      const end = event => {
-        if (!state.startedAt) return;
-        const elapsed = Date.now() - state.startedAt;
-        const point = getPointerClientPoint(event);
-        const moved = state.moved || (point && Math.hypot(point.x - state.x, point.y - state.y) > maxTapMovePx);
-        state.startedAt = 0;
-        if (moved || elapsed > maxTapDurationMs) return;
-        if (marker._lastMobileTapOpenAt && Date.now() - marker._lastMobileTapOpenAt < 350) return;
-
-        const originalEvent = event?.originalEvent || event;
-        if (originalEvent?.preventDefault) originalEvent.preventDefault();
-        if (originalEvent?.stopPropagation) originalEvent.stopPropagation();
-
-        marker._lastMobileTapOpenAt = Date.now();
-        handlePinOpen(marker, p);
-      };
-
-      marker.on('touchstart', start);
-      marker.on('touchmove', move);
-      marker.on('touchend', end);
-      marker.on('pointerdown', start);
-      marker.on('pointermove', move);
-      marker.on('pointerup', end);
-      marker._mobileTapOpenHandlers = { start, move, end };
-    }
-
     function attachPopupHandlers(marker, p) {
-      attachMarkerMobileTapOpen(marker, p);
     /*  console.log('Wywołano attachPopupHandlers dla pinezki:', p); // <-- dodane */
       const bindPopupAction = (element, action) => {
         if (!element || element.dataset.popupActionBound === '1') return;
@@ -11629,7 +11568,6 @@ function zaladujPinezkiZFirestore() {
         marker.off('click', marker._highlightHandler);
       }
       marker._highlightHandler = () => {
-        if (marker._lastMobileTapOpenAt && Date.now() - marker._lastMobileTapOpenAt < 350) return;
         handlePinOpen(marker, marker.__pinRef || null);
       };
       marker.on('click', marker._highlightHandler);


### PR DESCRIPTION
### Motivation
- Mobile marker taps were handled by both a custom touch/pointer handler and the standard `click` handler which caused popup opening to be blocked in some mobile scenarios.
- The intent is to let marker opening go only through the standard Leaflet `click` highlight flow to avoid the duplicate-mechanism interference.

### Description
- Removed the `attachMarkerMobileTapOpen` function which implemented custom touch/pointer tap detection and opening logic.
- Stopped calling the removed `attachMarkerMobileTapOpen` from `attachPopupHandlers` so popup handlers no longer attach the custom mobile tap behavior.
- Simplified `attachHighlight` so `marker._highlightHandler` only calls `handlePinOpen(marker, marker.__pinRef || null)` and the handler is attached only to `marker.on('click', ...)`, removing the `_lastMobileTapOpenAt` guard.
- Did not change `createPopupHtml`, popup editing logic, or the long-press behavior as requested.

### Testing
- Ran `rg -n "attachMarkerMobileTapOpen|_lastMobileTapOpenAt" index.html` to verify the custom mobile tap function and guard were removed and the command returned no remaining occurrences.
- Ran a Python content check that asserts `attachHighlight` contains the `marker._highlightHandler` snippet that calls `handlePinOpen` and attaches it via `marker.on('click', ...)`, which succeeded.
- Executed a diff/check step to ensure there are no whitespace or diff errors after the change which completed cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2be280ced083308aab2a755b07e3eb)