### PR TITLE
Mobile new-pin form: reorder fields, status select, dropdown/emoji fixes and build bump

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-21 v.0.654';
+    const BUILD_VERSION = '2026-06-21 v.0.655';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-18-sidebar-buttons" />
+  <link rel="stylesheet" href="style.css?v=2026-06-21-mobile-new-pin" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -7999,6 +7999,7 @@ function emojiHtml(str, hue = 0) {
       if (!input) return;
       const wrapper = document.createElement('div');
       wrapper.style.position = 'relative';
+      wrapper.className = 'dropdown-input-wrapper';
       input.parentNode.insertBefore(wrapper, input);
       wrapper.appendChild(input);
       input.style.paddingRight = '20px';
@@ -8026,8 +8027,32 @@ function emojiHtml(str, hue = 0) {
           list.appendChild(div);
         });
       }
-      function show() { populate(); list.style.display = 'block'; }
-      function hide() { list.style.display = 'none'; }
+      function show() {
+        populate();
+        const inMobileModal = wrapper.closest('#mobilePinModal');
+        if (inMobileModal && window.matchMedia('(max-width: 800px)').matches) {
+          const rect = wrapper.getBoundingClientRect();
+          list.style.position = 'fixed';
+          list.style.left = `${Math.max(8, rect.left)}px`;
+          list.style.top = `${Math.min(window.innerHeight - 170, rect.bottom + 2)}px`;
+          list.style.width = `${Math.min(rect.width, window.innerWidth - 16)}px`;
+          list.style.zIndex = '2147483605';
+        } else {
+          list.style.position = 'absolute';
+          list.style.left = '';
+          list.style.top = '';
+          list.style.width = '100%';
+          list.style.zIndex = '';
+        }
+        list.style.display = 'block';
+      }
+      function hide() {
+        list.style.display = 'none';
+        list.style.position = 'absolute';
+        list.style.left = '';
+        list.style.top = '';
+        list.style.width = '100%';
+      }
       arrow.addEventListener('click', e => { e.stopPropagation(); list.style.display === 'block' ? hide() : show(); });
       document.addEventListener('click', e => { if (!wrapper.contains(e.target)) hide(); });
     }
@@ -11045,17 +11070,17 @@ function zaladujPinezkiZFirestore() {
         <textarea id="opisNew" placeholder="Opis" style="width: 100%; height: 100px"></textarea><br>
         <input id="odKogoNew" placeholder="Od kogo" style="width: 100%"><br>
         <label for="kategoriaGlownaNew">Kategoria główna</label><br>
-        <select id="kategoriaGlownaNew" style="width: 102%">
+        <select id="kategoriaGlownaNew" style="width: 100%">
           <option value="URBEX">URBEX</option>
           <option value="TURYSTYCZNE">TURYSTYCZNE</option>
         </select><br>
         <div class="edit-add-row">
-          <input id="kategoriaNew" placeholder="Podkategoria" style="width: 100%">
-          <button id="addCategoryFromPinNew" type="button" title="Dodaj nową podkategorię">＋</button>
-        </div><br>
-        <div class="edit-add-row">
           <input id="warstwaNew" placeholder="Warstwa" style="width: 100%">
           <button id="addLayerFromPinNew" type="button" title="Dodaj nową warstwę">＋</button>
+        </div><br>
+        <div class="edit-add-row">
+          <input id="kategoriaNew" placeholder="Podkategoria" style="width: 100%">
+          <button id="addCategoryFromPinNew" type="button" title="Dodaj nową podkategorię">＋</button>
         </div><br>
         <div class="trudnosc-wrapper">
           <div class="trudnosc-title">Poziom trudności</div>
@@ -11065,7 +11090,8 @@ function zaladujPinezkiZFirestore() {
           </div>
           <div class="trudnosc-value" id="trudnoscNewLabel" style="color:${trudnoscColor(0)}">${trudnoscText(0)}</div>
         </div>
-        ${buildStatusGrid('', 'New')}
+        <label for="statusNew">Status</label><br>
+        ${buildStatusSelect('statusNew', {})}
         <div class="new-pin-mobile-actions">
           <button id="saveNew">💾 Zapisz</button>
           <button id="cancelNew">Anuluj</button>
@@ -16519,13 +16545,8 @@ function confirmLayerDelete() {
       const emojiInput = document.getElementById('mobilePinEmoji');
       const emojiPicker = document.getElementById('mobilePinEmojiPicker');
       const emojiWrapper = document.getElementById('mobileEmojiPickerWrapper');
-      const inactiveInput = document.getElementById('mobilePinInactive');
-      const closedInput = document.getElementById('mobilePinClosed');
-      const secretInput = document.getElementById('mobilePinSecret');
-      const todoInput = document.getElementById('mobilePinTodo');
-      const destroyedInput = document.getElementById('mobilePinDestroyed');
-      const visitedInput = document.getElementById('mobilePinVisited');
-      const highlightedInput = document.getElementById('mobilePinHighlighted');
+      const statusSelect = document.getElementById('mobilePinStatus');
+      const statusLabel = document.querySelector('label[for="mobilePinStatus"]');
       const fromInput = document.getElementById('mobilePinFrom');
       const trudInput = document.getElementById('mobilePinTrudnosc');
       const trudLabel = document.getElementById('mobilePinTrudnoscLabel');
@@ -16594,13 +16615,8 @@ function confirmLayerDelete() {
         const pickerPanel = emojiPicker.querySelector('.emoji-picker-panel');
         if (pickerPanel) pickerPanel.style.display = 'none';
       }
-      inactiveInput.parentElement.style.display = 'none';
-      closedInput.parentElement.style.display = 'none';
-      secretInput.parentElement.style.display = 'none';
-      todoInput.parentElement.style.display = 'none';
-      destroyedInput.parentElement.style.display = 'none';
-      visitedInput.parentElement.style.display = 'none';
-        highlightedInput.parentElement.style.display = 'none';
+      if (statusSelect) statusSelect.style.display = 'none';
+      if (statusLabel) statusLabel.style.display = 'none';
         fromInput.style.display = 'none';
         trudWrapper.style.display = 'none';
         modal.style.display = 'flex';
@@ -16621,13 +16637,10 @@ function confirmLayerDelete() {
       emojiInput.dataset.emojiDefault = 'true';
       mobileEmojiHue = 0;
       if (emojiWrapper) emojiWrapper.style.display = '';
-      inactiveInput.checked = false;
-      closedInput.checked = false;
-      secretInput.checked = false;
-      todoInput.checked = false;
-      destroyedInput.checked = false;
-      visitedInput.checked = false;
-      highlightedInput.checked = false;
+      if (statusSelect) {
+        statusSelect.innerHTML = buildInlineSelectOptions(pinStatusSelectOptions, '');
+        statusSelect.value = '';
+      }
       storePhotos(mobileDraftPhotosSlug, []);
       if (mobilePhotoGallery) renderGallery(mobilePhotoGallery);
       if (mobilePhotoGallery) mobilePhotoGallery.style.display = '';
@@ -16636,13 +16649,8 @@ function confirmLayerDelete() {
       layerInput.style.display = '';
       mainCatInput.style.display = '';
       catInput.style.display = '';
-      inactiveInput.parentElement.style.display = '';
-      closedInput.parentElement.style.display = '';
-      secretInput.parentElement.style.display = '';
-      todoInput.parentElement.style.display = '';
-      destroyedInput.parentElement.style.display = '';
-      visitedInput.parentElement.style.display = '';
-        highlightedInput.parentElement.style.display = '';
+      if (statusSelect) statusSelect.style.display = '';
+      if (statusLabel) statusLabel.style.display = '';
         fromInput.style.display = '';
         fromInput.value = '';
         trudWrapper.style.display = '';
@@ -16709,13 +16717,7 @@ function confirmLayerDelete() {
           emoji: normalizePinEmojiValue(emojiInput.value),
           emojiHue: mobileEmojiHue,
           emojiDefault: emojiInput.dataset.emojiDefault === 'true',
-          nieaktywne: inactiveInput.checked,
-          zamkniete: closedInput.checked,
-          tajne: secretInput.checked,
-          doSprawdzenia: todoInput.checked,
-          zdewastowane: destroyedInput.checked,
-          zwiedzone: visitedInput.checked,
-          wyroznione: highlightedInput.checked,
+          ...getPinStatusStateFromSelect(statusSelect),
           odKogo: fromInput.value,
           trudnosc: trudInput.value,
           photos: getStoredPhotos(mobileDraftPhotosSlug)
@@ -16798,11 +16800,11 @@ function confirmLayerDelete() {
       <input type="text" id="mobilePinName" placeholder="Nazwa pinezki" style="width: 100%">
       <textarea id="mobilePinDesc" placeholder="Opis" style="width: 100%; height: 100px"></textarea>
       <input type="text" id="mobilePinFrom" placeholder="Od kogo" style="width: 100%">
-      <input type="text" id="mobilePinLayer" placeholder="Warstwa" style="width: 100%">
       <select id="mobilePinMainCategory" style="width: 100%">
         <option value="URBEX">URBEX</option>
         <option value="TURYSTYCZNE">TURYSTYCZNE</option>
       </select>
+      <input type="text" id="mobilePinLayer" placeholder="Warstwa" style="width: 100%">
       <input type="text" id="mobilePinCategory" placeholder="Podkategoria" style="width: 100%">
       <div id="mobileEmojiPickerWrapper" class="mobile-emoji-picker">
         <div id="mobilePinEmojiPicker" class="emoji-picker"></div>
@@ -16816,15 +16818,8 @@ function confirmLayerDelete() {
         </div>
         <div class="trudnosc-value" id="mobilePinTrudnoscLabel"></div>
       </div>
-      <div class="status-grid">
-        <label><input type="checkbox" id="mobilePinInactive"> Niedostępne ⛔</label>
-        <label><input type="checkbox" id="mobilePinClosed"> Zamknięte 🔐</label>
-        <label><input type="checkbox" id="mobilePinSecret"> Tajne 🤫</label>
-        <label><input type="checkbox" id="mobilePinTodo"> Do sprawdzenia ❔</label>
-        <label><input type="checkbox" id="mobilePinDestroyed"> Zdewastowane 💥</label>
-        <label><input type="checkbox" id="mobilePinVisited"> Zwiedzone <img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Green_check.svg" width="16" height="16" class="checkmark-obrys"></label>
-        <label><input type="checkbox" id="mobilePinHighlighted"> Wyróżnione ⭐</label>
-      </div>
+      <label for="mobilePinStatus" class="mobile-pin-status-label">Status</label>
+      <select id="mobilePinStatus" class="mobile-pin-status-select"></select>
       <div class="mobile-pin-actions">
         <button id="mobilePinOk">Zapisz</button>
         <button id="mobilePinCancel">Anuluj</button>

--- a/style.css
+++ b/style.css
@@ -1600,3 +1600,56 @@ html body .new-pin-mobile-actions {
 html body .mobile-pin-actions {
   gap: 8px;
 }
+
+/* Mobile new-pin form fixes */
+@media (max-width: 800px) {
+  #mobilePinModal .mobile-modal-content select,
+  #mobilePinModal .mobile-pin-status-select {
+    width: 100%;
+    min-height: 42px;
+    box-sizing: border-box;
+    color: #f0f0f0;
+    background: #1d2028;
+    border: 1px solid #555;
+    border-radius: 6px;
+  }
+
+  #mobilePinModal #mobilePinMainCategory,
+  #mobilePinModal #kategoriaGlownaNew {
+    min-width: 100%;
+    height: 44px;
+    line-height: 1.25;
+    padding: 8px 34px 8px 10px;
+    font-size: 16px;
+  }
+
+  #mobilePinModal .dropdown-input-wrapper {
+    width: 100%;
+  }
+
+  #mobilePinModal .list-dropdown {
+    color: #f0f0f0;
+    background: #1f222b;
+    border-color: #555;
+    border-radius: 8px;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+    max-height: 160px;
+    overflow-y: auto;
+  }
+
+  #mobilePinModal .list-dropdown div {
+    padding: 10px 12px;
+    min-height: 20px;
+  }
+
+  #mobilePinModal .mobile-emoji-picker .emoji-picker-grid,
+  #mobilePinModal #emojiPickerNew .emoji-picker-grid {
+    top: 0 !important;
+    bottom: auto !important;
+    left: calc(100% + 8px) !important;
+    right: auto !important;
+    grid-template-columns: repeat(4, 24px);
+    width: calc(4 * 24px + 3 * 8px);
+    max-width: calc(100vw - 96px);
+  }
+}


### PR DESCRIPTION
### Motivation
- Improve mobile new-pin UX so main category appears above layer and category inputs and fields are visually legible on small screens.
- Prevent dropdowns and emoji grid from being clipped by the modal scroll container on mobile.
- Replace multiple status checkboxes with a single select to simplify status selection and persist via existing select-to-state helpers.
- Bump build/version and refresh CSS cache key to deploy the changes.

### Description
- Bumped `BUILD_VERSION` to `2026-06-21 v.0.655` and updated the stylesheet reference query string to `style.css?v=2026-06-21-mobile-new-pin` in `index.html`.
- Reordered mobile form fields so the main category (`#mobilePinMainCategory`) is rendered before the layer input and moved the layer input above the subcategory in mobile-new-pin templates in `index.html`.
- Replaced the mobile status checkbox grid with a single `<select id="mobilePinStatus">` and wired saving to use `getPinStatusStateFromSelect(statusSelect)` when building the save payload.
- Improved dropdown behavior in `setupDropdownInput` by adding a `dropdown-input-wrapper` class and positioning the dropdown as `fixed` when opened inside the `#mobilePinModal` to avoid being clipped by modal scrolling.
- Adjusted emoji picker behavior/positioning for mobile so the emoji grid opens to the right of the button (via CSS and mobile-specific rules) and added mobile styles to increase select/button readability (`style.css`).

### Testing
- Ran JavaScript syntax check with `node --check /tmp/index-script.js` which passed.
- Ran `git diff --check` to ensure no whitespace/syntax errors, which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37d7d2f2ec83308687d08b942c6cac)