### PR TITLE
Fix mobile new pin form layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-21 v.0.655';
+    const BUILD_VERSION = '2026-06-23 v.0.656';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
@@ -1965,6 +1965,7 @@ img.emoji {
 	/*
   --emoji-picker-grid-width: calc((var(--emoji-picker-columns) * var(--emoji-picker-item-size)) + ((var(--emoji-picker-columns) - 1) * var(--emoji-picker-gap)));
   */
+  --emoji-picker-grid-width: calc((var(--emoji-picker-columns) * var(--emoji-picker-item-size)) + ((var(--emoji-picker-columns) - 1) * var(--emoji-picker-gap)));
 	display: none;
   position: absolute;
   z-index: 2147483602;
@@ -7955,7 +7956,7 @@ function emojiHtml(str, hue = 0) {
         const margin = 8;
         const spacing = 6;
         const gridRect = grid.getBoundingClientRect();
-        const gridW = gridRect.width || 248;
+        const gridW = gridRect.width || Math.min(248, viewportW - 16);
         const gridH = gridRect.height || Math.min(280, Math.floor(viewportH * 0.45));
         const maxLeft = Math.max(margin, viewportW - gridW - margin);
         const left = Math.min(Math.max(margin, rect.left), maxLeft);
@@ -8035,7 +8036,8 @@ function emojiHtml(str, hue = 0) {
           list.style.position = 'fixed';
           list.style.left = `${Math.max(8, rect.left)}px`;
           list.style.top = `${Math.min(window.innerHeight - 170, rect.bottom + 2)}px`;
-          list.style.width = `${Math.min(rect.width, window.innerWidth - 16)}px`;
+          list.style.width = `${Math.min(Math.max(rect.width, 220), window.innerWidth - 16)}px`;
+          list.style.maxHeight = `${Math.max(140, Math.min(260, window.innerHeight - rect.bottom - 16))}px`;
           list.style.zIndex = '2147483605';
         } else {
           list.style.position = 'absolute';
@@ -11066,22 +11068,41 @@ function zaladujPinezkiZFirestore() {
           <button class="popup-add-photo" data-slug="${tempPin.slug}">📷</button>
           <div id="emojiPickerNew" class="emoji-picker"></div>
         </div>
-        <input id="nazwaNew" placeholder="Nazwa" style="width: 100%"><br>
-        <textarea id="opisNew" placeholder="Opis" style="width: 100%; height: 100px"></textarea><br>
-        <input id="odKogoNew" placeholder="Od kogo" style="width: 100%"><br>
-        <label for="kategoriaGlownaNew">Kategoria główna</label><br>
-        <select id="kategoriaGlownaNew" style="width: 100%">
-          <option value="URBEX">URBEX</option>
-          <option value="TURYSTYCZNE">TURYSTYCZNE</option>
-        </select><br>
-        <div class="edit-add-row">
-          <input id="warstwaNew" placeholder="Warstwa" style="width: 100%">
-          <button id="addLayerFromPinNew" type="button" title="Dodaj nową warstwę">＋</button>
-        </div><br>
-        <div class="edit-add-row">
-          <input id="kategoriaNew" placeholder="Podkategoria" style="width: 100%">
-          <button id="addCategoryFromPinNew" type="button" title="Dodaj nową podkategorię">＋</button>
-        </div><br>
+        <div class="edit-form-field">
+          <input id="nazwaNew" placeholder="Nazwa">
+        </div>
+        <div class="edit-form-field">
+          <textarea id="opisNew" placeholder="Opis" style="height: 72px"></textarea>
+        </div>
+        <div class="edit-form-field">
+          <span class="inline-labeled-input" data-label="Od kogo" style="--inline-label-offset: 78px;">
+            <input id="odKogoNew" placeholder="Od kogo">
+          </span>
+        </div>
+        <div class="edit-form-field">
+          <span class="inline-labeled-input" data-label="Kategoria główna" style="--inline-label-offset: 132px;">
+            <select id="kategoriaGlownaNew">
+              <option value="URBEX">URBEX</option>
+              <option value="TURYSTYCZNE">TURYSTYCZNE</option>
+            </select>
+          </span>
+        </div>
+        <div class="edit-form-field">
+          <div class="edit-add-row">
+            <span class="inline-labeled-input" data-label="Warstwa" style="--inline-label-offset: 76px;">
+              <input id="warstwaNew" placeholder="Warstwa">
+            </span>
+            <button id="addLayerFromPinNew" type="button" title="Dodaj nową warstwę">＋</button>
+          </div>
+        </div>
+        <div class="edit-form-field">
+          <div class="edit-add-row">
+            <span class="inline-labeled-input" data-label="Podkategoria" style="--inline-label-offset: 108px;">
+              <input id="kategoriaNew" placeholder="Podkategoria">
+            </span>
+            <button id="addCategoryFromPinNew" type="button" title="Dodaj nową podkategorię">＋</button>
+          </div>
+        </div>
         <div class="trudnosc-wrapper">
           <div class="trudnosc-title">Poziom trudności</div>
           <input type="range" id="trudnoscNew" class="trudnosc-range" min="0" max="5" step="1" value="0">
@@ -11090,8 +11111,9 @@ function zaladujPinezkiZFirestore() {
           </div>
           <div class="trudnosc-value" id="trudnoscNewLabel" style="color:${trudnoscColor(0)}">${trudnoscText(0)}</div>
         </div>
-        <label for="statusNew">Status</label><br>
-        ${buildStatusSelect('statusNew', {})}
+        <div class="edit-form-field">
+          ${buildStatusSelect('statusNew', {})}
+        </div>
         <div class="new-pin-mobile-actions">
           <button id="saveNew">💾 Zapisz</button>
           <button id="cancelNew">Anuluj</button>
@@ -11148,13 +11170,11 @@ function zaladujPinezkiZFirestore() {
       }));
       setupDropdownInput(newCategoryInput, () => getCategorySuggestions(newMainCategoryInput ? newMainCategoryInput.value : MAIN_CATEGORY_URBEX));
       if (newMainCategoryInput) newMainCategoryInput.addEventListener('change', () => { if (newCategoryInput) newCategoryInput.value = ''; });
-      if (!useMobilePinForm) {
-        setupInlineFieldLabel(container.querySelector('#odKogoNew'), 'Od kogo');
-        setupInlineFieldLabel(container.querySelector('#kategoriaGlownaNew'), 'Kategoria główna');
-        setupInlineFieldLabel(container.querySelector('#kategoriaNew'), 'Podkategoria');
-        setupInlineFieldLabel(container.querySelector('#warstwaNew'), 'Warstwa');
-        setupInlineFieldLabel(container.querySelector('#statusNew'), 'Status');
-      }
+      setupInlineFieldLabel(container.querySelector('#odKogoNew'), 'Od kogo');
+      setupInlineFieldLabel(container.querySelector('#kategoriaGlownaNew'), 'Kategoria główna');
+      setupInlineFieldLabel(container.querySelector('#kategoriaNew'), 'Podkategoria');
+      setupInlineFieldLabel(container.querySelector('#warstwaNew'), 'Warstwa');
+      setupInlineFieldLabel(container.querySelector('#statusNew'), 'Status');
       setupTrudnoscInput(container.querySelector('#trudnoscNew'), container.querySelector('#trudnoscNewLabel'));
       const osmPrefill = window.__osmPrefillNewPin && window.__osmPrefillNewPin.defaults ? window.__osmPrefillNewPin.defaults : null;
       if (osmPrefill) {

--- a/style.css
+++ b/style.css
@@ -1642,14 +1642,67 @@ html body .mobile-pin-actions {
     min-height: 20px;
   }
 
+  #mobilePinModal .edit-popup {
+    min-width: 0;
+    width: 100%;
+  }
+
+  #mobilePinModal .edit-popup .edit-form-field {
+    margin-bottom: 4px;
+  }
+
+  #mobilePinModal .edit-popup input,
+  #mobilePinModal .edit-popup textarea,
+  #mobilePinModal .edit-popup select {
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+
+  #mobilePinModal .edit-popup .inline-labeled-input {
+    position: relative;
+    display: block;
+  }
+
+  #mobilePinModal .edit-popup .inline-labeled-input::before {
+    content: attr(data-label) ":";
+    position: absolute;
+    left: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 1;
+    display: none;
+    color: #aaa;
+    font-size: 13px;
+    font-weight: 700;
+    pointer-events: none;
+    margin: 0;
+    line-height: normal;
+    white-space: nowrap;
+  }
+
+  #mobilePinModal .edit-popup .inline-labeled-input.has-value::before {
+    display: block;
+  }
+
+  #mobilePinModal .edit-popup .inline-labeled-input.has-value input,
+  #mobilePinModal .edit-popup .inline-labeled-input.has-value select {
+    padding-left: var(--inline-label-offset, 82px);
+  }
+
+  #mobilePinModal .mobile-emoji-picker .emoji-picker-panel,
+  #mobilePinModal #emojiPickerNew .emoji-picker-panel {
+    --emoji-picker-item-size: 1.8em;
+    --emoji-picker-gap: 4px;
+    --emoji-picker-columns: 8;
+    width: var(--emoji-picker-grid-width);
+    max-width: calc(100vw - 24px);
+  }
+
   #mobilePinModal .mobile-emoji-picker .emoji-picker-grid,
   #mobilePinModal #emojiPickerNew .emoji-picker-grid {
-    top: 0 !important;
-    bottom: auto !important;
-    left: calc(100% + 8px) !important;
-    right: auto !important;
-    grid-template-columns: repeat(4, 24px);
-    width: calc(4 * 24px + 3 * 8px);
-    max-width: calc(100vw - 96px);
+    grid-template-columns: repeat(var(--emoji-picker-columns), var(--emoji-picker-item-size));
+    width: var(--emoji-picker-grid-width);
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
### Motivation
- Mobile new-pin form had large gaps, static "Kategoria główna" header and a too-narrow emoji grid/dropdown which made category/warstwa selection and emoji picking unusable on small screens.
- The goal is to make the mobile form match the edit-popup appearance: inline labels (e.g. “warstwa: sztosy”), reduced spacing, full emoji grid and correctly-sized suggestion lists.

### Description
- Bumped build version in `index.html` from `2026-06-21 v.0.655` to `2026-06-23 v.0.656`.
- Rewrote the mobile new-pin form HTML in `index.html` to use `.edit-form-field` and `.inline-labeled-input` wrappers so inline labels appear and the separate static "Kategoria główna" header is removed.
- Always call `setupInlineFieldLabel(...)` for mobile new-pin inputs to ensure inline-label behaviour mirrors the edit popup.
- Adjusted emoji picker logic and CSS to restore full grid width on mobile by re-introducing `--emoji-picker-grid-width` and making the mobile picker use responsive column/count variables (`index.html` + `style.css`).
- Improved dropdown suggestion sizing for mobile in JS so suggestion lists open as a usable panel (set minimum width and `maxHeight`) instead of a narrow strip (`index.html`).
- Added mobile-specific CSS rules in `style.css` to reduce vertical spacing between fields, make inputs/selects full-width, and show inline labels when fields have values.
- Files changed: `index.html`, `style.css`.

### Testing
- Ran `git diff --check` and it returned clean results (passed).
- Ran a Python content-check script that verified the new build version string and presence of the updated mobile form/emoji-grid markers (succeeded).
- Performed `git add` + `git commit` which succeeded and produced the commit for these changes (succeeded).
- Attempted automated visual/browser test but no Chromium/Playwright was available in the environment, so the browser-based screenshot test could not be executed (failed due to missing browser).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a3e1fb60483308e080d00b9d64bc4)