### PR TITLE
Poprawki popupu tworzenia/edycji pinezki (status, odstępy, przyciski, wersja)

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-18 v.0.652';
+    const BUILD_VERSION = '2026-06-18 v.0.653';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
@@ -10134,7 +10134,7 @@ function zaladujPinezkiZFirestore() {
       const selected = getSelectedPinStatusKey(status);
       const options = buildInlineSelectOptions(pinStatusSelectOptions, selected);
       return `
-        <span class="inline-labeled-input" data-label="Status" style="--inline-label-offset: 64px;">
+        <span class="inline-labeled-input has-value" data-label="Status" style="--inline-label-offset: 64px;">
           <select id="${id}">${options}</select>
         </span>
       `;
@@ -11033,10 +11033,8 @@ function zaladujPinezkiZFirestore() {
         <div class="edit-form-field">
           ${buildStatusSelect('statusNew', {})}
         </div>
-        <div class="edit-popup-action-row">
-          <button id="cancelNew" type="button" class="edit-popup-delete-btn">Anuluj</button>
-        </div>
-        <button id="saveNew" type="button" class="edit-popup-save-btn">💾 Zapisz</button>`;
+        <button id="saveNew" type="button" class="edit-popup-save-btn">💾 Zapisz</button>
+        <button id="cancelNew" type="button" class="edit-popup-delete-btn edit-popup-cancel-btn">Anuluj</button>`;
       const mobileNewPinFormHtml = `
         <div class="photo-gallery" data-slug="${tempPin.slug}"></div>
         <div class="popup-media-row">
@@ -11068,8 +11066,10 @@ function zaladujPinezkiZFirestore() {
           <div class="trudnosc-value" id="trudnoscNewLabel" style="color:${trudnoscColor(0)}">${trudnoscText(0)}</div>
         </div>
         ${buildStatusGrid('', 'New')}
-        <button id="saveNew">💾 Zapisz</button>
-        <button id="cancelNew">Anuluj</button>`;
+        <div class="new-pin-mobile-actions">
+          <button id="saveNew">💾 Zapisz</button>
+          <button id="cancelNew">Anuluj</button>
+        </div>`;
       container.innerHTML = useMobilePinForm ? mobileNewPinFormHtml : desktopNewPinFormHtml;
 
       setupGallery(container.querySelector('.photo-gallery'), { markUnsaved: false });

--- a/style.css
+++ b/style.css
@@ -1557,3 +1557,46 @@ html body .popup-status-row {
     flex-basis: 14px !important;
   }
 }
+
+/* New pin popup refinements */
+html body .new-pin-popup .edit-form-field {
+  margin-bottom: 3px;
+}
+
+html body .new-pin-popup .edit-form-field input,
+html body .new-pin-popup .edit-form-field select,
+html body .new-pin-popup .edit-form-field textarea {
+  margin: 0;
+}
+
+html body .new-pin-popup .edit-popup-save-btn,
+html body .new-pin-popup .edit-popup-cancel-btn {
+  display: block;
+  width: 100%;
+  margin-top: 6px;
+}
+
+html body .new-pin-popup .edit-popup-cancel-btn {
+  min-height: 34px;
+  border-radius: 8px;
+}
+
+html body .new-pin-mobile-actions,
+html body .mobile-pin-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+html body .new-pin-mobile-actions button,
+html body .mobile-pin-actions button {
+  width: 100%;
+}
+
+html body .new-pin-mobile-actions {
+  gap: 6px;
+}
+
+html body .mobile-pin-actions {
+  gap: 8px;
+}


### PR DESCRIPTION
### Motivation
- Etykieta pola `Status` powinna być widoczna także gdy wybrana jest opcja „Brak”, tak samo jak przy innych statusach.
- W formularzu tworzenia nowej pinezki trzeba zmniejszyć odstępy między polami (nazwa, opis, od kogo, kategorie) dla bardziej zwartego widoku.
- Przyciski akcji powinny mieć układ „Zapisz” nad „Anuluj” oraz oba przyciski mają mieć taką samą szerokość dla lepszej użyteczności na mobilnych popupach.
- Zaktualizować numer builda i datę do kolejnej wartości zgodnie z wymaganiem wersjonowania.

### Description
- Podbito `BUILD_VERSION` do `2026-06-18 v.0.653` (aktualizacja daty i numeru builda) w `index.html`.
- W `buildStatusSelect` dodano klasę `has-value` do wrappera `inline-labeled-input`, aby etykieta `Status:` była zawsze wyświetlana również przy wartości pustej/pustym wyborze.
- Zmieniono kolejność i strukturę markup dla popupu tworzenia pinezki: przycisk `Zapisz` przeniesiono przed `Anuluj`, a mobilne przyciski opakowano w `.new-pin-mobile-actions` aby umożliwić pionowe ułożenie.
- Dodano reguły CSS w `style.css` pod `.new-pin-popup` i `.new-pin-mobile-actions` aby zmniejszyć odstępy między polami oraz ustawić przyciski akcji jako pełnej szerokości i ułożyć je pionowo (dotyczy też `.mobile-pin-actions`).

### Testing
- Uruchomiono `git diff --check` i nie wykryto problemów, test zakończył się pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33ceb6cbd08330812c668ef569f6d2)