### PR TITLE
Adjust mobile popup sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -7281,7 +7281,8 @@ function emojiHtml(str, hue = 0) {
       if (typeof marker.unbindPopup === 'function') marker.unbindPopup();
       if (typeof marker.bindPopup === 'function') {
         marker.bindPopup(popupDiv, {
-          maxWidth: 300,
+          maxWidth: 380,
+          minWidth: window.innerWidth <= 700 ? 340 : 300,
           autoPan: true,
           autoPanPadding: L.point(24, 80),
           keepInView: true
@@ -8084,7 +8085,8 @@ function emojiHtml(str, hue = 0) {
 
         marker.unbindPopup();
         marker.bindPopup(popupDiv, {
-          maxWidth: 300,
+          maxWidth: 380,
+          minWidth: window.innerWidth <= 700 ? 340 : 300,
           autoPan: true,
           autoPanPadding: L.point(24, 80),
           keepInView: true

--- a/style.css
+++ b/style.css
@@ -654,8 +654,8 @@ html body .leaflet-popup-content-wrapper {
 }
 
 html body .leaflet-popup-content {
-  max-width: min(360px, calc(100vw - 42px)) !important;
-  width: min(360px, calc(100vw - 42px)) !important;
+  max-width: min(380px, calc(100vw - 32px)) !important;
+  width: min(380px, calc(100vw - 32px)) !important;
   margin: 0 !important;
   color: #f8fafc !important;
   text-align: left !important;
@@ -951,8 +951,8 @@ html body .popup-route-actions .popup-direct-route-btn:hover {
   }
 
   html body .leaflet-popup-content {
-    max-width: min(92vw, 340px) !important;
-    width: auto !important;
+    max-width: min(380px, calc(100vw - 32px)) !important;
+    width: min(380px, calc(100vw - 32px)) !important;
   }
 
   html body .popup-container {
@@ -1178,8 +1178,8 @@ html body .popup-container .popup-route-actions .popup-direct-route-btn:hover {
 
 @media (max-width: 700px) {
   html body .leaflet-popup-content {
-    max-width: min(92vw, 340px) !important;
-    width: auto !important;
+    max-width: min(380px, calc(100vw - 32px)) !important;
+    width: min(380px, calc(100vw - 32px)) !important;
   }
 
   html body .popup-container {


### PR DESCRIPTION
### Motivation
- Mobile popups were too narrow and not sized responsively to small viewports causing cramped UI on phones.
- Popups should auto-pan and stay in view when opened so content is not cut off by the map edges.
- CSS caps should match the new desired max width (380px) while remaining viewport-safe.

### Description
- Update `ensureViewPopup()` popup bindings in `index.html` to use `maxWidth: 380` and add a mobile-aware `minWidth` of `window.innerWidth <= 700 ? 340 : 300` to expand popups on small screens.
- Keep `autoPan: true`, `autoPanPadding: L.point(24, 80)`, and `keepInView: true` for the popups to remain visible when opened.
- Do not set an explicit `offset` in the `ensureViewPopup` bindings so icon `popupAnchor` can take precedence.
- Adjust `style.css` `.leaflet-popup-content` rules to `max-width: min(380px, calc(100vw - 32px))` and mirror that width in mobile media queries to make the content wider but viewport-safe.

### Testing
- Ran the inline Python assertions (`python3 - <<'PY' ... PY`) that verify updated `bindPopup` options and CSS and they passed.
- Started a local static server and verified `index.html` served successfully and inspected headers with `curl -I`; checks passed.
- Ran `git diff --check` and committed the changes successfully with the message `Adjust mobile popup sizing`.
- Attempted browser screenshot verification via Playwright but `npx` failed due to `npm` registry `403` in this environment, so no Playwright run was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c0a0cb7608330b589eb4d34966781)