### PR TITLE
Fix mobile popup content fitting

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-16 v.0.644';
+    const BUILD_VERSION = '2026-06-16 v.0.645';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-16-mobile-popup-layer-loading" />
+  <link rel="stylesheet" href="style.css?v=2026-06-16-mobile-popup-fit" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -7374,7 +7374,7 @@ function emojiHtml(str, hue = 0) {
       if (typeof marker.bindPopup === 'function') {
         marker.bindPopup(popupDiv, {
           maxWidth: 380,
-          minWidth: window.innerWidth <= 700 ? 340 : 300,
+          minWidth: window.innerWidth <= 700 ? Math.min(300, Math.max(0, window.innerWidth - 56)) : 300,
           autoPan: false,
           closeOnClick: false,
           autoPanPadding: L.point(24, 80),
@@ -8179,7 +8179,7 @@ function emojiHtml(str, hue = 0) {
         marker.unbindPopup();
         marker.bindPopup(popupDiv, {
           maxWidth: 380,
-          minWidth: window.innerWidth <= 700 ? 340 : 300,
+          minWidth: window.innerWidth <= 700 ? Math.min(300, Math.max(0, window.innerWidth - 56)) : 300,
           autoPan: false,
           closeOnClick: false,
           autoPanPadding: L.point(24, 80),

--- a/style.css
+++ b/style.css
@@ -1378,17 +1378,29 @@ html body .popup-status-row {
 
 /* Mobile pin popup: compact sizing to keep long descriptions from forcing map autopan. */
 @media (max-width: 700px) {
+  html body .leaflet-popup {
+    max-width: calc(100vw - 24px) !important;
+  }
+
   html body .leaflet-popup-content {
+    box-sizing: border-box !important;
+    width: calc(100vw - 56px) !important;
+    min-width: 0 !important;
+    max-width: min(300px, calc(100vw - 56px)) !important;
     max-height: calc(76dvh - env(safe-area-inset-bottom)) !important;
     overflow-y: auto !important;
+    overflow-x: hidden !important;
     overscroll-behavior: contain !important;
     -webkit-overflow-scrolling: touch !important;
   }
 
   html body .leaflet-popup-content-wrapper {
+    box-sizing: border-box !important;
+    max-width: calc(100vw - 32px) !important;
     max-height: calc(76dvh - env(safe-area-inset-bottom)) !important;
     border-radius: 12px !important;
     overflow-y: auto !important;
+    overflow-x: hidden !important;
     overscroll-behavior: contain !important;
     -webkit-overflow-scrolling: touch !important;
   }
@@ -1400,16 +1412,21 @@ html body .popup-status-row {
   }
 
   html body .leaflet-popup .popup-container {
+    box-sizing: border-box !important;
+    width: 100% !important;
+    min-width: 0 !important;
     max-height: calc(76dvh - env(safe-area-inset-bottom)) !important;
     padding: 10px !important;
     gap: 6px !important;
     overflow-y: auto !important;
+    overflow-x: hidden !important;
     overscroll-behavior: contain !important;
     -webkit-overflow-scrolling: touch !important;
   }
 
   html body .leaflet-popup .popup-card-header {
     gap: 8px !important;
+    min-width: 0 !important;
   }
 
   html body .leaflet-popup .popup-card-title,
@@ -1422,8 +1439,11 @@ html body .popup-status-row {
   html body .leaflet-popup .popup-status-line,
   html body .leaflet-popup .popup-info-item,
   html body .leaflet-popup .popup-description {
+    min-width: 0 !important;
     font-size: 12px !important;
     line-height: 1.25 !important;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
   }
 
   html body .leaflet-popup .popup-description.scrollable {
@@ -1446,6 +1466,8 @@ html body .popup-status-row {
   html body .leaflet-popup .popup-chatgpt-btn,
   html body .leaflet-popup .popup-container .popup-google-card,
   html body .leaflet-popup .popup-container .popup-chatgpt-btn {
+    box-sizing: border-box !important;
+    min-width: 0 !important;
     min-height: 30px !important;
     height: 30px !important;
     padding: 4px 8px !important;
@@ -1477,6 +1499,8 @@ html body .popup-status-row {
   html body .leaflet-popup .popup-route-actions,
   html body .leaflet-popup .popup-container .popup-route-actions {
     gap: 6px !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    min-width: 0 !important;
   }
 
   html body .leaflet-popup .popup-route-actions button,
@@ -1485,6 +1509,8 @@ html body .popup-status-row {
   html body .leaflet-popup .popup-container .popup-route-actions button,
   html body .leaflet-popup .popup-container .popup-route-actions .popup-route-btn,
   html body .leaflet-popup .popup-container .popup-route-actions .popup-direct-route-btn {
+    box-sizing: border-box !important;
+    min-width: 0 !important;
     min-height: 30px !important;
     height: 30px !important;
     padding: 3px 6px !important;
@@ -1492,6 +1518,8 @@ html body .popup-status-row {
     font-size: 11px !important;
     line-height: 1.05 !important;
     gap: 4px !important;
+    white-space: normal !important;
+    overflow-wrap: anywhere !important;
   }
 
   html body .leaflet-popup .popup-action-svg {


### PR DESCRIPTION
### Motivation
- Mobile popup content was being visually clipped because the popup and its children enforced widths that could exceed narrow viewports, so content must be allowed to shrink/wrap on small screens while keeping desktop behavior unchanged.
- The app build badge and stylesheet cache key needed bumping to reflect the change so clients fetch the updated CSS.

### Description
- Constrained mobile Leaflet popup sizing and layout in `style.css` under `@media (max-width: 700px)` by adding `box-sizing`, `width: calc(...)`, `min-width: 0`, `max-width`, `overflow-x: hidden`, and text wrapping rules (`overflow-wrap: anywhere`, `word-break: break-word`) so inner elements can shrink instead of being clipped (file: `style.css`).
- Ensured popup wrapper and container also use `box-sizing` and `min-width: 0` and made route/action buttons allow wrapping (`white-space: normal`) to avoid forced overflow (file: `style.css`).
- Made Leaflet popup `minWidth` dynamic in `index.html` for mobile: use `Math.min(300, Math.max(0, window.innerWidth - 56))` when `window.innerWidth <= 700` so the popup cannot force a too-large minimum width on narrow screens (file: `index.html`).
- Bumped `BUILD_VERSION` from `2026-06-16 v.0.644` to `2026-06-16 v.0.645` and updated the stylesheet query string to `style.css?v=2026-06-16-mobile-popup-fit` to refresh cache (file: `index.html`).

### Testing
- Ran `git diff --check` and it returned no whitespace or diff errors (success).
- Verified repository status via `git status --short` and created a commit for the changes (commit created successfully).
- Performed repository-wide searches (`rg`) and inspected relevant regions of `index.html` and `style.css` to validate the edits (manual grep/checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3119f4466083309953704f4596e297)