### PR TITLE
Suppress GPS-follow loader on mobile and fix long popups

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-15 v.0.638';
+    const BUILD_VERSION = '2026-06-15 v.0.639';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
@@ -1523,6 +1523,13 @@ body:not(.trip-planner-mode) .trip-planner-panel {
   -webkit-overflow-scrolling: touch;
 }
 
+body.mobile-layout .leaflet-popup-content {
+  max-height: calc(100dvh - 150px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
 body.mobile-layout .popup-description.scrollable {
   max-height: 110px;
   max-height: min(110px, 22dvh);
@@ -1530,6 +1537,13 @@ body.mobile-layout .popup-description.scrollable {
 }
 
 @media (max-width: 700px) {
+  .leaflet-popup-content {
+    max-height: calc(100dvh - 150px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
   .popup-description.scrollable {
     max-height: 110px;
     max-height: min(110px, 22dvh);
@@ -8351,7 +8365,12 @@ function emojiHtml(str, hue = 0) {
           dx = popupRect.right - maxRight;
         }
 
-        if (popupRect.top < minTop) {
+        if (popupRect.height > maxHeight) {
+          // Na małych ekranach długie popupy nie mieszczą się w całości.
+          // Wtedy trzymaj ich górę pod kontrolkami i pozwól przewijać treść,
+          // zamiast przesuwać mapę tak wysoko, że nagłówek popupu znika.
+          dy = popupRect.top - minTop;
+        } else if (popupRect.top < minTop) {
           dy = popupRect.top - minTop;
         } else if (popupRect.bottom > maxBottom) {
           dy = popupRect.bottom - maxBottom;
@@ -8406,6 +8425,7 @@ function emojiHtml(str, hue = 0) {
         }
       }
       map.on('movestart zoomstart dragstart', () => {
+        if (consumeSuppressPinViewportLoading()) return;
         showPinViewportLoading(0);
       });
       map.on('moveend zoomend dragend', () => {
@@ -14373,6 +14393,17 @@ function getTripPointEmoji(p) {
     let mapWhenReadyExecuted = false;
     let pinsFirestoreLoaded = false;
     let pinViewportLoadingHideTimer = null;
+    let suppressNextPinViewportLoading = false;
+
+    function suppressGpsFollowViewportLoading() {
+      suppressNextPinViewportLoading = true;
+    }
+
+    function consumeSuppressPinViewportLoading() {
+      if (!suppressNextPinViewportLoading) return false;
+      suppressNextPinViewportLoading = false;
+      return true;
+    }
 
     function showPinViewportLoading(percent = null) {
       const el = document.getElementById('pinViewportLoading');
@@ -15919,6 +15950,7 @@ function confirmLayerDelete() {
         updateGpsHeading(heading);
       }
       if (followGps) {
+        suppressGpsFollowViewportLoading();
         map.setView(currentLocation, map.getZoom());
       }
       if (typeof window.updateMobileSavePinButton === 'function') window.updateMobileSavePinButton();


### PR DESCRIPTION
### Motivation
- Przy centrowaniu mapy podczas śledzenia GPS na urządzeniach mobilnych pojawiał się pasek ładowania za każdym przemieszczeniem GPS, co jest niepotrzebne i rozprasza użytkownika.
- Na małych ekranach długie opisy w popupach powodowały przesunięcie mapy tak, że nagłówek popupu znikał lub popup był poza widokiem, a czasem wyglądał jakby się zamykał.
- Należało pozostawić loader dla innych przypadków ładowania i jedynie stłumić go przy automatycznym recenterze GPS oraz umożliwić przewijanie długich popupów zamiast agresywnego autopanu.
- Zaktualizowano numer builda strony do kolejnej wersji zgodnie z metadanymi aplikacji.

### Description
- Zwiększono `BUILD_VERSION` w nagłówku z `2026-06-15 v.0.638` do `2026-06-15 v.0.639`.
- Dodano mechanizm jednorazowego tłumienia loadera (`suppressNextPinViewportLoading` wraz z `suppressGpsFollowViewportLoading()` i `consumeSuppressPinViewportLoading()`), oraz wykorzystano go przed wywołaniem `map.setView` podczas `followGps`, tak by automatyczne centrowanie GPS nie pokazywało paska ładowania.
- Zmieniono obsługę zdarzenia ruchu mapy tak, aby przed pokazaniem pin-viewport loadera sprawdzać flagę tłumienia i w razie potrzeby jej używać (map.on('movestart zoomstart dragstart') sprawdza `consumeSuppressPinViewportLoading()`).
- Dostosowano logikę autopanowania popupu; jeśli popup jest wyższy niż dostępne miejsce, mapę nie przesuwa się tak wysoko, by ukryć nagłówek — zamiast tego popup trzymany jest poniżej kontrolek i treść popupu może być przewijana.
- Dodano ograniczenia CSS dla mobilnych popupów (`.leaflet-popup-content` max-height i przewijanie) aby długie opisy były przewijalne i nie wypychały popupu poza widok.

### Testing
- Uruchomiono automatyczne sprawdzenie spójności repozytorium i konfliktów — kontrola przeszła bez błędów.
- Zmiany zbudowane i zapisane w repozytorium przez narzędzie do tworzenia PR (lokalne sprawdzenie i generacja diff zakończone sukcesem).
- Brak dedykowanych jednostkowych testów automatycznych obejmujących UI w tym change set; rekomendowane manualne sprawdzenie na urządzeniu mobilnym (GPS follow + długie popupy) po wdrożeniu.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fd75d01ec833087774523ec154831)