### PR TITLE
Expose openPinViewPopup globally to fix pin-list popup; bump build version

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-17 v.0.647';
+    const BUILD_VERSION = '2026-06-17 v.0.648';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
@@ -8206,6 +8206,8 @@ function emojiHtml(str, hue = 0) {
         marker.openPopup();
       }
 
+      window.openPinViewPopup = openPinViewPopup;
+
       function handlePinOpen(marker, p, options = {}) {
         if (!marker || drawingRoute) return null;
         const pin = p || marker.__pinRef || wszystkiePinezki.find(item => item && item.marker === marker);
@@ -8224,7 +8226,7 @@ function emojiHtml(str, hue = 0) {
           popupMarker.openPopup();
           setMarkerHighlight(marker);
         } else {
-          openPinViewPopup(marker, pin);
+          window.openPinViewPopup(marker, pin);
         }
 
         revealPinInSidebar(pin, { scrollBehavior: 'auto' });
@@ -11588,7 +11590,15 @@ function zaladujPinezkiZFirestore() {
           return;
         }
 
-        openPinViewPopup(p.marker, p);
+        if (typeof window.openPinViewPopup === 'function') {
+          window.openPinViewPopup(p.marker, p);
+        } else {
+          console.error('[popup] Brak window.openPinViewPopup — popup nie może się otworzyć', {
+            pin: p,
+            marker: p?.marker
+          });
+          return;
+        }
         rebindPinPopupAfterOpen(p.marker, p);
         if (typeof setMarkerHighlight === 'function') setMarkerHighlight(p.marker);
 
@@ -12634,7 +12644,7 @@ function showRoutePopup(pinId, tr, latlng) {
         window.requestAnimationFrame(() => {
           const marker = pin.marker;
           if (!marker) return;
-          openPinViewPopup(marker, pin);
+          window.openPinViewPopup(marker, pin);
           setMarkerHighlight(marker);
         });
       }


### PR DESCRIPTION
### Motivation

- Fix a ReferenceError thrown when clicking a pin from the pin list because `openPinViewPopup` was not visible in the caller scope. 
- Maintain existing popup/list logic and avoid adding new global marker structures or new event listeners.

### Description

- Exposed the existing `openPinViewPopup` function on the global object by adding `window.openPinViewPopup = openPinViewPopup;` immediately after its definition. 
- Replaced direct/local calls to `openPinViewPopup(...)` in callers with `window.openPinViewPopup(...)` where necessary, and updated `openMarkerPopup` to guard the call with `if (typeof window.openPinViewPopup === 'function') { ... } else { console.error(...) ; return; }` to avoid `ReferenceError`. 
- Updated all other call sites to use the global accessor so the function is reachable from different scopes. 
- Bumped `BUILD_VERSION` from `2026-06-17 v.0.647` to `2026-06-17 v.0.648` as requested.

### Testing

- Ran a static search ensuring `window.openPinViewPopup = openPinViewPopup;` is present and there are no remaining unqualified `openPinViewPopup(...)` calls outside its definition using a Python check script, which passed. 
- Ran `git diff --check` to validate there are no whitespace/conflict issues, which produced no errors. 
- Verified the updated `BUILD_VERSION` string is present in `index.html` via a direct file check, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3255e11d0483308674f07dc38e2732)