### PR TITLE
Compact mobile pin popups and bump build/versioned stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-15 v.0.640';
+    const BUILD_VERSION = '2026-06-15 v.0.643';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-15-mobile-panel-popup-fix" />
+  <link rel="stylesheet" href="style.css?v=2026-06-15-mobile-popup-compact-no-edit" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 

--- a/style.css
+++ b/style.css
@@ -1375,3 +1375,128 @@ html body .popup-status-row {
     height: 14px !important;
   }
 }
+
+/* Mobile pin popup: compact sizing to keep long descriptions from forcing map autopan. */
+@media (max-width: 700px) {
+  html body .leaflet-popup-content {
+    max-height: calc(76dvh - env(safe-area-inset-bottom)) !important;
+    overflow-y: auto !important;
+    overscroll-behavior: contain !important;
+    -webkit-overflow-scrolling: touch !important;
+  }
+
+  html body .leaflet-popup-content-wrapper {
+    max-height: calc(76dvh - env(safe-area-inset-bottom)) !important;
+    border-radius: 12px !important;
+    overflow-y: auto !important;
+    overscroll-behavior: contain !important;
+    -webkit-overflow-scrolling: touch !important;
+  }
+
+  html body .leaflet-popup .popup-container,
+  html body .leaflet-popup .popup-container *:not(.popup-action-svg) {
+    font-size: 12px !important;
+    line-height: 1.2 !important;
+  }
+
+  html body .leaflet-popup .popup-container {
+    max-height: calc(76dvh - env(safe-area-inset-bottom)) !important;
+    padding: 10px !important;
+    gap: 6px !important;
+    overflow-y: auto !important;
+    overscroll-behavior: contain !important;
+    -webkit-overflow-scrolling: touch !important;
+  }
+
+  html body .leaflet-popup .popup-card-header {
+    gap: 8px !important;
+  }
+
+  html body .leaflet-popup .popup-card-title,
+  html body .leaflet-popup .popup-title,
+  html body .leaflet-popup .popup-pin-title {
+    font-size: 12px !important;
+    line-height: 1.15 !important;
+  }
+
+  html body .leaflet-popup .popup-status-line,
+  html body .leaflet-popup .popup-info-item,
+  html body .leaflet-popup .popup-description {
+    font-size: 12px !important;
+    line-height: 1.25 !important;
+  }
+
+  html body .leaflet-popup .popup-description.scrollable {
+    max-height: min(88px, 18dvh) !important;
+    padding-right: 3px !important;
+  }
+
+  html body .leaflet-popup .popup-section-label {
+    font-size: 10px !important;
+    line-height: 1.1 !important;
+    margin-bottom: 3px !important;
+    letter-spacing: .06em !important;
+  }
+
+  html body .leaflet-popup .popup-soft-separator {
+    margin: 2px 0 !important;
+  }
+
+  html body .leaflet-popup .popup-google-card,
+  html body .leaflet-popup .popup-chatgpt-btn,
+  html body .leaflet-popup .popup-container .popup-google-card,
+  html body .leaflet-popup .popup-container .popup-chatgpt-btn {
+    min-height: 30px !important;
+    height: 30px !important;
+    padding: 4px 8px !important;
+    border-radius: 7px !important;
+    font-size: 11px !important;
+    line-height: 1.1 !important;
+    gap: 7px !important;
+  }
+
+  html body .leaflet-popup .popup-details,
+  html body .leaflet-popup .popup-container .popup-details {
+    border-radius: 7px !important;
+  }
+
+  html body .leaflet-popup .popup-details summary,
+  html body .leaflet-popup .popup-container .popup-details summary {
+    min-height: 26px !important;
+    height: 26px !important;
+    padding: 3px 8px !important;
+    font-size: 11px !important;
+    line-height: 1.1 !important;
+  }
+
+  html body .leaflet-popup .popup-details-body {
+    gap: 4px !important;
+    padding: 0 8px 8px !important;
+  }
+
+  html body .leaflet-popup .popup-route-actions,
+  html body .leaflet-popup .popup-container .popup-route-actions {
+    gap: 6px !important;
+  }
+
+  html body .leaflet-popup .popup-route-actions button,
+  html body .leaflet-popup .popup-route-actions .popup-route-btn,
+  html body .leaflet-popup .popup-route-actions .popup-direct-route-btn,
+  html body .leaflet-popup .popup-container .popup-route-actions button,
+  html body .leaflet-popup .popup-container .popup-route-actions .popup-route-btn,
+  html body .leaflet-popup .popup-container .popup-route-actions .popup-direct-route-btn {
+    min-height: 30px !important;
+    height: 30px !important;
+    padding: 3px 6px !important;
+    border-radius: 7px !important;
+    font-size: 11px !important;
+    line-height: 1.05 !important;
+    gap: 4px !important;
+  }
+
+  html body .leaflet-popup .popup-action-svg {
+    width: 14px !important;
+    height: 14px !important;
+    flex-basis: 14px !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- Prevent long pin descriptions on small screens from forcing map autopan and improve mobile popup usability by making popups compact and scrollable.
- Deploy the CSS change by bumping the app build/version string and stylesheet query parameter.

### Description
- Updated `index.html` to set `BUILD_VERSION` to `2026-06-15 v.0.643` and to reference `style.css?v=2026-06-15-mobile-popup-compact-no-edit`.
- Added a responsive block in `style.css` under `@media (max-width: 700px)` that constrains popup heights using `calc(76dvh - env(safe-area-inset-bottom))`, enables internal scrolling, and applies `overscroll-behavior: contain` and `-webkit-overflow-scrolling: touch` for smoother touch scrolling.
- Adjusted font sizes, paddings, gaps, button and icon sizes, and various popup element styles to create a more compact, touch-friendly popup layout on mobile.

### Testing
- No automated tests were modified or added for this UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2febdca8d88330972dd2d9ac5d423f)