### PR TITLE
Naprawa otwierania popupu z listy pinezek

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-17 v.0.646';
+    const BUILD_VERSION = '2026-06-17 v.0.647';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
@@ -7444,8 +7444,10 @@ function emojiHtml(str, hue = 0) {
       };
 
       const bindCurrentPopupButtons = () => {
-        const currentPopup = marker.getPopup();
-        const container = currentPopup?.getElement?.();
+        const markerPopup = marker?.getPopup?.() || null;
+        const markerPopupElement = markerPopup?.getElement?.() || null;
+        const currentPopup = markerPopupElement ? markerPopup : (map?._popup || markerPopup || null);
+        const container = markerPopupElement || currentPopup?.getElement?.();
         if (!container) return;
         // Zapobiega przechwyceniu pierwszego kliknięcia przez mapę (zwłaszcza na mobile),
         // przez co przyciski w popupie reagują od razu po otwarciu.
@@ -7541,8 +7543,8 @@ function emojiHtml(str, hue = 0) {
       };
 
       const handler = e => {
-        const popupElement = marker.getPopup && marker.getPopup() ? marker.getPopup().getElement() : null;
-        if (popupElement && popupElement.querySelector('.edit-popup') && !p._isEditing) {
+        const popupElement = marker?.getPopup?.() ? marker.getPopup().getElement() : null;
+        if (marker && popupElement && popupElement.querySelector('.edit-popup') && !p._isEditing) {
           ensureViewPopup(marker, p);
           return;
         }
@@ -7551,6 +7553,10 @@ function emojiHtml(str, hue = 0) {
         map.once('moveend', bindCurrentPopupButtons);
         setTimeout(bindCurrentPopupButtons, 150);
       };
+      if (!marker) {
+        handler();
+        return;
+      }
       if (marker._editHandler) {
         marker.off('popupopen', marker._editHandler);
       }
@@ -11525,14 +11531,18 @@ function zaladujPinezkiZFirestore() {
       if (!p || !map) return;
       if (isMobile) {
         stopGpsFollow('open pin from list');
+        document.getElementById('sidebar')?.classList.remove('show');
       }
       const pinLatLng = L.latLng(Number(p.lat), Number(p.lng));
       if (!Number.isFinite(pinLatLng.lat) || !Number.isFinite(pinLatLng.lng)) return;
       const layerName = p.warstwa || "Inne";
-      const layerData = warstwy[layerName];
-      if (layerData && !p.marker) createLeafletMarkerForPin(p, layerName);
+      const getLayerData = () => warstwy[layerName];
+      if (!p.marker) createLeafletMarkerForPin(p, layerName);
 
       const ensurePinLayerReady = () => {
+        let layerData = getLayerData();
+        if (!p.marker) createLeafletMarkerForPin(p, layerName);
+        layerData = getLayerData();
         if (!layerData || !p.marker || !layerData.layer) return false;
         if (layerData.visible === false) {
           layerData.visible = true;
@@ -11541,6 +11551,8 @@ function zaladujPinezkiZFirestore() {
           const layerCheckbox = layerSection ? layerSection.querySelector('input[type="checkbox"]') : null;
           if (layerCheckbox) layerCheckbox.checked = true;
           setLayerVisibilityState(layerName, true);
+          layerData = getLayerData();
+          if (!layerData || !p.marker || !layerData.layer) return false;
         }
         if (!map.hasLayer(layerData.layer) && typeof layerData.layer.addTo === 'function') {
           layerData.layer.addTo(map);
@@ -11548,25 +11560,58 @@ function zaladujPinezkiZFirestore() {
         if (typeof layerData.layer.hasLayer === 'function' && !layerData.layer.hasLayer(p.marker)) {
           layerData.layer.addLayer(p.marker);
         }
-        return true;
+        return typeof layerData.layer.hasLayer !== 'function' || layerData.layer.hasLayer(p.marker);
       };
 
-      ensurePinLayerReady();
-      const openPopupForPin = () => {
-        updateMarkerVisibility();
-        if (p.marker) {
-          ensurePinLayerReady();
+      const openFallbackPopup = () => {
+        const popupDiv = document.createElement('div');
+        popupDiv.className = 'popup-container';
+        popupDiv.innerHTML = createPopupHtml(p);
+        L.popup({
+          maxWidth: 380,
+          minWidth: window.innerWidth <= 700 ? Math.min(300, Math.max(0, window.innerWidth - 56)) : 300,
+          autoPan: false,
+          closeOnClick: false,
+          keepInView: false
+        })
+          .setLatLng(pinLatLng)
+          .setContent(popupDiv)
+          .openOn(map);
+        attachPopupHandlers(p.marker || null, p);
+      };
 
-          requestAnimationFrame(() => {
-            requestAnimationFrame(() => {
-              ensurePinLayerReady();
-              openPinViewPopup(p.marker, p);
-              rebindPinPopupAfterOpen(p.marker, p);
-              if (typeof setMarkerHighlight === 'function') setMarkerHighlight(p.marker);
-            });
-          });
+      const openMarkerPopup = () => {
+        if (!p.marker) createLeafletMarkerForPin(p, layerName);
+        const layerReady = ensurePinLayerReady();
+        if (!p.marker || !layerReady) {
+          openFallbackPopup();
+          return;
         }
+
+        openPinViewPopup(p.marker, p);
+        rebindPinPopupAfterOpen(p.marker, p);
+        if (typeof setMarkerHighlight === 'function') setMarkerHighlight(p.marker);
+
+        requestAnimationFrame(() => {
+          const opened = map.hasLayer(p.marker) && p.marker.isPopupOpen && p.marker.isPopupOpen();
+          if (!opened) openFallbackPopup();
+        });
       };
+
+      const openPopupForPin = () => {
+        if (!p.marker) createLeafletMarkerForPin(p, layerName);
+        ensurePinLayerReady();
+        const layerData = getLayerData();
+        if (layerData?.layer && p.marker && typeof layerData.layer.zoomToShowLayer === 'function') {
+          layerData.layer.zoomToShowLayer(p.marker, () => {
+            ensurePinLayerReady();
+            requestAnimationFrame(openMarkerPopup);
+          });
+          return;
+        }
+        requestAnimationFrame(openMarkerPopup);
+      };
+
       let popupOpened = false;
       let centerFallbackTimer = null;
       const openPopupOnce = () => {


### PR DESCRIPTION
### Motivation
- Poprawić odporność funkcji `openPinFromList()` na brak/ukrycie/klastrowanie markerów oraz na zasłonięcie mapy przez mobilny sidebar. 
- Uniknąć dodawania globalnego `document.addEventListener('click')` i zachować istniejący mechanizm wyboru z listy oraz obecne funkcje popupów, clusteringu i lazy-loading.

### Description
- Zaktualizowano build strony na `2026-06-17 v.0.647` poprzez zmianę `BUILD_VERSION` w `index.html`.
- W `openPinFromList()` wprowadzono `const getLayerData = () => warstwy[layerName];` i po każdej potencjalnej kreacji markera ponownie pobierane jest świeże `layerData` zamiast polegać na starej referencji.
- Jeśli `p.marker` nie istnieje, teraz tworzymy go przez `createLeafletMarkerForPin(p, layerName)` zanim próbujemy dodać do warstwy lub otworzyć popup, oraz przywracamy niewidoczną warstwę (ustawiając checkbox/`setLayerVisibilityState`).
- Usunięto wywołanie `updateMarkerVisibility()` tuż przed otwarciem popupu; zamiast tego upewniamy się, że marker jest w warstwie, wspieramy `MarkerClusterGroup` przez `layerData.layer.zoomToShowLayer(p.marker, ...)`, a następnie otwieramy popup markera.
- Dodano twardy fallback: jeśli otwarcie popupu markera nie powiedzie się, tworzymy tymczasowy `L.popup(...)` bezpośrednio na współrzędnych pinezki z zawartością `createPopupHtml(p)` i podpinamy obsługę przez `attachPopupHandlers(p.marker || null, p)`.
- Dostosowano `attachPopupHandlers()` / binding popupów, aby obsłużyć również ścieżkę fallbackowego popupu (szukając najpierw popupu markera, a potem `map._popup`) oraz bezpiecznie obsłużyć brak markera podczas wiązania handlerów.
- Na mobile podczas otwierania z listy teraz zamykany jest sidebar (`document.getElementById('sidebar')?.classList.remove('show')`).

### Testing
- Uruchomiono `node --check /tmp/index-inline.js` aby sprawdzić poprawność składni wyciągniętego skryptu i komenda zakończyła się sukcesem.
- Uruchomiono `git diff --check` w celu sprawdzenia błędów białych znaków i konfliktów, i raport był czysty.
- Lokalna inspekcja zmian kodu potwierdziła, że istniejące funkcje (highlight listy, `setMarkerHighlight`, edycja popupu, clustering, lazy loading, lista warstw, wyszukiwarka i mobile popup) zostały zachowane bez zastępowania ich logiki.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a324b2f6e64833091f85dc307a1efde)