### PR TITLE
Fix Leaflet pin popup anchoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -1490,12 +1490,6 @@ body:not(.trip-planner-mode) .trip-planner-panel {
   color: #f0f0f0;
 }
 
-    .leaflet-popup {
-    position: absolute;
-    text-align: center;
-    margin-bottom: 40px;
-}
-
 .popup-description.scrollable {
   max-height: 150px;
   overflow-y: auto;
@@ -2512,8 +2506,8 @@ img.emoji {
     }
 
     .leaflet-popup-tip {
-      background: #171a21;
-      border: 1px solid var(--ui-border);
+      background: #2b2b2b;
+      border: 1px solid #444;
     }
 
     #deleteModal,
@@ -5755,7 +5749,12 @@ function slugify(str) {
         const popupDiv = document.createElement("div");
         popupDiv.className = "popup-container";
         popupDiv.innerHTML = createPopupHtml(data);
-        marker.bindPopup(popupDiv);
+        marker.bindPopup(popupDiv, {
+          maxWidth: 300,
+          autoPan: false,
+          keepInView: false,
+          offset: L.point(0, -24)
+        });
         attachPopupHandlers(marker, data);
         attachMarkerLongPress(marker, data);
         attachHighlight(marker, null);
@@ -6211,7 +6210,7 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
             </div>`,
           iconSize: [markerSize, markerSize],
           iconAnchor: [markerSize / 2, markerSize],
-          popupAnchor: [0, -14]
+          popupAnchor: [0, -24]
         });
       }
 
@@ -6226,7 +6225,7 @@ if (pinBtn) pinBtn.addEventListener("click", () => selectTool("pin"));
           </div>`,
         iconSize: [markerSize, markerSize],
         iconAnchor: [markerSize / 2, markerSize],
-        popupAnchor: [0, -14]
+        popupAnchor: [0, -24]
       });
     }
 
@@ -7284,7 +7283,8 @@ function emojiHtml(str, hue = 0) {
         marker.bindPopup(popupDiv, {
           maxWidth: 300,
           autoPan: false,
-          keepInView: false
+          keepInView: false,
+          offset: L.point(0, -24)
         });
       }
     }
@@ -8086,7 +8086,8 @@ function emojiHtml(str, hue = 0) {
         marker.bindPopup(popupDiv, {
           maxWidth: 300,
           autoPan: false,
-          keepInView: false
+          keepInView: false,
+          offset: L.point(0, -24)
         });
 
         attachPopupHandlers(marker, p);
@@ -10624,7 +10625,12 @@ function zaladujPinezkiZFirestore() {
       const popupDiv = document.createElement("div");
       popupDiv.className = "popup-container";
       popupDiv.innerHTML = createPopupHtml(p);
-      p.marker.bindPopup(popupDiv);
+      p.marker.bindPopup(popupDiv, {
+        maxWidth: 300,
+        autoPan: false,
+        keepInView: false,
+        offset: L.point(0, -24)
+      });
       attachPopupHandlers(p.marker, p);
       attachMarkerLongPress(p.marker, p);
       if (p.plany) {
@@ -11008,7 +11014,12 @@ function zaladujPinezkiZFirestore() {
         const popupDiv = document.createElement('div');
         popupDiv.className = 'popup-container';
         popupDiv.innerHTML = createPopupHtml(data);
-        marker.bindPopup(popupDiv);
+        marker.bindPopup(popupDiv, {
+          maxWidth: 300,
+          autoPan: false,
+          keepInView: false,
+          offset: L.point(0, -24)
+        });
         attachPopupHandlers(marker, data);
         attachMarkerLongPress(marker, data);
 
@@ -11274,7 +11285,12 @@ function zaladujPinezkiZFirestore() {
         const popupDiv = document.createElement('div');
         popupDiv.className = 'popup-container';
         popupDiv.innerHTML = createPopupHtml(p);
-        marker.bindPopup(popupDiv);
+        marker.bindPopup(popupDiv, {
+          maxWidth: 300,
+          autoPan: false,
+          keepInView: false,
+          offset: L.point(0, -24)
+        });
         attachPopupHandlers(marker, p);
         attachMarkerLongPress(marker, p);
         attachHighlight(marker, null);
@@ -11709,7 +11725,12 @@ function zaladujPinezkiZFirestore() {
         const popupDiv = document.createElement('div');
         popupDiv.className = 'popup-container';
         popupDiv.innerHTML = createPopupHtml(pin);
-        marker.bindPopup(popupDiv);
+        marker.bindPopup(popupDiv, {
+          maxWidth: 300,
+          autoPan: false,
+          keepInView: false,
+          offset: L.point(0, -24)
+        });
         attachPopupHandlers(marker, pin);
         updateSaveButton();
       };
@@ -14401,7 +14422,12 @@ function getTripPointEmoji(p) {
       const iconEmoji = layerData.emoji || normalizePinEmojiValue(pin.emoji);
       const marker = L.marker([lat, lng], { icon: createEmojiIcon(iconEmoji, pin.warstwaId, 32, pin) });
       marker.__pinRef = pin;
-      marker.bindPopup('<div class="popup-container">Ładowanie…</div>');
+      marker.bindPopup('<div class="popup-container">Ładowanie…</div>', {
+        maxWidth: 300,
+        autoPan: false,
+        keepInView: false,
+        offset: L.point(0, -24)
+      });
       attachPopupHandlers(marker, pin);
       marker.on('popupopen', (evt) => {
         const popupStartTs = performance.now();
@@ -15980,7 +16006,12 @@ function confirmLayerDelete() {
     const popupDiv = document.createElement('div');
     popupDiv.className = 'popup-container';
     popupDiv.innerHTML = createPopupHtml(data);
-    marker.bindPopup(popupDiv);
+    marker.bindPopup(popupDiv, {
+      maxWidth: 300,
+      autoPan: false,
+      keepInView: false,
+      offset: L.point(0, -24)
+    });
     attachPopupHandlers(marker, data);
     data.marker = marker;
     movingLayer.lista.push(data);
@@ -16056,7 +16087,12 @@ function confirmLayerDelete() {
     const popupDiv = document.createElement('div');
     popupDiv.className = 'popup-container';
     popupDiv.innerHTML = createPopupHtml(data);
-    marker.bindPopup(popupDiv);
+    marker.bindPopup(popupDiv, {
+      maxWidth: 300,
+      autoPan: false,
+      keepInView: false,
+      offset: L.point(0, -24)
+    });
     attachPopupHandlers(marker, data);
     data.unsaved = true;
     nowePinezki.push(data);

--- a/style.css
+++ b/style.css
@@ -662,10 +662,8 @@ html body .leaflet-popup-content {
 }
 
 html body .leaflet-popup-tip {
-  background: rgba(18, 23, 32, 0.92) !important;
-  border: 1px solid rgba(255, 255, 255, 0.12) !important;
-  backdrop-filter: blur(10px) !important;
-  -webkit-backdrop-filter: blur(10px) !important;
+  background: #2b2b2b !important;
+  border: 1px solid #444 !important;
 }
 
 html body .leaflet-popup-close-button {
@@ -945,16 +943,6 @@ html body .popup-route-actions .popup-direct-route-btn:hover {
 }
 
 @media (max-width: 700px) {
-  html body .leaflet-popup {
-    top: 50% !important;
-    bottom: auto !important;
-    left: 50% !important;
-    width: min(94vw, 430px) !important;
-    max-width: 94vw !important;
-    margin: 0 !important;
-    transform: translate3d(-50%, -50%, 0) !important;
-  }
-
   html body .leaflet-popup-content-wrapper {
     max-height: calc(90dvh - env(safe-area-inset-bottom)) !important;
     overflow-y: auto !important;
@@ -973,10 +961,6 @@ html body .popup-route-actions .popup-direct-route-btn:hover {
     overflow-y: auto;
     overscroll-behavior: contain;
     padding: 16px;
-  }
-
-  html body .leaflet-popup-tip-container {
-    display: none !important;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Mobile popups were positioned differently than desktop because CSS and icon anchors overrode Leaflet's placement and the popup tip didn't point exactly at the pin; CSS `margin-bottom` and mobile fixed positioning interfered with Leaflet's transform-based placement.
- The goal is to make pin popups behave identically on mobile and desktop by letting Leaflet control placement and by aligning popup anchors with the pin tip.

### Description
- Set `popupAnchor: [0, -24]` for the emoji `L.divIcon` in `createEmojiIcon()` so popups originate above the top of the pin (matches `iconSize [24,24]` and `iconAnchor [12,24]`).
- Add explicit Leaflet popup options to all pin `bindPopup` calls: `maxWidth: 300`, `autoPan: false`, `keepInView: false`, and `offset: L.point(0, -24)` to ensure consistent anchoring and disable auto-pan behavior that differed on mobile.
- Remove the custom `.leaflet-popup` CSS positioning override (including the `margin-bottom: 40px` rule) and the mobile media-rule that forced `top/left/transform` on `.leaflet-popup`, so Leaflet's transform/left/bottom placement is preserved.
- Restore/standardize the popup tip style to `background: #2b2b2b` and `border: 1px solid #444` so the pointer remains the standard Leaflet tip.

### Testing
- Ran `node --check /tmp/explomapa-inline.js` to validate inline script syntax, which succeeded.
- Ran a Python assertion that checks every `bindPopup(popupDiv` call includes the required popup options, which passed (`All popupDiv bindPopup calls include required pin popup options`).
- Ran `rg` / grep checks to ensure removed CSS rules and old `popupAnchor: [0, -14]` patterns are absent, which passed.
- Ran `git diff --check` to ensure there are no whitespace/merge issues, which passed; browser automation (`playwright`) was not available in the environment so no visual screenshot tests were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2be82515048330b93d03fb16920c96)