### PR TITLE
Poprawa wyrównania emoji w nagłówku popup i podbicie numeru builda

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-30 v.0.671';
+    const BUILD_VERSION = '2026-06-30 v.0.672';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-30-v0.671" />
+  <link rel="stylesheet" href="style.css?v=2026-06-30-v0.672" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -7454,7 +7454,7 @@ function emojiHtml(str, hue = 0) {
       return `
         <div class="photo-gallery" data-slug="${slug}"></div>
         <div class="popup-card-header">
-          <div class="popup-card-title${longTitleClass}" title="${escapedPinName}">${p.emoji ? emojiHtml(p.emoji, getPinEmojiHue(p)) + ' ' : ''}<b>${escapedPinName}</b></div>
+          <div class="popup-card-title${longTitleClass}" title="${escapedPinName}">${p.emoji ? `<span class="popup-card-title-emoji">${emojiHtml(p.emoji, getPinEmojiHue(p))}</span>` : ''}<b class="popup-card-title-text">${escapedPinName}</b></div>
           <div class="popup-edit-row">
             <button class="popup-edit-btn popup-edit-pin-btn" title="Edytuj pinezkę">✏️</button>
             <button class="popup-edit-btn popup-delete-btn" title="Usuń pinezkę">🗑️</button>

--- a/style.css
+++ b/style.css
@@ -1338,7 +1338,8 @@ html body .popup-container .popup-route-actions .popup-direct-route-btn:hover {
 /* Popup pinezki: kompaktowy nagłówek, statusy i akcje */
 html body .popup-card-title {
   display: flex;
-  align-items: flex-end;
+  align-items: flex-start;
+  gap: 0.42em;
   flex: 1 1 auto;
   min-width: 0;
   min-height: calc(2em * 1.18);
@@ -1355,6 +1356,18 @@ html body .popup-card-title.popup-card-title-long {
   white-space: normal;
   overflow: visible;
   text-overflow: clip;
+  overflow-wrap: anywhere;
+}
+
+html body .popup-card-title-emoji {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: flex-start;
+  line-height: inherit;
+}
+
+html body .popup-card-title-text {
+  min-width: 0;
   overflow-wrap: anywhere;
 }
 


### PR DESCRIPTION
### Motivation
- Emoji pinów w popupie przy nazwach wieloliniowych opadało poniżej pierwszej linii zamiast być przyklejone do początku nazwy, co psuło czytelność nagłówków. 
- Trzeba było też zaktualizować numer i query string builda, żeby wymusić przeładowanie zaktualizowanego CSS na klientach. 

### Description
- Zwiększono numer builda w `index.html` z `2026-06-30 v.0.671` na `2026-06-30 v.0.672` i zaktualizowano cache-busting dla `style.css` (link `style.css?v=2026-06-30-v0.672`).
- W HTML popupu rozdzielono emoji i tekst nazwy na oddzielne elementy: emoji w `<span class="popup-card-title-emoji">...</span>` i tekst w `<b class="popup-card-title-text">...</b>` w konstrukcji tworzącej popup. 
- W `style.css` zmieniono wyrównanie nagłówka popupu na `align-items: flex-start` i dodano odstęp `gap: 0.42em` między emoji a tekstem, oraz dodano style dla klas `.popup-card-title-emoji` i `.popup-card-title-text` aby wymusić przyklejenie emoji do początku pierwszej linii i umożliwić poprawne zawijanie tekstu. 

### Testing
- Uruchomiono `git diff --check` (sprawdzenie spójności diff); test zakończył się pomyślnie. 
- Wykonano skrypt sprawdzający obecność oczekiwanych fragmentów w plikach (`python3` presence check for updated `BUILD_VERSION` and new classes); sprawdzenie zakończone pomyślnie. 
- Sprawdzono status drzewa roboczego aby upewnić się, że zmienione pliki są obecne i zatwierdzone; kontrola zakończona pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43667f21e88330bbe33761e753fea2)