### PR TITLE
Unify inline pin fields on desktop, fix mobile dropdown positioning and bump build

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-28 v.0.663';
+    const BUILD_VERSION = '2026-06-29 v.0.664';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-28-v0.663" />
+  <link rel="stylesheet" href="style.css?v=2026-06-29-v0.664" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -1147,13 +1147,19 @@ body, #sidebar, #basemap-switcher {
 }
 .edit-popup .inline-labeled-input {
   display: grid;
-  grid-template-columns: minmax(112px, 34%) minmax(0, 1fr);
+  grid-template-columns: max-content minmax(0, 1fr);
   align-items: center;
-  column-gap: 10px;
+  column-gap: 8px;
   width: 100%;
+  min-height: 42px;
+  padding: 0 10px;
+  border: 1px solid #343946;
+  border-radius: 8px;
+  background: #1d2028;
+  box-sizing: border-box;
 }
 .edit-popup .inline-field-label {
-  display: none;
+  display: block;
   color: #aaa;
   font-size: 13px;
   font-weight: 700;
@@ -1168,7 +1174,7 @@ body, #sidebar, #basemap-switcher {
 .edit-popup .inline-labeled-input > .dropdown-input-wrapper {
   min-width: 0;
   width: 100%;
-  grid-column: 1 / -1;
+  grid-column: 2;
 }
 .edit-popup .inline-labeled-input.has-value > input,
 .edit-popup .inline-labeled-input.has-value > select,
@@ -1180,6 +1186,27 @@ body, #sidebar, #basemap-switcher {
 .edit-popup .edit-form-field select {
   box-sizing: border-box;
   width: 100%;
+}
+
+.edit-popup .inline-labeled-input > input,
+.edit-popup .inline-labeled-input > select,
+.edit-popup .inline-labeled-input .dropdown-input-wrapper > input {
+  height: auto;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  outline: none;
+  background: transparent;
+  color: #f0f0f0;
+  box-shadow: none;
+}
+.edit-popup .inline-labeled-input > select {
+  padding-right: 28px;
+}
+.edit-popup .inline-labeled-input .dropdown-arrow {
+  right: 0;
+  color: #bfc3cc;
 }
 .edit-popup .edit-form-field textarea {
   resize: vertical;
@@ -8019,50 +8046,90 @@ function emojiHtml(str, hue = 0) {
         return Array.isArray(items) ? items.filter(item => item !== null && item !== undefined && `${item}`.trim()) : [];
       }
 
+      function chooseValue(value, event) {
+        if (event) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+        input.value = value;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        hide();
+      }
+
       function populate() {
         list.innerHTML = '';
         getItems().forEach(item => {
           const value = `${item}`;
           const div = document.createElement('div');
           div.textContent = value;
-          div.addEventListener('mousedown', e => {
-            e.preventDefault();
-            input.value = value;
-            input.dispatchEvent(new Event('input', { bubbles: true }));
-            input.dispatchEvent(new Event('change', { bubbles: true }));
-            hide();
-          });
+          div.addEventListener('pointerdown', e => chooseValue(value, e));
+          div.addEventListener('mousedown', e => chooseValue(value, e));
           list.appendChild(div);
         });
       }
+
+      function positionList() {
+        const useFixed = wrapper.closest('#mobilePinModal') && window.matchMedia('(max-width: 800px)').matches;
+        if (!useFixed) {
+          list.style.position = 'absolute';
+          list.style.left = '0';
+          list.style.right = '0';
+          list.style.top = 'calc(100% + 2px)';
+          list.style.width = 'auto';
+          list.style.maxHeight = '';
+          list.style.zIndex = '';
+          return;
+        }
+        const rect = wrapper.getBoundingClientRect();
+        const viewportHeight = window.visualViewport?.height || window.innerHeight || document.documentElement.clientHeight || 0;
+        const spaceBelow = Math.max(120, viewportHeight - rect.bottom - 8);
+        list.style.position = 'fixed';
+        list.style.left = `${Math.round(rect.left)}px`;
+        list.style.right = 'auto';
+        list.style.top = `${Math.round(rect.bottom + 2)}px`;
+        list.style.width = `${Math.round(rect.width)}px`;
+        list.style.maxHeight = `${Math.min(220, spaceBelow)}px`;
+        list.style.zIndex = '2147483605';
+      }
+
       function show() {
         populate();
         if (!list.children.length) {
           hide();
           return;
         }
-        list.style.position = 'absolute';
-        list.style.left = '0';
-        list.style.right = '0';
-        list.style.top = 'calc(100% + 2px)';
-        list.style.width = 'auto';
-        list.style.maxHeight = wrapper.closest('#mobilePinModal') && window.matchMedia('(max-width: 800px)').matches ? '220px' : '';
-        list.style.zIndex = wrapper.closest('#mobilePinModal') ? '2147483605' : '';
+        positionList();
         list.style.display = 'block';
       }
       function hide() {
         list.style.display = 'none';
+        list.style.position = '';
         list.style.left = '';
         list.style.right = '';
         list.style.top = '';
         list.style.width = '';
         list.style.maxHeight = '';
+        list.style.zIndex = '';
       }
-      arrow.addEventListener('click', e => { e.preventDefault(); e.stopPropagation(); list.style.display === 'block' ? hide() : show(); });
+      let lastPointerToggleAt = 0;
+      const toggle = e => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.type === 'click' && Date.now() - lastPointerToggleAt < 500) return;
+        if (e.type === 'pointerdown') lastPointerToggleAt = Date.now();
+        list.style.display === 'block' ? hide() : show();
+      };
+      arrow.addEventListener('pointerdown', toggle);
+      arrow.addEventListener('click', toggle);
       input.addEventListener('focus', show);
       input.addEventListener('click', e => { e.stopPropagation(); show(); });
+      input.addEventListener('pointerdown', e => { e.stopPropagation(); });
       input.addEventListener('input', () => { if (list.style.display === 'block') show(); });
-      document.addEventListener('click', e => { if (!wrapper.contains(e.target)) hide(); });
+      window.addEventListener('resize', () => { if (list.style.display === 'block') positionList(); });
+      window.visualViewport?.addEventListener('resize', () => { if (list.style.display === 'block') positionList(); });
+      window.visualViewport?.addEventListener('scroll', () => { if (list.style.display === 'block') positionList(); });
+      document.addEventListener('click', e => { if (!wrapper.contains(e.target) && !list.contains(e.target)) hide(); });
     }
 
     function setupTrudnoscInput(range, label) {

--- a/style.css
+++ b/style.css
@@ -174,13 +174,19 @@
 
 .edit-popup .inline-labeled-input {
   display: grid;
-  grid-template-columns: minmax(112px, 34%) minmax(0, 1fr);
+  grid-template-columns: max-content minmax(0, 1fr);
   align-items: center;
-  column-gap: 10px;
+  column-gap: 8px;
   width: 100%;
+  min-height: 42px;
+  padding: 0 10px;
+  border: 1px solid #343946;
+  border-radius: 8px;
+  background: #1d2028;
+  box-sizing: border-box;
 }
 .edit-popup .inline-field-label {
-  display: none;
+  display: block;
   color: #aaa;
   font-size: 13px;
   font-weight: 700;
@@ -193,11 +199,33 @@
 .edit-popup .inline-labeled-input > .dropdown-input-wrapper {
   min-width: 0;
   width: 100%;
-  grid-column: 1 / -1;
+  grid-column: 2;
 }
 .edit-popup .inline-labeled-input.has-value > input,
 .edit-popup .inline-labeled-input.has-value > select,
 .edit-popup .inline-labeled-input.has-value > .dropdown-input-wrapper { grid-column: 2; }
+
+
+.edit-popup .inline-labeled-input > input,
+.edit-popup .inline-labeled-input > select,
+.edit-popup .inline-labeled-input .dropdown-input-wrapper > input {
+  height: auto;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  outline: none;
+  background: transparent;
+  color: #f0f0f0;
+  box-shadow: none;
+}
+.edit-popup .inline-labeled-input > select {
+  padding-right: 28px;
+}
+.edit-popup .inline-labeled-input .dropdown-arrow {
+  right: 0;
+  color: #bfc3cc;
+}
 
 .list-dropdown {
   position: absolute;
@@ -1673,20 +1701,20 @@ html body .mobile-pin-actions {
   }
 
   #mobilePinModal .list-dropdown {
-    position: absolute !important;
-    top: calc(100% + 2px) !important;
-    left: 0 !important;
-    right: 0 !important;
-    z-index: 2147483605 !important;
+    position: absolute;
+    top: calc(100% + 2px);
+    left: 0;
+    right: 0;
+    z-index: 2147483605;
     display: none;
     color: #f0f0f0;
     background: #1f222b;
     border-color: #555;
     border-radius: 8px;
     box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
-    max-height: 220px !important;
-    overflow-y: auto !important;
-    width: auto !important;
+    max-height: 220px;
+    overflow-y: auto;
+    width: auto;
   }
 
   #mobilePinModal .inline-labeled-input {
@@ -1695,8 +1723,8 @@ html body .mobile-pin-actions {
     column-gap: 12px;
     align-items: center;
     width: 100%;
-    min-height: 54px;
-    padding: 0 14px;
+    min-height: 44px;
+    padding: 0 10px;
     border: 1px solid #343946;
     border-radius: 8px;
     background: #1d2028;
@@ -1763,7 +1791,7 @@ html body .mobile-pin-actions {
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: 6px;
+    gap: 4px;
     width: 100%;
     flex-wrap: nowrap;
   }
@@ -1795,7 +1823,7 @@ html body .mobile-pin-actions {
   }
 
   #mobilePinModal .edit-popup .edit-form-field {
-    margin-bottom: 4px;
+    margin-bottom: 3px;
   }
 
   #mobilePinModal .edit-popup input,


### PR DESCRIPTION
### Motivation
- Bump the site build stamp per request by incrementing `BUILD_VERSION` and stylesheet cache key to the new date/version. 
- Make inline form fields (Od kogo, Kategoria główna, Warstwa, Podkategoria, Status) render as a single labeled field on desktop, matching the already-correct mobile appearance. 
- Fix the mobile subcategory dropdown so it reliably opens and shows options on touch devices instead of remaining collapsed. 

### Description
- Updated `index.html` to set `BUILD_VERSION` to `2026-06-29 v.0.664` and updated the linked stylesheet query string to `style.css?v=2026-06-29-v0.664`.
- Reworked inline form field styling in `style.css` by changing `.edit-popup .inline-labeled-input` to use `grid-template-columns: max-content minmax(0, 1fr)`, showing the inline label, and styling the wrapper to appear as one combined field while keeping the inner `input/select` visually transparent and occupying the value area.
- Reduced mobile-only inline field vertical size and spacing (smaller `min-height`, `padding`, and `gap`) under `#mobilePinModal` so the specified inline fields are ~15–20% slimmer while leaving `Nazwa` and `Opis` untouched.
- Fixed the shared dropdown component in `index.html` (`setupDropdownInput`) by adding a `chooseValue` helper using `pointerdown` + `mousedown` listeners, a `positionList` routine that uses `position: fixed` and viewport-based calculations when the list is inside `#mobilePinModal`, and extra event handling (pointer vs click toggle debounce, `visualViewport` resize/scroll listeners) so the list positions, sizes and shows correctly on mobile.
- Removed aggressive `!important` rules and other static constraints for the mobile `.list-dropdown` so JavaScript can set position/width/height as needed.
- Kept the dropdown and inline-field implementation shared so both add-new and edit popups use the same corrected behavior.

### Testing
- Ran `git diff --check` to ensure no whitespace/syntax diffs reported and it succeeded. 
- Performed a static JavaScript syntax check via `node --check /tmp/index-scripts.js` and it reported no syntax errors. 
- Verified repository status and committed the changes; automated checks shown in the rollout indicated the modified files were staged and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a420d5fa1a083308be0ae6662a016b9)