### PR TITLE
Disable popup keepInView and make desktop popups more compact

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-11-popup-fixes-2" />
+  <link rel="stylesheet" href="style.css?v=2026-06-15-popup-compact-autopan" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -5753,7 +5753,7 @@ function slugify(str) {
           maxWidth: 300,
           autoPan: true,
           autoPanPadding: L.point(24, 80),
-          keepInView: true
+          keepInView: false
         });
         attachPopupHandlers(marker, data);
         attachMarkerLongPress(marker, data);
@@ -7285,7 +7285,7 @@ function emojiHtml(str, hue = 0) {
           minWidth: window.innerWidth <= 700 ? 340 : 300,
           autoPan: true,
           autoPanPadding: L.point(24, 80),
-          keepInView: true
+          keepInView: false
         });
       }
     }
@@ -8089,7 +8089,7 @@ function emojiHtml(str, hue = 0) {
           minWidth: window.innerWidth <= 700 ? 340 : 300,
           autoPan: true,
           autoPanPadding: L.point(24, 80),
-          keepInView: true
+          keepInView: false
         });
 
         attachPopupHandlers(marker, p);
@@ -10627,7 +10627,7 @@ function zaladujPinezkiZFirestore() {
         maxWidth: 300,
         autoPan: true,
         autoPanPadding: L.point(24, 80),
-        keepInView: true
+        keepInView: false
       });
       attachPopupHandlers(p.marker, p);
       attachMarkerLongPress(p.marker, p);
@@ -11016,7 +11016,7 @@ function zaladujPinezkiZFirestore() {
           maxWidth: 300,
           autoPan: true,
           autoPanPadding: L.point(24, 80),
-          keepInView: true
+          keepInView: false
         });
         attachPopupHandlers(marker, data);
         attachMarkerLongPress(marker, data);
@@ -11287,7 +11287,7 @@ function zaladujPinezkiZFirestore() {
           maxWidth: 300,
           autoPan: true,
           autoPanPadding: L.point(24, 80),
-          keepInView: true
+          keepInView: false
         });
         attachPopupHandlers(marker, p);
         attachMarkerLongPress(marker, p);
@@ -11727,7 +11727,7 @@ function zaladujPinezkiZFirestore() {
           maxWidth: 300,
           autoPan: true,
           autoPanPadding: L.point(24, 80),
-          keepInView: true
+          keepInView: false
         });
         attachPopupHandlers(marker, pin);
         updateSaveButton();
@@ -14424,7 +14424,7 @@ function getTripPointEmoji(p) {
         maxWidth: 300,
         autoPan: true,
         autoPanPadding: L.point(24, 80),
-        keepInView: true
+        keepInView: false
       });
       attachPopupHandlers(marker, pin);
       marker.on('popupopen', (evt) => {
@@ -16008,7 +16008,7 @@ function confirmLayerDelete() {
       maxWidth: 300,
       autoPan: true,
       autoPanPadding: L.point(24, 80),
-      keepInView: true
+      keepInView: false
     });
     attachPopupHandlers(marker, data);
     data.marker = marker;
@@ -16089,7 +16089,7 @@ function confirmLayerDelete() {
       maxWidth: 300,
       autoPan: true,
       autoPanPadding: L.point(24, 80),
-      keepInView: true
+      keepInView: false
     });
     attachPopupHandlers(marker, data);
     data.unsaved = true;

--- a/style.css
+++ b/style.css
@@ -1339,3 +1339,39 @@ html body .popup-status-row {
   flex-wrap: wrap;
   gap: 3px 8px;
 }
+
+/* Desktop pin popup compact text and one-time autopan compatibility */
+@media (min-width: 701px) {
+  html body .leaflet-popup .popup-container,
+  html body .leaflet-popup .popup-container *:not(.popup-action-svg) {
+    font-size: 12px !important;
+    line-height: 1.2 !important;
+  }
+
+  html body .leaflet-popup .popup-card-title,
+  html body .leaflet-popup .popup-title,
+  html body .leaflet-popup .popup-pin-title {
+    font-size: 12px !important;
+    line-height: 1.18 !important;
+  }
+
+  html body .leaflet-popup .popup-google-card,
+  html body .leaflet-popup .popup-chatgpt-btn,
+  html body .leaflet-popup .popup-container .popup-google-card,
+  html body .leaflet-popup .popup-container .popup-chatgpt-btn {
+    min-height: 30px !important;
+    height: 30px !important;
+    padding: 4px 8px !important;
+    font-size: 11px !important;
+    line-height: 1.1 !important;
+    border-radius: 7px !important;
+  }
+
+  html body .leaflet-popup .popup-google-card .popup-external-icon,
+  html body .leaflet-popup .popup-chatgpt-btn .popup-external-icon,
+  html body .leaflet-popup .popup-chatgpt-btn img,
+  html body .leaflet-popup .popup-google-card img {
+    width: 14px !important;
+    height: 14px !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- Ensure pin popup can be auto-panned below search/tool overlays when opened but does not force the map to snap back when the user manually pans the map. 
- Make desktop popups visually smaller by capping text size and reducing the Google Maps / ChatGPT button footprint so the popup occupies less space.

### Description
- Replaced Leaflet popup option `keepInView: true` with `keepInView: false` for pin popups in multiple places so the existing one-time `autoPan` logic still runs on open but subsequent manual pans won't re-center the map.
- Added a desktop-focused CSS block under `@media (min-width: 701px)` that limits popup text to `12px`, forces title sizes to `12px`, and reduces sizes/padding/icons for `.popup-google-card` and `.popup-chatgpt-btn` to make popups more compact.
- Bumped the stylesheet cache-buster in `index.html` to force clients to load the updated CSS.

### Testing
- Confirmed no remaining `keepInView: true` occurrences after the change by running a repository search, and observed the expected `keepInView: false` placements (10 replacements). (succeeded)
- Ran `git diff --check` to validate there are no whitespace/patch issues (succeeded).
- Searched for `style.css?v=` and the new desktop CSS marker to verify the stylesheet bump and new rules are present (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fba0858048330a969e21fa24d3dde)