### PR TITLE
Fix mobile popup description scrolling and bump build

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-15 v.0.636';
+    const BUILD_VERSION = '2026-06-15 v.0.637';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
@@ -1519,6 +1519,22 @@ body:not(.trip-planner-mode) .trip-planner-panel {
 .popup-description.scrollable {
   max-height: 150px;
   overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+body.mobile-layout .popup-description.scrollable {
+  max-height: 110px;
+  max-height: min(110px, 22dvh);
+  overflow-y: auto;
+}
+
+@media (max-width: 700px) {
+  .popup-description.scrollable {
+    max-height: 110px;
+    max-height: min(110px, 22dvh);
+    overflow-y: auto;
+  }
 }
 .sztosy-gwiazda {
   position: absolute;


### PR DESCRIPTION
### Motivation
- Mobile popup with long `opis` could grow too tall and then be auto-panned under the search/tools bar which made the popup disappear shortly after opening. 
- The goal is to keep popup height bounded on small screens and enable an inner scroll so descriptions can still be read without breaking the auto-pan logic.
- Also update the visible build identifier per the build-number instruction.

### Description
- Bumped `BUILD_VERSION` from `2026-06-15 v.0.636` to `2026-06-15 v.0.637` in `index.html`.
- Restricted long popup description height and enabled touch-friendly scrolling by updating `.popup-description.scrollable` with `overscroll-behavior: contain` and `-webkit-overflow-scrolling: touch`.
- Added mobile-specific rules `body.mobile-layout .popup-description.scrollable` and an `@media (max-width: 700px)` block to set a smaller `max-height: min(110px, 22dvh)` so popups remain compact and inner content is scrollable.

### Testing
- Ran `git diff --check`, which reported no problems and passed. 
- Verified the change was staged and committed (commit message: `Fix mobile popup description scrolling`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fd574db648330bf2d44be1315bb92)