### PR TITLE
Adjust mobile 'Załaduj pinezki' button placement and bump build version

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-29 v.0.666';
+    const BUILD_VERSION = '2026-06-29 v.0.667';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-29-v0.666" />
+  <link rel="stylesheet" href="style.css?v=2026-06-29-v0.667" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -3192,7 +3192,6 @@ body.mobile-layout #saveChanges {
         <input type="file" id="importKmlInput" accept=".kml" style="display:none;">
       </div>
       </div>
-      <button id="loadPinsBtn">Załaduj pinezki</button>
       <div id="mainCategoryFilters" class="main-category-filters">
         <div class="main-category-title">Kategoria główna</div>
         <div class="main-category-options">
@@ -3204,7 +3203,10 @@ body.mobile-layout #saveChanges {
           <button id="mainPinsVisibilityToggle" type="button">Ukryj pinezki</button>
         </div>
       </div>
-      <div id="pinTotalCounter" class="pin-total-counter">Liczba miejsc: 0</div>
+      <div class="pin-counter-actions-row">
+        <div id="pinTotalCounter" class="pin-total-counter">Liczba miejsc: 0</div>
+        <button id="loadPinsBtn">Załaduj pinezki</button>
+      </div>
       <div id="tripPlannerPanel" class="trip-planner-panel" style="display:none;">
         <h3>Plan tripu</h3>
         <div class="trip-select-row">

--- a/style.css
+++ b/style.css
@@ -337,10 +337,41 @@
   display: none;
 }
 
+.pin-counter-actions-row {
+  display: block;
+}
+
 @media (max-width: 700px) {
+  .pin-counter-actions-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    overflow: hidden;
+  }
+
+  .pin-counter-actions-row .pin-total-counter {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   #loadPinsBtn {
-    display: block;
-    margin-top: 5px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 1 auto;
+    width: auto;
+    max-width: 48%;
+    margin-top: 0;
+    padding: 7px 8px;
+    white-space: nowrap;
+    box-sizing: border-box;
   }
 }
 


### PR DESCRIPTION
### Motivation
- The mobile sidebar showed the "Załaduj pinezki" button in a position that could overflow the sidebar and appear separate from the place counter, so it should sit to the right of the "Liczba miejsc" counter and stay inside the sidebar.
- The site build/version and CSS cache-busting query must be bumped so clients pick up the layout change.

### Description
- Updated `index.html` to bump `BUILD_VERSION` from `2026-06-29 v.0.666` to `2026-06-29 v.0.667` and updated the stylesheet link query `style.css?v=2026-06-29-v0.667`.
- Moved the `<button id="loadPinsBtn">Załaduj pinezki</button>` into a new wrapper `div.pin-counter-actions-row` alongside the `#pinTotalCounter` element in `index.html`.
- Added mobile CSS in `style.css` to make `.pin-counter-actions-row` a responsive flex row and constrained `#loadPinsBtn` (inline-flex, max-width, padding, overflow handling) so the button remains to the right of the counter and does not protrude from the sidebar.

### Testing
- Ran static assertions with a Python script to verify the build/version string, stylesheet query, presence of `pin-counter-actions-row`, and single occurrence of `id="loadPinsBtn"`, and they passed.
- Started a local HTTP server as a smoke check and created a git commit for the changes, both operations succeeded.
- Attempted browser-based visual/screenshot testing but it was skipped because no browser/Playwright is available in the environment (`playwright` check returned false).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a425bd3a0288330ab90cf9bcb07768b)