### PR TITLE
Prefill new pin name from search result; bump build to 2026-07-05 v.0.673

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
   <script>
-    const BUILD_VERSION = '2026-06-30 v.0.672';
+    const BUILD_VERSION = '2026-07-05 v.0.673';
     window.BUILD_VERSION = BUILD_VERSION;
     window.APP_BUILD = BUILD_VERSION;
   </script>
-  <link rel="stylesheet" href="style.css?v=2026-06-30-v0.672" />
+  <link rel="stylesheet" href="style.css?v=2026-07-05-v0.673" />
   <link rel="icon" type="image/png" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 <link rel="apple-touch-icon" sizes="1080x1080" href="/ExploMapa/fav1080.png">
 
@@ -12916,7 +12916,7 @@ function showRoutePopup(pinId, tr, latlng) {
           searchMarker = null;
           generujListeWarstw();
         }
-        openNewPinPopup(latlng);
+        openNewPinPopupWithDefaults(latlng, { nazwa: label });
       });
       const routeBtn = container.querySelector('#routeSearchBtn');
       if (routeBtn) {


### PR DESCRIPTION
### Motivation
- When a search result popup is used to add a new pin, the displayed place name should automatically populate the new-pin form so users don't need to retype it.
- Update the app build badge and stylesheet cache-busting query to the new build date/number as requested.

### Description
- Bumped `BUILD_VERSION` from `2026-06-30 v.0.672` to `2026-07-05 v.0.673` and updated the stylesheet reference query to `style.css?v=2026-07-05-v0.673` in `index.html`.
- Replaced the call to `openNewPinPopup(latlng)` from search-result popups with `openNewPinPopupWithDefaults(latlng, { nazwa: label })` so the place `label` is passed as a default name.
- The new-pin form already reads `window.__osmPrefillNewPin` and now fills `#nazwaNew` (and other fields) from the provided defaults, enabling the prefill behavior without additional form changes.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check issues.
- Committed the change successfully and verified the modified `index.html` contains the updated `BUILD_VERSION`, stylesheet query, and the new `openNewPinPopupWithDefaults` call.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a58af9cc883308f0934452ac5b5c7)