### PR TITLE
Fix Leaflet mobile popup positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -5751,9 +5751,9 @@ function slugify(str) {
         popupDiv.innerHTML = createPopupHtml(data);
         marker.bindPopup(popupDiv, {
           maxWidth: 300,
-          autoPan: false,
-          keepInView: false,
-          offset: L.point(0, -24)
+          autoPan: true,
+          autoPanPadding: L.point(24, 80),
+          keepInView: true
         });
         attachPopupHandlers(marker, data);
         attachMarkerLongPress(marker, data);
@@ -7282,9 +7282,9 @@ function emojiHtml(str, hue = 0) {
       if (typeof marker.bindPopup === 'function') {
         marker.bindPopup(popupDiv, {
           maxWidth: 300,
-          autoPan: false,
-          keepInView: false,
-          offset: L.point(0, -24)
+          autoPan: true,
+          autoPanPadding: L.point(24, 80),
+          keepInView: true
         });
       }
     }
@@ -8085,9 +8085,9 @@ function emojiHtml(str, hue = 0) {
         marker.unbindPopup();
         marker.bindPopup(popupDiv, {
           maxWidth: 300,
-          autoPan: false,
-          keepInView: false,
-          offset: L.point(0, -24)
+          autoPan: true,
+          autoPanPadding: L.point(24, 80),
+          keepInView: true
         });
 
         attachPopupHandlers(marker, p);
@@ -10627,9 +10627,9 @@ function zaladujPinezkiZFirestore() {
       popupDiv.innerHTML = createPopupHtml(p);
       p.marker.bindPopup(popupDiv, {
         maxWidth: 300,
-        autoPan: false,
-        keepInView: false,
-        offset: L.point(0, -24)
+        autoPan: true,
+        autoPanPadding: L.point(24, 80),
+        keepInView: true
       });
       attachPopupHandlers(p.marker, p);
       attachMarkerLongPress(p.marker, p);
@@ -11016,9 +11016,9 @@ function zaladujPinezkiZFirestore() {
         popupDiv.innerHTML = createPopupHtml(data);
         marker.bindPopup(popupDiv, {
           maxWidth: 300,
-          autoPan: false,
-          keepInView: false,
-          offset: L.point(0, -24)
+          autoPan: true,
+          autoPanPadding: L.point(24, 80),
+          keepInView: true
         });
         attachPopupHandlers(marker, data);
         attachMarkerLongPress(marker, data);
@@ -11287,9 +11287,9 @@ function zaladujPinezkiZFirestore() {
         popupDiv.innerHTML = createPopupHtml(p);
         marker.bindPopup(popupDiv, {
           maxWidth: 300,
-          autoPan: false,
-          keepInView: false,
-          offset: L.point(0, -24)
+          autoPan: true,
+          autoPanPadding: L.point(24, 80),
+          keepInView: true
         });
         attachPopupHandlers(marker, p);
         attachMarkerLongPress(marker, p);
@@ -11727,9 +11727,9 @@ function zaladujPinezkiZFirestore() {
         popupDiv.innerHTML = createPopupHtml(pin);
         marker.bindPopup(popupDiv, {
           maxWidth: 300,
-          autoPan: false,
-          keepInView: false,
-          offset: L.point(0, -24)
+          autoPan: true,
+          autoPanPadding: L.point(24, 80),
+          keepInView: true
         });
         attachPopupHandlers(marker, pin);
         updateSaveButton();
@@ -14424,9 +14424,9 @@ function getTripPointEmoji(p) {
       marker.__pinRef = pin;
       marker.bindPopup('<div class="popup-container">Ładowanie…</div>', {
         maxWidth: 300,
-        autoPan: false,
-        keepInView: false,
-        offset: L.point(0, -24)
+        autoPan: true,
+        autoPanPadding: L.point(24, 80),
+        keepInView: true
       });
       attachPopupHandlers(marker, pin);
       marker.on('popupopen', (evt) => {
@@ -16008,9 +16008,9 @@ function confirmLayerDelete() {
     popupDiv.innerHTML = createPopupHtml(data);
     marker.bindPopup(popupDiv, {
       maxWidth: 300,
-      autoPan: false,
-      keepInView: false,
-      offset: L.point(0, -24)
+      autoPan: true,
+      autoPanPadding: L.point(24, 80),
+      keepInView: true
     });
     attachPopupHandlers(marker, data);
     data.marker = marker;
@@ -16089,9 +16089,9 @@ function confirmLayerDelete() {
     popupDiv.innerHTML = createPopupHtml(data);
     marker.bindPopup(popupDiv, {
       maxWidth: 300,
-      autoPan: false,
-      keepInView: false,
-      offset: L.point(0, -24)
+      autoPan: true,
+      autoPanPadding: L.point(24, 80),
+      keepInView: true
     });
     attachPopupHandlers(marker, data);
     data.unsaved = true;

--- a/style.css
+++ b/style.css
@@ -951,8 +951,8 @@ html body .popup-route-actions .popup-direct-route-btn:hover {
   }
 
   html body .leaflet-popup-content {
-    width: min(94vw, 430px) !important;
-    max-width: 94vw !important;
+    max-width: min(92vw, 340px) !important;
+    width: auto !important;
   }
 
   html body .popup-container {
@@ -1178,8 +1178,8 @@ html body .popup-container .popup-route-actions .popup-direct-route-btn:hover {
 
 @media (max-width: 700px) {
   html body .leaflet-popup-content {
-    width: min(92vw, 430px) !important;
-    max-width: min(92vw, 430px) !important;
+    max-width: min(92vw, 340px) !important;
+    width: auto !important;
   }
 
   html body .popup-container {


### PR DESCRIPTION
### Motivation
- Mobile popups were mis-positioned because `popupAnchor` on the icon and `offset: L.point(0, -24)` were used together, causing the popup to "run away" from the marker. 
- Popups should be standard Leaflet popups: centered above the marker with the tip pointing to the pin and auto-panning on small screens. 
- Mobile styles forced a `width: 94vw` which produced oversized/wrongly positioned popups on small viewports. 

### Description
- Updated `bindPopup` calls in `index.html` to remove `offset: L.point(0, -24)` and enable `autoPan: true`, `autoPanPadding: L.point(24, 80)`, and `keepInView: true` for pin popups (keeps positioning driven by the icon `popupAnchor`).
- Left icon creation code using `popupAnchor: [0, -24]` so popup position is controlled only by the icon settings. 
- Modified mobile CSS in `style.css` to remove forced `width: min(94vw, 430px)` and similar rules and replace them with `max-width: min(92vw, 340px) !important` and `width: auto !important` so popups can have a capped max-width without forcing a viewport width. 
- Changes are limited to `index.html` and `style.css` and only alter popup options and mobile sizing rules to restore standard Leaflet behavior. 

### Testing
- Ran `rg -n "offset:\s*L\.point\(0, -24\)|width: min\(94vw|max-width: 94vw" index.html style.css` to verify the `offset` rule and old mobile width rules were removed and the new rules are present, and the check passed. 
- Executed `git diff --check` to validate there are no whitespace/merge issues, and it passed. 
- Ran a Python check script (`python3 - <<'PY' ... PY`) to assert the new `bindPopup` blocks appear (`maxWidth: 300` + `autoPan: true` + `autoPanPadding`) and it reported the expected occurrences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bf96efaa08330a822298cd08e22e2)