### PR TITLE
Fix mobile pin modal dropdown and label overlap (build v0.660)

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-26 v.0.659';
+    const BUILD_VERSION = '2026-06-26 v.0.660';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-21-mobile-new-pin" />
+  <link rel="stylesheet" href="style.css?v=2026-06-26-v0.660" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 

--- a/style.css
+++ b/style.css
@@ -1624,17 +1624,73 @@ html body .mobile-pin-actions {
   }
 
   #mobilePinModal .dropdown-input-wrapper {
+    position: relative;
     width: 100%;
+    overflow: visible !important;
+  }
+
+  #mobilePinModal .edit-popup .edit-form-field,
+  #mobilePinModal .edit-add-row,
+  #mobilePinModal .edit-layer-row,
+  #mobilePinModal .inline-labeled-input {
+    overflow: visible !important;
   }
 
   #mobilePinModal .list-dropdown {
+    position: absolute !important;
+    z-index: 99999 !important;
+    display: block;
     color: #f0f0f0;
     background: #1f222b;
     border-color: #555;
     border-radius: 8px;
     box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
-    max-height: 160px;
-    overflow-y: auto;
+    max-height: 200px !important;
+    overflow-y: auto !important;
+    width: 100%;
+    left: 0;
+    top: 100%;
+  }
+
+  #mobilePinModal .inline-labeled-input input,
+  #mobilePinModal .inline-labeled-input select,
+  #mobilePinModal .inline-labeled-input .dropdown-input-wrapper input {
+    padding-left: 90px !important;
+  }
+
+  #mobilePinModal .inline-labeled-input::before {
+    position: absolute !important;
+    left: 10px !important;
+    top: 50% !important;
+    transform: translateY(-50%) !important;
+    display: block !important;
+    pointer-events: none;
+  }
+
+  #mobilePinModal .edit-add-row,
+  #mobilePinModal .edit-layer-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    flex-wrap: nowrap;
+  }
+
+  #mobilePinModal .edit-add-row .inline-labeled-input,
+  #mobilePinModal .edit-layer-row .inline-labeled-input {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  #mobilePinModal .edit-add-row button,
+  #mobilePinModal .edit-layer-row button {
+    flex: 0 0 auto;
+    width: 42px;
+    min-width: 42px;
+    height: 42px;
+    padding: 0;
+    line-height: 1;
   }
 
   #mobilePinModal .list-dropdown div {


### PR DESCRIPTION
### Motivation
- Fix visual issues in the mobile pin edit popup (`#mobilePinModal`) where the subcategory dropdown was clipped to a thin bar, input/select text overlapped inline labels, and the plus icon could push the row layout.

### Description
- In `style.css` (mobile rules) set form containers (`#mobilePinModal .edit-popup .edit-form-field`, `.edit-add-row`, `.edit-layer-row`, `.inline-labeled-input`) to `overflow: visible !important` and made `#mobilePinModal .dropdown-input-wrapper` `position: relative` to avoid clipping.
- Made `#mobilePinModal .list-dropdown` `position: absolute` with a high `z-index`, `max-height: 200px`, `overflow-y: auto`, `left: 0; top: 100%` and `width: 100%` so the dropdown fully renders and scrolls.
- Added fixed left padding `padding-left: 90px` for inputs/selects and positioned the inline label pseudo-element vertically centered, and constrained the add-row plus-button with flex sizing so it stays inline and does not expand the row.
- Updated `index.html` build metadata to `const BUILD_VERSION = '2026-06-26 v.0.660';` and refreshed the stylesheet cache-busting query to `style.css?v=2026-06-26-v0.660`.

### Testing
- Ran `git diff --check` which completed successfully with no diff-check errors.
- Verified the modified files (`index.html`, `style.css`) were staged and committed without reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e4669eff883308643e0a13a2686ae)