### PR TITLE
Fix mobile pin popup layout and dropdown behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-26 v.0.661';
+    const BUILD_VERSION = '2026-06-26 v.0.662';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-26-v0.660" />
+  <link rel="stylesheet" href="style.css?v=2026-06-26-v0.662" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -1146,28 +1146,34 @@ body, #sidebar, #basemap-switcher {
   margin-bottom: 6px;
 }
 .edit-popup .inline-labeled-input {
-  position: relative;
-  display: block;
+  display: grid;
+  grid-template-columns: minmax(112px, 34%) minmax(0, 1fr);
+  align-items: center;
+  column-gap: 10px;
+  width: 100%;
 }
-.edit-popup .inline-labeled-input::before {
-  content: attr(data-label) ":";
-  position: absolute;
-  left: 8px;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 1;
+.edit-popup .inline-field-label {
   display: none;
   color: #aaa;
   font-size: 13px;
   font-weight: 700;
-  pointer-events: none;
+  line-height: 1.2;
+  white-space: nowrap;
 }
-.edit-popup .inline-labeled-input.has-value::before {
+.edit-popup .inline-labeled-input.has-value .inline-field-label {
   display: block;
 }
-.edit-popup .inline-labeled-input.has-value input,
-.edit-popup .inline-labeled-input.has-value select {
-  padding-left: var(--inline-label-offset, 82px);
+.edit-popup .inline-labeled-input > input,
+.edit-popup .inline-labeled-input > select,
+.edit-popup .inline-labeled-input > .dropdown-input-wrapper {
+  min-width: 0;
+  width: 100%;
+  grid-column: 1 / -1;
+}
+.edit-popup .inline-labeled-input.has-value > input,
+.edit-popup .inline-labeled-input.has-value > select,
+.edit-popup .inline-labeled-input.has-value > .dropdown-input-wrapper {
+  grid-column: 2;
 }
 .edit-popup .edit-form-field input,
 .edit-popup .edit-form-field textarea,
@@ -7987,14 +7993,18 @@ function emojiHtml(str, hue = 0) {
     }
 
     function setupDropdownInput(input, itemsFn) {
-      if (!input) return;
-      if (input.parentElement?.classList?.contains('dropdown-input-wrapper')) return;
-      const wrapper = document.createElement('div');
-      wrapper.style.position = 'relative';
+      if (!input || typeof itemsFn !== 'function') return;
+      let wrapper = input.parentElement?.classList?.contains('dropdown-input-wrapper') ? input.parentElement : null;
+      if (wrapper) {
+        wrapper._dropdownItemsFn = itemsFn;
+        return;
+      }
+      wrapper = document.createElement('div');
       wrapper.className = 'dropdown-input-wrapper';
+      wrapper._dropdownItemsFn = itemsFn;
       input.parentNode.insertBefore(wrapper, input);
       wrapper.appendChild(input);
-      input.style.paddingRight = '20px';
+      input.style.paddingRight = '28px';
       input.style.boxSizing = 'border-box';
       const arrow = document.createElement('span');
       arrow.textContent = '▼';
@@ -8004,14 +8014,20 @@ function emojiHtml(str, hue = 0) {
       list.className = 'list-dropdown';
       wrapper.appendChild(list);
 
+      function getItems() {
+        const items = wrapper._dropdownItemsFn ? wrapper._dropdownItemsFn() : [];
+        return Array.isArray(items) ? items.filter(item => item !== null && item !== undefined && `${item}`.trim()) : [];
+      }
+
       function populate() {
         list.innerHTML = '';
-        itemsFn().forEach(item => {
+        getItems().forEach(item => {
+          const value = `${item}`;
           const div = document.createElement('div');
-          div.textContent = item;
+          div.textContent = value;
           div.addEventListener('mousedown', e => {
             e.preventDefault();
-            input.value = item;
+            input.value = value;
             input.dispatchEvent(new Event('input', { bubbles: true }));
             input.dispatchEvent(new Event('change', { bubbles: true }));
             hide();
@@ -8021,6 +8037,10 @@ function emojiHtml(str, hue = 0) {
       }
       function show() {
         populate();
+        if (!list.children.length) {
+          hide();
+          return;
+        }
         list.style.position = 'absolute';
         list.style.left = '0';
         list.style.right = '0';
@@ -8032,14 +8052,16 @@ function emojiHtml(str, hue = 0) {
       }
       function hide() {
         list.style.display = 'none';
-        list.style.position = 'absolute';
         list.style.left = '';
         list.style.right = '';
         list.style.top = '';
         list.style.width = '';
         list.style.maxHeight = '';
       }
-      arrow.addEventListener('click', e => { e.stopPropagation(); list.style.display === 'block' ? hide() : show(); });
+      arrow.addEventListener('click', e => { e.preventDefault(); e.stopPropagation(); list.style.display === 'block' ? hide() : show(); });
+      input.addEventListener('focus', show);
+      input.addEventListener('click', e => { e.stopPropagation(); show(); });
+      input.addEventListener('input', () => { if (list.style.display === 'block') show(); });
       document.addEventListener('click', e => { if (!wrapper.contains(e.target)) hide(); });
     }
 
@@ -10132,12 +10154,22 @@ function zaladujPinezkiZFirestore() {
       const wrapper = input.closest('.inline-labeled-input');
       if (!wrapper) return;
       wrapper.dataset.label = label;
+      let labelEl = wrapper.querySelector(':scope > .inline-field-label');
+      if (!labelEl) {
+        labelEl = document.createElement('span');
+        labelEl.className = 'inline-field-label';
+        wrapper.insertBefore(labelEl, wrapper.firstChild);
+      }
+      labelEl.textContent = `${label}:`;
       const update = () => {
         wrapper.classList.toggle('has-value', Boolean((input.value || '').trim()) || wrapper.dataset.inlineLabelAlways === 'true');
       };
-      input.addEventListener('input', update);
-      input.addEventListener('change', update);
-      input.addEventListener('blur', update);
+      if (!input.dataset.inlineLabelBound) {
+        input.addEventListener('input', update);
+        input.addEventListener('change', update);
+        input.addEventListener('blur', update);
+        input.dataset.inlineLabelBound = '1';
+      }
       update();
     }
 

--- a/style.css
+++ b/style.css
@@ -172,6 +172,33 @@
   overflow: visible;
 }
 
+.edit-popup .inline-labeled-input {
+  display: grid;
+  grid-template-columns: minmax(112px, 34%) minmax(0, 1fr);
+  align-items: center;
+  column-gap: 10px;
+  width: 100%;
+}
+.edit-popup .inline-field-label {
+  display: none;
+  color: #aaa;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.edit-popup .inline-labeled-input.has-value .inline-field-label { display: block; }
+.edit-popup .inline-labeled-input > input,
+.edit-popup .inline-labeled-input > select,
+.edit-popup .inline-labeled-input > .dropdown-input-wrapper {
+  min-width: 0;
+  width: 100%;
+  grid-column: 1 / -1;
+}
+.edit-popup .inline-labeled-input.has-value > input,
+.edit-popup .inline-labeled-input.has-value > select,
+.edit-popup .inline-labeled-input.has-value > .dropdown-input-wrapper { grid-column: 2; }
+
 .list-dropdown {
   position: absolute;
   top: calc(100% + 2px);
@@ -1663,7 +1690,8 @@ html body .mobile-pin-actions {
   }
 
   #mobilePinModal .inline-labeled-input {
-    --inline-label-offset: clamp(112px, 34vw, 142px);
+    grid-template-columns: 124px minmax(0, 1fr);
+    column-gap: 10px;
   }
 
   #mobilePinModal .edit-add-row,


### PR DESCRIPTION
### Motivation
- Naprawić błędne wyrównanie etykiet i wartości w mobilnym popupie (pola: Od kogo, Kategoria główna, Podkategoria, Warstwa, Status) po rezygnacji z hacków opartych na `::before`, `position:absolute`, `padding-left` i `--inline-label-offset`.
- Przywrócić poprawne działanie dropdownów podkategorii/warstw tak, aby lista rozwijała się bezpośrednio pod polem i nie renderowała się jako cienki pasek.
- Zastosować jedno wspólne, trwałe rozwiązanie dla formularza dodawania i edycji pinezek bez zmiany logiki zapisu do Firestore.

### Description
- Podbiłem numer builda aplikacji i cache-bustingu CSS z `2026-06-26 v.0.661`/`v0.660` na `2026-06-26 v.0.662` (aktualizacja w `index.html`).
- Zastąpiłem mechanizm inline-label oparty na pseudo-elementach i paddingach rzeczywistym dwukolumnowym układem Grid (`.inline-labeled-input`) oraz elementem `.inline-field-label` w CSS, tak aby etykieta zajmowała stałą kolumnę, a wartość drugą kolumnę.
- Zmodyfikowałem `setupInlineFieldLabel()` tak, by tworzył i aktualizował rzeczywisty element `.inline-field-label` (wstawiany do kontenera), oraz by wiązał zdarzenia tylko raz (`data-inlineLabelBound`).
- Przebudowałem `setupDropdownInput()` tak, aby wspierane były: ponowne przypisanie źródła elementów do istniejącego wrappera, wygenerowanie widocznych elementów listy (`.list-dropdown`), ukrywanie pustej listy (zapobiega renderowaniu cienkiego paska), otwieranie listy przy focus/click pola i poprawne pozycjonowanie listy bez przenoszenia jej na dół formularza.
- Zastosowałem dopasowane reguły CSS dla mobilnego popupu (`#mobilePinModal`) aby korzystał z tego samego gridowego układu etykiet zamiast `--inline-label-offset`, oraz utrzymałem mobilny limit wysokości dropdownu.

### Testing
- Uruchomiono skrypt Pythona z asercjami statycznymi potwierdzającymi usunięcie użycia `::before` i `--inline-label-offset` oraz aktualizację builda i cache-bustingu (`assert` passed).
- Wykonano prosty parser HTML (`html.parser`) jako smoke-test poprawności składniowej pliku `index.html` (passed).
- Uruchomiono `git diff --check` oraz zatwierdzono zmiany i commit (no whitespace/merge errors).
- Środowisko nie zawiera przeglądarki/Playwrighta, więc nie wykonano automatycznych screenshotów/emulacji mobilnych; ręczne testy na urządzeniu mobilnym zalecane do końcowego potwierdzenia wizualnego działania dropdownów i układu (zmiany nie modyfikują logiki zapisu do Firestore).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e7d6d51f8833089c490d186774c24)