### PR TITLE
Fix opening pin popups from list

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-16 v.0.645';
+    const BUILD_VERSION = '2026-06-17 v.0.646';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
@@ -11554,19 +11554,18 @@ function zaladujPinezkiZFirestore() {
       ensurePinLayerReady();
       const openPopupForPin = () => {
         updateMarkerVisibility();
-        ensurePinLayerReady();
-        if (!p.marker || !layerData || typeof layerData.layer.zoomToShowLayer !== 'function') {
-          if (p.marker) {
-            openPinViewPopup(p.marker, p);
-            rebindPinPopupAfterOpen(p.marker, p);
-          }
-          return;
-        }
-        layerData.layer.zoomToShowLayer(p.marker, () => {
+        if (p.marker) {
           ensurePinLayerReady();
-          openPinViewPopup(p.marker, p);
-          rebindPinPopupAfterOpen(p.marker, p);
-        });
+
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              ensurePinLayerReady();
+              openPinViewPopup(p.marker, p);
+              rebindPinPopupAfterOpen(p.marker, p);
+              if (typeof setMarkerHighlight === 'function') setMarkerHighlight(p.marker);
+            });
+          });
+        }
       };
       let popupOpened = false;
       let centerFallbackTimer = null;


### PR DESCRIPTION
### Motivation
- Popup opened from the sidebar sometimes failed to show because markers are created lazily, clustered, or not yet attached when `zoomToShowLayer` callback ran.  
- The goal is to make list-click -> center -> ensure marker exists -> open popup reliably without reworking popup subsystem.  
- Keep existing layering, clustering, search, mobile/desktop popup behavior and only change the list-click opening flow.

### Description
- Bumped the build badge from `2026-06-16 v.0.645` to `2026-06-17 v.0.646` in `index.html`.  
- Replaced the `zoomToShowLayer`-centric branch inside `openPinFromList()` with logic that calls `updateMarkerVisibility()`, forces layer/marker attachment via `ensurePinLayerReady()`, waits two animation frames with nested `requestAnimationFrame`, and then directly calls `openPinViewPopup(p.marker, p)` and `rebindPinPopupAfterOpen(p.marker, p)`.  
- After opening the popup the code restores the existing marker highlight by calling `setMarkerHighlight(p.marker)` when available.  
- The change is minimal and scoped to `openPinFromList`; it preserves list highlighting, map centering, lazy-loading, clustering, and popup implementations for desktop/mobile as-is.

### Testing
- Ran `git diff --check` to validate no diff-check errors and it passed.  
- Verified the modified block with a pattern search using `rg` to confirm the old `zoomToShowLayer` branch was replaced and the double `requestAnimationFrame` open flow was inserted.  
- Confirmed repository shows a single file change (`index.html`) and no reported check failures after the edit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a324815367483308a38cd86de23b328)