### PR TITLE
Make pin popup coordinates clickable to copy; bump build

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-18 v.0.651';
+    const BUILD_VERSION = '2026-06-18 v.0.652';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
@@ -7324,7 +7324,7 @@ function emojiHtml(str, hue = 0) {
             <div class="popup-info-item">Od kogo: ${p.odKogo || '—'}</div>
             <div class="popup-info-item">Data dodania: ${formatDate(p.dataDodania)}</div>
             <div class="popup-info-item popup-address" data-lat="${p.lat}" data-lng="${p.lng}">Adres: wyszukiwanie...</div>
-            <div class="popup-info-item">Współrzędne: ${formatCoords(p.lat, p.lng)}</div>
+            <button type="button" class="popup-info-item popup-coords-copy" data-coords="${escapeHtml(formatCoords(p.lat, p.lng))}" title="Kliknij, aby skopiować współrzędne">Współrzędne: <span>${formatCoords(p.lat, p.lng)}</span></button>
           </div>
         </details>
         <div class="popup-route-actions">
@@ -7412,6 +7412,31 @@ function emojiHtml(str, hue = 0) {
         return { x: source.clientX, y: source.clientY };
       }
       return null;
+    }
+
+
+    async function copyTextToClipboard(text) {
+      const value = String(text || '').trim();
+      if (!value) return false;
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(value);
+        return true;
+      }
+      const textarea = document.createElement('textarea');
+      textarea.value = value;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'fixed';
+      textarea.style.left = '-9999px';
+      textarea.style.top = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      let copied = false;
+      try {
+        copied = document.execCommand('copy');
+      } finally {
+        document.body.removeChild(textarea);
+      }
+      return copied;
     }
 
     function attachPopupHandlers(marker, p) {
@@ -7525,6 +7550,22 @@ function emojiHtml(str, hue = 0) {
         const tripBtn = container.querySelector('.popup-trip-add-btn');
         bindPopupAction(tripBtn, async () => {
           await addPointToTripFromData({ type: 'existing', pinId: p.id, pinFirebaseId: p.firebaseId || null, nameSnapshot: p.nazwa, lat: p.lat, lng: p.lng, emojiSnapshot: p.emoji || '', defaultPointType: 'urbex', defaultVisitMinutes: 60 });
+        });
+
+        const coordsCopyBtn = container.querySelector('.popup-coords-copy');
+        bindPopupAction(coordsCopyBtn, async () => {
+          const coords = coordsCopyBtn?.dataset?.coords || formatCoords(p.lat, p.lng);
+          try {
+            const copied = await copyTextToClipboard(coords);
+            if (copied) {
+              showToast(`Skopiowano współrzędne: ${coords}`);
+            } else {
+              showToast('Nie udało się skopiować współrzędnych.', 4000);
+            }
+          } catch (err) {
+            console.warn('Nie udało się skopiować współrzędnych:', err);
+            showToast('Nie udało się skopiować współrzędnych.', 4000);
+          }
         });
 
         updatePopupAddress(container, p.lat, p.lng);

--- a/style.css
+++ b/style.css
@@ -907,6 +907,27 @@ html body .popup-info-item {
   line-height: 1.35;
   overflow-wrap: anywhere;
 }
+html body .popup-coords-copy {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: copy;
+}
+
+html body .popup-coords-copy span {
+  color: #8fd3ff;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+html body .popup-coords-copy:hover span,
+html body .popup-coords-copy:focus-visible span {
+  color: #b9e7ff;
+}
+
 
 html body .popup-route-actions {
   display: grid !important;


### PR DESCRIPTION
### Motivation
- Enable easy copying of pin coordinates directly from the pin popup by clicking the coordinate row. 
- Ensure the app build metadata is advanced to reflect the change (`BUILD_VERSION`).

### Description
- Bumped `BUILD_VERSION` from `2026-06-18 v.0.651` to `2026-06-18 v.0.652` in `index.html`.
- Replaced the static coordinates line in the pin popup with a clickable button (`.popup-coords-copy`) that stores the coordinate text in a `data-coords` attribute.
- Added a `copyTextToClipboard` helper that uses the Clipboard API when available and falls back to `document.execCommand('copy')` for older contexts, and wired it into `attachPopupHandlers` to copy coordinates and show success/error `showToast` messages.
- Added CSS rules for `.popup-coords-copy` to make the control look interactive and readable in `style.css`.

### Testing
- Ran `python3` assertions to verify the new `BUILD_VERSION`, presence of the popup copy markup, the `copyTextToClipboard` helper, and the new `.popup-coords-copy` styles, and they succeeded.
- Performed a repository diff/check to ensure no obvious whitespace or diff issues were introduced and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33cb4d00248330b1cde7c9fab399fe)