### PR TITLE
Odchudź przycisk „Szczegóły” w popupie pinezki i podbij build

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-29 v.0.665';
+    const BUILD_VERSION = '2026-06-29 v.0.666';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-29-v0.665" />
+  <link rel="stylesheet" href="style.css?v=2026-06-29-v0.666" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 

--- a/style.css
+++ b/style.css
@@ -918,11 +918,14 @@ html body .popup-details summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
-  min-height: 38px;
-  padding: 9px 11px;
+  gap: 6px;
+  min-height: 20px;
+  height: auto;
+  padding: 2px 7px;
   color: #f8fafc;
   font-weight: 800;
+  font-size: 11px;
+  line-height: 1.1;
   cursor: pointer;
   list-style: none;
 }
@@ -1131,8 +1134,9 @@ html body .popup-container .popup-details {
 }
 
 html body .popup-container .popup-details summary {
-  min-height: 38px;
-  padding: 9px 11px;
+  min-height: 20px;
+  height: auto;
+  padding: 2px 7px;
 }
 
 html body .popup-container .popup-details summary:focus-visible {
@@ -1227,10 +1231,11 @@ html body .popup-container .popup-route-actions .popup-direct-route-btn:hover {
   }
 
   html body .popup-details summary {
-    min-height: 34px !important;
-    height: 34px !important;
-    padding: 6px 10px !important;
-    font-size: 13px !important;
+    min-height: 22px !important;
+    height: auto !important;
+    padding: 2px 7px !important;
+    font-size: 11px !important;
+    line-height: 1.1 !important;
   }
 
   html body .popup-details {
@@ -1327,10 +1332,10 @@ html body .popup-status-separator {
 
 html body .popup-details summary,
 html body .popup-container .popup-details summary {
-  min-height: 28px !important;
-  height: 28px !important;
-  padding: 4px 9px !important;
-  font-size: 12px !important;
+  min-height: 20px !important;
+  height: auto !important;
+  padding: 2px 7px !important;
+  font-size: 11px !important;
   line-height: 1.1 !important;
 }
 
@@ -1573,9 +1578,9 @@ html body .popup-status-row {
 
   html body .leaflet-popup .popup-details summary,
   html body .leaflet-popup .popup-container .popup-details summary {
-    min-height: 26px !important;
-    height: 26px !important;
-    padding: 3px 8px !important;
+    min-height: 20px !important;
+    height: auto !important;
+    padding: 2px 7px !important;
     font-size: 11px !important;
     line-height: 1.1 !important;
   }


### PR DESCRIPTION
### Motivation
- Zmniejszyć wizualnie przycisk/`summary` "Szczegóły" w popupie pinezki, aby był maksymalnie cienki przy zachowaniu czytelnego tekstu.
- Zapewnić spójne, „odchudzone” wymiary dla wariantów w `.popup-container` oraz w popupach Leaflet.
- Zaktualizować numer i datę builda oraz cache-busting CSS, żeby zmiany były rozpoznane przez klienty.

### Description
- Zmieniono reguły w `style.css` dla `html body .popup-details summary`, `html body .popup-container .popup-details summary` oraz odpowiednich nadpisów responsywnych i Leaflet, redukując `gap`, `min-height`, `padding`, `font-size` i dodając `height: auto` i `line-height: 1.1` aby tekst nadal się mieścił.
- Zaktualizowano `BUILD_VERSION` w `index.html` z `2026-06-29 v.0.665` na `2026-06-29 v.0.666` oraz link do CSS z `style.css?v=2026-06-29-v0.665` na `style.css?v=2026-06-29-v0.666`.
- Zmiany dotyczyły plików `style.css` i `index.html`.

### Testing
- Uruchomiono `git diff --check` aby sprawdzić problemy z formatowaniem i zakończyło się bez błędów.
- Wykonano skrypt `python3` z asercjami sprawdzającymi obecność nowego `BUILD_VERSION` i reguły `min-height: 20px` w `style.css`, który zakończył się pomyślnie.
- Sprawdzono statystyki różnic przez `git diff --stat` i potwierdzono zmiany w obu plikach.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a421e4128608330addc793dda157ec5)