### PR TITLE
Prevent tools panel from covering popups

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-15 v.0.637';
+    const BUILD_VERSION = '2026-06-15 v.0.638';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
@@ -8300,16 +8300,22 @@ function emojiHtml(str, hue = 0) {
           return rect;
         };
 
-        const overlayBottoms = mobileLayout
+        const topOverlaySelectors = mobileLayout
           ? [
-              getVisibleBottom('#toggleLayers'),
-              getVisibleBottom('#toggleBasemaps'),
-              getVisibleBottom('#geosearch-container'),
-              // Na mobile popup pinezki ma zostać odsunięty poniżej panelu „narzędzia”,
+              '#toggleLayers',
+              '#toggleBasemaps',
+              '#geosearch-container',
+              '#narzedzia'
+            ]
+          : [
+              '#geosearch-container',
+              // Popup pinezki ma zostać odsunięty poniżej panelu „narzędzia”,
               // żeby panel nie przykrywał górnej części popupu po jego otwarciu.
-              getVisibleBottom('#narzedzia')
-            ].filter(bottom => Number.isFinite(bottom))
-          : [getVisibleBottom('#geosearch-container')].filter(bottom => Number.isFinite(bottom));
+              '#narzedzia'
+            ];
+        const overlayBottoms = topOverlaySelectors
+          .map(selector => getVisibleBottom(selector))
+          .filter(bottom => Number.isFinite(bottom));
 
         const sidebarRect = getVisibleRect('#sidebar');
         const basemapRect = getVisibleRect('#basemap-switcher');


### PR DESCRIPTION
### Motivation
- Ensure popups are auto-panned below the top UI controls so they are not obscured by the search bar or the "Narzędzia" tools panel.  
- Update the app build badge to the next build number and current date so deployments reflect the change.

### Description
- Bumped the in-page `BUILD_VERSION` from `2026-06-15 v.0.637` to `2026-06-15 v.0.638` and kept `window.APP_BUILD` in sync in `index.html`.  
- Reworked the popup auto-pan overlay calculation by introducing `topOverlaySelectors` and mapping selectors to visible bottoms, and included `#narzedzia` so the tools panel is considered on both mobile and desktop.  
- Replaced multiple direct `getVisibleBottom(...)` calls with a single `map(selector => getVisibleBottom(selector))` + `filter(...)` step to simplify and centralize the logic in `index.html`.

### Testing
- Ran an automated assertion via `python3` that verified `index.html` contains the updated `BUILD_VERSION` and the `'#narzedzia'` selector, and it passed.  
- Ran repository static checks and basic validation of the modified file and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fd6529ebc83309afdbb81ccc888d6)