### PR TITLE
Zachowaj inline-labels i poziome wiersze + na mobilu; bump build

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-25 v.0.658';
+    const BUILD_VERSION = '2026-06-26 v.0.659';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
@@ -1181,8 +1181,10 @@ body, #sidebar, #basemap-switcher {
 .edit-popup .edit-add-row,
 .edit-popup .edit-layer-row {
   display: flex;
-  gap: 6px;
+  flex-direction: row;
   align-items: center;
+  gap: 6px;
+  width: 100%;
 }
 .edit-popup .edit-add-row .inline-labeled-input,
 .edit-popup .edit-layer-row .inline-labeled-input {
@@ -1192,26 +1194,14 @@ body, #sidebar, #basemap-switcher {
 .edit-popup .edit-layer-row input {
   flex: 1;
 }
-@media (max-width: 700px) and (hover: none) and (pointer: coarse) {
-  .edit-popup .inline-labeled-input {
+@media (max-width: 700px), (max-width: 800px) {
+  .edit-popup .edit-add-row,
+  .edit-popup .edit-layer-row {
     display: flex;
-    flex-direction: column;
-    gap: 3px;
-  }
-  .edit-popup .inline-labeled-input::before {
-    position: static;
-    display: none;
-    transform: none;
-    margin-left: 2px;
-    line-height: 1.15;
-    white-space: normal;
-  }
-  .edit-popup .inline-labeled-input.has-value::before {
-    display: block;
-  }
-  .edit-popup .inline-labeled-input.has-value input,
-  .edit-popup .inline-labeled-input.has-value select {
-    padding-left: 6px;
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
   }
 }
 .edit-popup-name-dialog-backdrop {


### PR DESCRIPTION
### Motivation
- Mobile styles were forcing `.inline-labeled-input` into a stacked/static layout and turning label pseudo-elements non-absolute, which broke parity with desktop header placement and padding. 
- Rows containing the plus-button (`.edit-add-row`, `.edit-layer-row`) were not guaranteed to remain horizontal on small breakpoints, causing button positioning differences on mobile. 
- Bump the displayed build number/date to the next build as requested.

### Description
- Updated the app build string in `index.html` from `2026-06-25 v.0.658` to `2026-06-26 v.0.659` so the site shows the next build. 
- Removed the mobile-only overrides that changed `.edit-popup .inline-labeled-input` to a column layout and set its `::before` label to `position: static`, preserving the desktop behavior of absolute-positioned labels and left padding. 
- Ensured `.edit-popup .edit-add-row` and `.edit-popup .edit-layer-row` explicitly use a horizontal flex layout with `flex-direction: row`, `align-items: center`, `gap: 6px` and `width: 100%`. 
- Added a mobile breakpoint rule so the add/layer rows remain horizontal under `@media (max-width: 700px)` and `@media (max-width: 800px)` instead of being changed to vertical stacking.

### Testing
- Ran `git diff --check` and it reported no style issues. 
- Verified presence and locations of the modified selectors with `rg -n "inline-labeled-input|edit-add-row|edit-layer-row|BUILD_VERSION" index.html` which returned the updated lines. 
- Manual inspection of `index.html` confirmed `data-label` wrappers remain present so `::before` content for labels will still render on mobile with the same font size and color as desktop.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e413aa99083308c91e7bea80a50d9)