### PR TITLE
Fix single-photo popup scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-15 v.0.634';
+    const BUILD_VERSION = '2026-06-15 v.0.635';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-15-popup-compact-autopan" />
+  <link rel="stylesheet" href="style.css?v=2026-06-15-popup-single-photo-cover" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -1355,6 +1355,10 @@ body:not(.trip-planner-mode) .trip-planner-panel {
   object-fit: contain;
   background: #111;
   cursor: pointer;
+}
+.photo-gallery.single-photo .popup-photo {
+  object-fit: cover;
+  background: transparent;
 }
 .photo-gallery {
   display: flex;
@@ -6254,7 +6258,9 @@ function emojiHtml(str, hue = 0) {
       const slug = gallery.dataset.slug;
       const photos = getStoredPhotos(slug);
       gallery.innerHTML = '';
+      gallery.classList.remove('single-photo');
       if (photos.length === 0) return;
+      gallery.classList.toggle('single-photo', photos.length === 1);
       photos.forEach((ph, idx) => {
         const url = getPhotoEntryUrl(ph);
         if (!url) return;


### PR DESCRIPTION
### Motivation

- Usunąć czarne pola przy pojedynczym zdjęciu w popupie, tak aby obraz zawsze wypełniał ramkę bez przyciętych krawędzi.
- Odświeżyć numer builda i cache klucza CSS, żeby zmiana była widoczna w deployment.

### Description

- Zaktualizowano `BUILD_VERSION` w `index.html` na `2026-06-15 v.0.635` i zmieniono parametr cache dla CSS na `?v=2026-06-15-popup-single-photo-cover`.
- Dodano regułę CSS `.photo-gallery.single-photo .popup-photo { object-fit: cover; background: transparent; }` aby pojedyncze zdjęcie używało `cover` zamiast `contain`.
- W funkcji `renderGallery` dodano zarządzanie klasą `single-photo` (`gallery.classList.toggle('single-photo', photos.length === 1)`) i usuwanie jej przed renderowaniem, żeby przełączenie stylu działało gdy w galerii jest dokładnie jedno zdjęcie.
- Zmiany ograniczają się do `index.html` (CSS + drobne JS w renderowaniu galerii) i nie modyfikują logiki uploadu ani przechowywania zdjęć.

### Testing

- Uruchomiono prosty skrypt sprawdzający zawartość `index.html` (assertions): weryfikacja `BUILD_VERSION`, obecności selektora CSS `.photo-gallery.single-photo .popup-photo` oraz wywołania `gallery.classList.toggle('single-photo', photos.length === 1)` — wszystkie asercje przeszły pomyślnie.
- Zmiany zostały zapisane i dodane do repozytorium (commit wykonany) bez błędów podczas operacji automatycznych.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fbde2cd588330b0eaf47a192b5ca3)