### PR TITLE
Wyrównanie tytułu pinezki w popupie, usunięcie pustego wiersza statusu i podbicie builda

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-29 v.0.669';
+    const BUILD_VERSION = '2026-06-30 v.0.670';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-29-v0.669" />
+  <link rel="stylesheet" href="style.css?v=2026-06-30-v0.670" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -7390,6 +7390,7 @@ function emojiHtml(str, hue = 0) {
       ].filter(Boolean);
       const statusHtml = statusItems.length ? `<span class="popup-status-row">${statusItems.map(item => `<span class="popup-status-item">${item}</span>`).join('')}</span>` : '';
       const statusLineHtml = [trudHtml, statusHtml].filter(Boolean).join('');
+      const popupStatusLineHtml = statusLineHtml ? `<div class="popup-status-line">${statusLineHtml}</div>` : '';
       return `
         <div class="photo-gallery" data-slug="${slug}"></div>
         <div class="popup-card-header">
@@ -7399,7 +7400,7 @@ function emojiHtml(str, hue = 0) {
             <button class="popup-edit-btn popup-delete-btn" title="Usuń pinezkę">🗑️</button>
           </div>
         </div>
-        <div class="popup-status-line">${statusLineHtml}</div>
+        ${popupStatusLineHtml}
         <div class="popup-soft-separator"></div>${descriptionHtml}
         <a class="popup-google-card" href="https://maps.google.com/?q=${p.lat},${p.lng}" target="_blank" rel="noopener noreferrer">
           <span class="popup-action-icon">📍</span>

--- a/style.css
+++ b/style.css
@@ -1337,8 +1337,11 @@ html body .popup-container .popup-route-actions .popup-direct-route-btn:hover {
 
 /* Popup pinezki: kompaktowy nagłówek, statusy i akcje */
 html body .popup-card-title {
+  display: flex;
+  align-items: flex-end;
   flex: 1 1 auto;
   min-width: 0;
+  min-height: calc(2em * 1.18);
   font-size: 15px !important;
   line-height: 1.18 !important;
   white-space: nowrap;


### PR DESCRIPTION
### Motivation
- Zmniejszyć nadmierny odstęp między nazwą pinezki a separatorem w popupie, tak aby krótkie nazwy były wyrównane bliżej dolnej krawędzi, a długie mogły się zawinąć do góry i zmieścić się w dwóch liniach.
- Unikać renderowania pustego wiersza statusu gdy brak treści statusów, co powodowało nieestetyczny odstęp.
- Zaktualizować numer i datę builda oraz cache-busting CSS zgodnie z wymaganiem wersjonowania.

### Description
- Zaktualizowano `BUILD_VERSION` w `index.html` z `2026-06-29 v.0.669` na `2026-06-30 v.0.670` oraz odświeżono odnośnik do stylów `style.css?v=2026-06-30-v0.670`.
- W `style.css` zmieniono styl `.popup-card-title` na `display: flex; align-items: flex-end;` oraz dodano `min-height: calc(2em * 1.18);` aby tytuł był wyrównany do dolnej krawędzi przy pojedynczej linii i mógł naturalnie przesunąć się w górę przy zawijaniu.
- W `index.html` (funkcja tworząca HTML popupu) zastąpiono zawsze-renderowany element statusu warunkowym `popupStatusLineHtml`, tak aby wiersz statusu był wstawiany tylko jeśli istnieje zawartość statusu.
- Zmiany dotyczyły plików `index.html` i `style.css`.

### Testing
- Uruchomiono `git diff --check` i nie zgłosił błędów (sukces).
- Sprawdzono `git status --short` aby potwierdzić zmodyfikowane pliki (`index.html`, `style.css`).
- Wykonano `git commit` i zatwierdzono zmiany bez błędów (sukces).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a435d5515f48330afe5e6d331facc1e)