### PR TITLE
Mobile new-pin form: fix overlapping labels, single cancel button, update build & status label

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-23 v.0.656';
+    const BUILD_VERSION = '2026-06-25 v.0.657';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
@@ -10115,7 +10115,7 @@ function zaladujPinezkiZFirestore() {
 
     const pinStatusFieldKeys = ['nieaktywne', 'zamkniete', 'tajne', 'doSprawdzenia', 'zdewastowane', 'zwiedzone', 'wyroznione'];
     const pinStatusSelectOptions = [
-      { value: '', label: 'Brak' },
+      { value: '', label: 'Status: brak' },
       { value: 'nieaktywne', label: 'Niedostępne ⛔' },
       { value: 'zamkniete', label: 'Zamknięte 🔐' },
       { value: 'tajne', label: 'Tajne 🤫' },
@@ -10161,7 +10161,7 @@ function zaladujPinezkiZFirestore() {
       const selected = getSelectedPinStatusKey(status);
       const options = buildInlineSelectOptions(pinStatusSelectOptions, selected);
       return `
-        <span class="inline-labeled-input has-value" data-label="Status" style="--inline-label-offset: 64px;">
+        <span class="inline-labeled-input${selected ? ' has-value' : ''}" data-label="Status" style="--inline-label-offset: 64px;">
           <select id="${id}">${options}</select>
         </span>
       `;
@@ -10522,19 +10522,22 @@ function zaladujPinezkiZFirestore() {
         if (ev.target === modal) cleanup();
       };
       modalContent.innerHTML = '';
-      closeBtn = document.createElement('button');
-      closeBtn.type = 'button';
-      closeBtn.id = 'mobileCustomFormCancel';
-      closeBtn.textContent = 'Anuluj';
-      closeBtn.style.marginLeft = '8px';
-      closeBtn.addEventListener('click', cleanup);
-      const saveBtnInForm = formContainer.querySelector('button[onclick^="zapiszLokalnie("]');
-      if (saveBtnInForm && saveBtnInForm.parentNode) {
-        saveBtnInForm.insertAdjacentElement('afterend', closeBtn);
-      } else {
-        closeBtn.style.alignSelf = 'flex-end';
-        closeBtn.style.marginBottom = '8px';
-        modalContent.appendChild(closeBtn);
+      const formHasOwnCancelButton = !!formContainer.querySelector('#cancelNew');
+      if (!formHasOwnCancelButton) {
+        closeBtn = document.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.id = 'mobileCustomFormCancel';
+        closeBtn.textContent = 'Anuluj';
+        closeBtn.style.marginLeft = '8px';
+        closeBtn.addEventListener('click', cleanup);
+        const saveBtnInForm = formContainer.querySelector('button[onclick^="zapiszLokalnie("]');
+        if (saveBtnInForm && saveBtnInForm.parentNode) {
+          saveBtnInForm.insertAdjacentElement('afterend', closeBtn);
+        } else {
+          closeBtn.style.alignSelf = 'flex-end';
+          closeBtn.style.marginBottom = '8px';
+          modalContent.appendChild(closeBtn);
+        }
       }
       modalContent.appendChild(formContainer);
       modal.dataset.customFormOpen = '1';

--- a/style.css
+++ b/style.css
@@ -1661,15 +1661,15 @@ html body .mobile-pin-actions {
 
   #mobilePinModal .edit-popup .inline-labeled-input {
     position: relative;
-    display: block;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
   }
 
   #mobilePinModal .edit-popup .inline-labeled-input::before {
     content: attr(data-label) ":";
-    position: absolute;
-    left: 8px;
-    top: 50%;
-    transform: translateY(-50%);
+    position: static;
+    transform: none;
     z-index: 1;
     display: none;
     color: #aaa;
@@ -1687,7 +1687,7 @@ html body .mobile-pin-actions {
 
   #mobilePinModal .edit-popup .inline-labeled-input.has-value input,
   #mobilePinModal .edit-popup .inline-labeled-input.has-value select {
-    padding-left: var(--inline-label-offset, 82px);
+    padding-left: 10px;
   }
 
   #mobilePinModal .mobile-emoji-picker .emoji-picker-panel,


### PR DESCRIPTION
### Motivation
- Mobile new-pin modal had overlapping inline labels for select fields which caused the main-category text (e.g. “Kategoria główna”) to overlap the selected value. 
- The mobile modal logic added an extra top cancel button even when the embedded form already provided its own bottom `Anuluj` button. 
- The empty status option was shown as `Brak` without a visible leading token, and the visible build/version needed to be bumped.

### Description
- Updated `index.html` to bump the visible build string from `2026-06-23 v.0.656` to `2026-06-25 v.0.657`. 
- Changed the empty status option to display `Status: brak` in the `pinStatusSelectOptions` array and made the inline status wrapper add `has-value` only when a status is selected. 
- Modified `openFormInMobileModal` so it does not inject an extra mobile cancel button when the provided `formContainer` already contains a `#cancelNew` button. 
- Adjusted mobile modal CSS in `style.css` so inline-labeled inputs in `#mobilePinModal` render labels above the control (`display: flex; flex-direction: column`) and removed absolute positioning that caused label/value overlap.

### Testing
- Ran a small automated source-check script (`python3` assertions) that verified the new `BUILD_VERSION` value, presence of the `Status: brak` option, and the added guard (`formHasOwnCancelButton`) to avoid duplicate cancel buttons, and all assertions passed. 
- No headless browser screenshot tests were available in the environment, so visual verification was not executed automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d2f9cea948330badaa50b0027c4da)